### PR TITLE
feat: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# =============================================================================
+# Pre-commit hooks — local quality gates before commit
+# =============================================================================
+# Install:
+#   brew install pre-commit
+#   pre-commit install
+#
+# Run manually on all files:
+#   pre-commit run --all-files
+# =============================================================================
+
+repos:
+  # General-purpose hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        exclude: ^\.github/workflows/  # GitHub Actions YAML allows syntax check-yaml misreads
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+
+  # Terraform formatting + validation
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.2
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+        exclude: ^terraform/environments/shared/aft/  # Requires AWS provider v6, skip in local validate
+
+  # JSON Schema validation for config/landing-zone.yaml
+  - repo: local
+    hooks:
+      - id: validate-landing-zone-config
+        name: Validate config/landing-zone.yaml against schema
+        entry: python3 scripts/validate-config.py
+        language: system
+        files: ^config/landing-zone\.yaml$
+        pass_filenames: false

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Validate config/landing-zone.yaml against config/schema.json.
+
+Called by pre-commit hook on config changes. Exit 0 on valid, 1 on invalid.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    config_path = repo_root / "config" / "landing-zone.yaml"
+    schema_path = repo_root / "config" / "schema.json"
+
+    if not config_path.exists():
+        print(f"ERROR: {config_path} does not exist.", file=sys.stderr)
+        return 1
+
+    if not schema_path.exists():
+        print(f"ERROR: {schema_path} does not exist.", file=sys.stderr)
+        return 1
+
+    try:
+        import yaml
+    except ImportError:
+        print("ERROR: PyYAML is required. Install: pip3 install pyyaml", file=sys.stderr)
+        return 1
+
+    try:
+        import jsonschema
+    except ImportError:
+        print("ERROR: jsonschema is required. Install: pip3 install jsonschema", file=sys.stderr)
+        return 1
+
+    with config_path.open() as f:
+        config = yaml.safe_load(f)
+
+    with schema_path.open() as f:
+        schema = json.load(f)
+
+    try:
+        jsonschema.validate(instance=config, schema=schema)
+    except jsonschema.ValidationError as e:
+        print(f"ERROR: config/landing-zone.yaml fails schema validation:", file=sys.stderr)
+        print(f"  Path: {'.'.join(str(p) for p in e.absolute_path)}", file=sys.stderr)
+        print(f"  Message: {e.message}", file=sys.stderr)
+        return 1
+
+    print("config/landing-zone.yaml: valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fulfills ADR-004 promise of pre-commit schema validation.

Adds .pre-commit-config.yaml with Terraform formatting, YAML/JSON syntax checks, and custom JSON Schema validation for config/landing-zone.yaml.

Install locally: `brew install pre-commit && pre-commit install`