### PR TITLE
feat: add Checkov IaC security scanning

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -1,0 +1,46 @@
+name: Checkov Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  checkov:
+    name: Checkov IaC Security Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Checkov
+        id: checkov
+        uses: bridgecrewio/checkov-action@master
+        with:
+          directory: terraform/
+          framework: terraform
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+          soft_fail: false
+          quiet: true
+          skip_path: terraform/environments/shared/aft
+          # Skip the AFT environment — it is vendor code from the aws-ia module,
+          # not our code. Scanning it generates noise about upstream design
+          # choices we cannot change.
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: checkov

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -3,12 +3,8 @@ name: Checkov Security Scan
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'terraform/**'
   push:
     branches: [main]
-    paths:
-      - 'terraform/**'
 
 permissions:
   contents: read

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -34,6 +34,26 @@ jobs:
           # not our code. Scanning it generates noise about upstream design
           # choices we cannot change.
 
+          # Each skipped check must cite a reason. New findings (not listed here)
+          # will fail the build and require either a fix or an explicit skip entry
+          # with justification.
+          skip_check: >-
+            CKV_AWS_18,
+            CKV_AWS_144,
+            CKV2_AWS_62,
+            CKV_AWS_274
+          # CKV_AWS_18  (S3 access logging) — deferred per ADR-003 Future Hardening.
+          #   Enabling requires a separate log-destination bucket with ACL-based
+          #   write permissions. Tracked for Phase 2 observability work.
+          # CKV_AWS_144 (S3 cross-region replication) — deferred per ADR-003.
+          #   Lab project accepts single-region state risk. Production needs CRR
+          #   to the DR region (eu-west-1).
+          # CKV2_AWS_62 (S3 event notifications) — not applicable for Terraform
+          #   state bucket. No downstream consumer needs object-level events.
+          # CKV_AWS_274 (AdministratorAccess policy) — intentional for lab per
+          #   ADR-001 scope boundary and inline comments in oidc-github.tf.
+          #   Production should scope down to per-environment minimum permissions.
+
       - name: Upload SARIF to GitHub Security tab
         if: always()
         uses: github/codeql-action/upload-sarif@v3

--- a/terraform/environments/shared/bootstrap/main.tf
+++ b/terraform/environments/shared/bootstrap/main.tf
@@ -48,6 +48,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "terraform_state" {
     noncurrent_version_expiration {
       noncurrent_days = 30
     }
+
+    # Clean up failed multipart uploads after 7 days (CKV_AWS_300)
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 


### PR DESCRIPTION
Adds Checkov to the CI pipeline. Scans all Terraform against CIS/ISO 27001 rules. Findings upload to GitHub Security tab.