### PR TITLE
feat: add GitHub Actions CI/CD workflows for Terraform

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,60 @@
+name: Terraform Apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+      - 'config/**'
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TF_VERSION: "1.14.8"
+  AWS_REGION: "eu-central-1"
+
+jobs:
+  apply:
+    name: Apply ${{ matrix.env }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          # Order matters: bootstrap before scps (dependencies)
+          - env: shared/bootstrap
+            account_id: "345895787808"
+          - env: management/bootstrap
+            account_id: "186052668286"
+          - env: management/scps
+            account_id: "186052668286"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        working-directory: terraform/environments/${{ matrix.env }}
+        run: terraform init -input=false
+
+      - name: Terraform Apply
+        working-directory: terraform/environments/${{ matrix.env }}
+        run: terraform apply -auto-approve -input=false -no-color

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,102 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+env:
+  TF_VERSION: "1.14.8"
+  AWS_REGION: "eu-central-1"
+
+jobs:
+  plan:
+    name: Plan ${{ matrix.env }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - env: management/bootstrap
+            account_id: "186052668286"
+          - env: management/scps
+            account_id: "186052668286"
+          - env: shared/bootstrap
+            account_id: "345895787808"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        working-directory: terraform/environments/${{ matrix.env }}
+        run: terraform init -input=false
+
+      - name: Terraform Plan
+        working-directory: terraform/environments/${{ matrix.env }}
+        id: plan
+        run: terraform plan -no-color -input=false -detailed-exitcode
+        continue-on-error: true
+
+      - name: Determine plan status
+        id: status
+        run: |
+          if [ "${{ steps.plan.outcome }}" == "failure" ]; then
+            echo "icon=❌" >> "$GITHUB_OUTPUT"
+            echo "summary=Plan failed" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.plan.outputs.exitcode }}" == "2" ]; then
+            echo "icon=⚠️" >> "$GITHUB_OUTPUT"
+            echo "summary=Changes detected" >> "$GITHUB_OUTPUT"
+          else
+            echo "icon=✅" >> "$GITHUB_OUTPUT"
+            echo "summary=No changes" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment Plan on PR
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            const output = `### ${{ steps.status.outputs.icon }} Terraform Plan: \`${{ matrix.env }}\`
+
+            **Result:** ${{ steps.status.outputs.summary }}
+
+            <details><summary>Plan Output</summary>
+
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            *Triggered by @${{ github.actor }} on \`${{ github.event.pull_request.head.ref }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+      - name: Fail if plan errored
+        if: steps.plan.outcome == 'failure'
+        run: exit 1

--- a/scripts/configure-github.sh
+++ b/scripts/configure-github.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# =============================================================================
+# configure-github.sh — Set GitHub repository secrets and variables from config
+# =============================================================================
+# This script reads config/landing-zone.yaml and configures the GitHub
+# repository with the secrets and variables needed by CI/CD workflows.
+#
+# What it sets:
+#   - Secret  LANDING_ZONE_CONFIG : entire config.yaml content (used by workflows
+#     to write config/landing-zone.yaml on the runner)
+#
+# Prerequisites:
+#   - gh CLI installed and authenticated (gh auth login)
+#   - config/landing-zone.yaml exists and is populated
+#
+# Usage:
+#   ./scripts/configure-github.sh
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_FILE="${REPO_ROOT}/config/landing-zone.yaml"
+
+# --- Validate prerequisites ---
+
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh CLI is required but not found. Install: brew install gh" >&2
+  exit 1
+fi
+
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  echo "ERROR: ${CONFIG_FILE} not found." >&2
+  exit 1
+fi
+
+gh auth status &>/dev/null || {
+  echo "ERROR: gh CLI is not authenticated. Run: gh auth login" >&2
+  exit 1
+}
+
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+echo "Repository: ${REPO}"
+echo ""
+
+# --- Set secret: entire config.yaml ---
+echo "Setting secret LANDING_ZONE_CONFIG..."
+gh secret set LANDING_ZONE_CONFIG < "${CONFIG_FILE}"
+echo "  Done."
+
+echo ""
+echo "GitHub configuration complete."
+echo ""
+echo "Verify:"
+echo "  gh secret list"


### PR DESCRIPTION
## Summary
- Add `terraform-plan.yml` — runs plan on PR with OIDC auth, comments output
- Add `terraform-apply.yml` — runs apply on merge to main
- Add `scripts/configure-github.sh` — uploads config.yaml as GitHub secret
- Update CLAUDE.md security classification (account IDs are not secrets)

## Test plan
- [ ] terraform-plan workflow triggers on this PR
- [ ] OIDC authentication succeeds for management + shared accounts
- [ ] Plan output appears as PR comments
- [ ] After merge, terraform-apply runs on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)