### PR TITLE
docs: ADR-012 VPC topology + ADR-013 EKS architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The script reads your `config/landing-zone.yaml` and updates all `backend.tf` fi
 | [009](docs/decisions/009-lifecycle-and-teardown-strategy.md) | Lifecycle and teardown strategy |
 | [010](docs/decisions/010-shared-account-bootstrap-sequence.md) | Shared account bootstrap sequence |
 | [011](docs/decisions/011-account-provisioning-two-path-strategy.md) | Account provisioning — two-path strategy |
+| [012](docs/decisions/012-vpc-topology-and-egress-strategy.md) | VPC topology and egress strategy |
+| [013](docs/decisions/013-eks-architecture.md) | EKS architecture |
 
 ## Companion Application Repository
 

--- a/docs/decisions/012-vpc-topology-and-egress-strategy.md
+++ b/docs/decisions/012-vpc-topology-and-egress-strategy.md
@@ -1,0 +1,83 @@
+# 012. VPC Topology and Egress Strategy
+
+## Status
+Accepted
+
+## Context
+Phase 3 introduces the first workload VPC in `aegis-staging` to host an EKS cluster. Four decisions need to be locked before any network Terraform runs: subnet topology, CIDR allocation mechanism, egress strategy (NAT Gateway vs VPC endpoints vs hybrid), and VPC Flow Log handling.
+
+Each decision has a cost dimension that matters for a lab project on a $30/month budget and a security dimension that matters for ISO 27001 Annex A compliance (ADR-005). Getting the egress strategy wrong either breaks ArgoCD's pull-based GitOps (no GitHub access from cluster) or burns money on VPC endpoints that duplicate what a single NAT Gateway would provide cheaper.
+
+## Decision
+
+**Subnet topology — three-AZ public/private split.**
+
+The VPC spans three Availability Zones (`eu-central-1a`, `eu-central-1b`, `eu-central-1c` per ADR-002). Each AZ has one public subnet and one private subnet:
+
+```
+VPC 10.x.0.0/20 (from IPAM)
+├── AZ-a
+│   ├── Public  /24 — ALB, NAT Gateway
+│   └── Private /23 — EKS nodes, workload pods
+├── AZ-b
+│   ├── Public  /24 — ALB, (no NAT)
+│   └── Private /23 — EKS nodes, workload pods
+└── AZ-c
+    ├── Public  /24 — ALB, (no NAT)
+    └── Private /23 — EKS nodes, workload pods
+```
+
+Public subnets host the ALB (multi-AZ required for ALB) and the single NAT Gateway. Private subnets host EKS nodes and all workload pods. The /23 sizing per AZ gives ~500 usable IPs per private subnet — ample for Karpenter-managed dynamic scaling without forcing a resize later.
+
+**CIDR allocation — IPAM (ADR-004 Mode B).**
+
+VPC CIDR is allocated from the regional IPAM pool declared in `config/landing-zone.yaml` (`ipam.pools.eu-central-1`). The staging VPC requests `netmask_length: 20` from IPAM, which assigns the first available /20 block. IPAM enforces non-overlap across all VPCs in the organization — no human CIDR planning, no accidental conflicts when adding future accounts.
+
+**Egress strategy — hybrid: one NAT Gateway + Gateway endpoints, no Interface endpoints.**
+
+```
+Internet-bound traffic  → NAT Gateway (1, in AZ-a) → IGW → Internet
+S3 and DynamoDB traffic → Gateway VPC Endpoint (free) → AWS backbone
+Other AWS services      → NAT Gateway → public AWS endpoints
+```
+
+The cluster needs internet egress for three specific external dependencies:
+- **GitHub.com** — ArgoCD pulls application manifests from `aegis-core` repository (pull-based GitOps per ADR-007).
+- **Public Helm repositories** — initial installation of ArgoCD, Karpenter, and AWS Load Balancer Controller charts.
+- **Public container registries** (rare) — if any workload explicitly pulls from a non-AWS registry. Default is to mirror everything to ECR (ADR-013).
+
+All three are non-AWS destinations that VPC endpoints cannot reach. NAT Gateway is the only mechanism that satisfies them. One NAT (not three) is sufficient because lab workloads tolerate an AZ-a outage reducing the cluster to degraded egress; production deployments should run three NATs for AZ-independent egress.
+
+Gateway endpoints for S3 and DynamoDB are included because they are **free**. S3 is the largest traffic source in any EKS cluster — container image layers from ECR traverse S3 internally — and routing S3 traffic through the Gateway endpoint avoids NAT data processing fees entirely ($0.045/GB saved on every image pull). DynamoDB is not used today but the endpoint costs nothing to provision and eliminates a future migration when state-aware services arrive.
+
+Interface VPC endpoints (ECR API, STS, EKS, SSM, CloudWatch Logs, EC2) are **not** provisioned. At $0.01/hour per endpoint per AZ, six endpoints in three AZs cost $131/month — more than three NAT Gateways. For a single-NAT lab topology the per-session cost of NAT data transfer is pennies and far cheaper than interface endpoints.
+
+**VPC Flow Logs — to logarchive account.**
+
+VPC Flow Logs capture all accepted and rejected traffic at the VPC level and ship to an S3 bucket in `aegis-logarchive` (the centralized log archive per ADR-006). The log format includes source/destination IP, port, protocol, action, bytes, and AWS account ID. Retention is 90 days in the logarchive bucket. Flow Logs satisfy ISO 27001 Annex A.8.15 (Logging) for network-layer events and feed future Security Hub / GuardDuty analysis.
+
+## Alternatives Considered
+
+**Pure PrivateLink topology — no NAT Gateway at all.** Rejected. Eliminating NAT requires eliminating all non-AWS outbound destinations, which means mirroring every external dependency: GitHub source to CodeCommit, public Helm charts to ECR, public container images to ECR, Let's Encrypt to ACM. This is technically feasible but defeats the portfolio narrative of GitHub-centric pull-based GitOps. The architectural story changes from "standard K8s GitOps on AWS" to "air-gapped AWS with mirror infrastructure" — a different demonstration with different audiences. This project optimizes for the standard-GitOps story.
+
+**Three NAT Gateways for AZ-independent egress.** Rejected for this lab project. Cost is $97/month always-on (three NATs × $32) versus $32 for a single NAT, for redundancy that lab workloads do not require. Teardown discipline (ADR-009) means NATs run for at most ~4 hours per session, so per-session cost is $0.54 vs $0.18 — pennies either way. But the "always-on" distinction matters if the operator forgets to tear down. The single-NAT choice is documented as a lab-specific compromise; production deployments must use one NAT per AZ.
+
+**Full Interface VPC endpoint coverage for all AWS services.** Rejected. The calculation is $0.01/hr × 6 endpoints × 3 AZs = $0.18/hr = $131/month always-on, exceeding even the three-NAT configuration. Per-session cost ($0.72 for a four-hour session) is higher than NAT ($0.18). Interface endpoints make sense for enterprise environments with sustained traffic where the hourly cost is amortized across heavy utilization, not for a lab that runs a few hours at a time.
+
+**Two NAT Gateways in different AZs as a compromise.** Considered and rejected. Two NATs is a weird middle ground: it costs two-thirds of the HA price but still leaves one AZ without NAT. The operational model is either "single NAT, lab accepts degraded-AZ impact" or "one NAT per AZ, production-grade resilience." There is no coherent story for two.
+
+**Single-AZ VPC (one public + one private subnet only).** Rejected. EKS requires subnets in at least two AZs for control plane resilience. Additionally, AWS Load Balancer Controller requires multi-AZ subnets to create an internet-facing ALB. Single-AZ is simply non-functional for the target workload.
+
+**Four-AZ topology** (eu-central-1 has four AZs). Rejected as over-scope. Three AZs match ADR-002's declared zones and provide K8s-recommended HA. Adding a fourth AZ increases subnet count and IP waste without meaningful resilience improvement at current scale.
+
+## Consequences
+
+VPC Flow Logs produce ~$0.50/GB/month of log storage — small volume at lab scale, but a nonzero line item in the monthly bill. The logarchive bucket has lifecycle rules to transition logs to Glacier after 30 days if cost becomes a concern.
+
+The single NAT Gateway creates a regional single point of failure. If AZ-a suffers an outage, all cluster egress to the internet stops. Private subnet → AWS services (via regional AWS backbone) and Gateway endpoints (S3, DynamoDB) continue working. This is explicitly accepted for the lab environment and explicitly documented as not acceptable for production.
+
+IPAM allocation couples the staging VPC to the shared/ipam Terraservices layer. VPC creation requires `shared/ipam/` to be applied first. This ordering is documented in the runbook and enforced by Terraform's `terraform_remote_state` data source reading the IPAM pool ID from the `shared/ipam` state.
+
+Future workload accounts (`aegis-prod`, future sandboxes) follow the same topology — three-AZ public/private, single NAT, Gateway endpoints, IPAM-allocated CIDR. A Terraform module at `terraform/modules/vpc/` extracts the pattern once there are two or more consumers (DRY triggered by actual reuse, not anticipation).
+
+The absence of Interface endpoints means every non-S3, non-DynamoDB AWS API call traverses NAT. For services like STS (IRSA token exchange, every pod every hour) and CloudWatch Logs (every log line), this is a measurable data volume. At lab scale the total is well under a dollar per session. At production scale, this is the trigger to add Interface endpoints — but only for the specific high-traffic services, not a blanket deployment.

--- a/docs/decisions/013-eks-architecture.md
+++ b/docs/decisions/013-eks-architecture.md
@@ -1,0 +1,89 @@
+# 013. EKS Architecture
+
+## Status
+Accepted
+
+## Context
+Phase 3 builds an EKS cluster in `aegis-staging` as the runtime for the `aegis-core` workload. Several load-bearing decisions need to be locked before any EKS Terraform runs: cluster version, node provisioning mechanism, control plane exposure, workload IAM model, image registry, TLS certificate provider, and GitOps bootstrapping.
+
+Each decision interacts with the others. Choosing Karpenter for nodes changes what bootstraps Karpenter itself. Choosing ACM for TLS changes whether cert-manager is installed. Choosing public container images changes whether NAT data transfer dominates cost. This ADR resolves the interactions coherently.
+
+## Decision
+
+**EKS version — 1.32.**
+
+EKS 1.32 was the current default for new clusters as of the Phase 3 start date. AWS standard support for 1.32 runs into 2027, which matches the expected project lifetime. Kubernetes 1.32 supports the full set of GA APIs required by Karpenter v1, ArgoCD 2.x, and AWS Load Balancer Controller — no need to pin to an older version for compatibility.
+
+**Node provisioning — Karpenter only, Karpenter itself on Fargate.**
+
+No managed node groups. Karpenter v1 provisions EC2 instances directly based on pod scheduling pressure, using the `NodePool` and `EC2NodeClass` CRDs. Node scaling is binpack-based and reacts within seconds, which matches the lab teardown cadence: when all workloads are destroyed, Karpenter terminates the underlying EC2 within minutes, zeroing EC2 cost automatically.
+
+Karpenter itself is a pod and needs to run somewhere. Running it on the nodes it provisions creates a chicken-and-egg bootstrap problem. The two clean solutions are a tiny managed node group for system pods (Karpenter, CoreDNS, kube-proxy) or running on EKS Fargate. This project uses **Fargate for Karpenter and CoreDNS**. Fargate eliminates the managed node group (one less Terraform resource and one less thing to forget to tear down), costs $0.04/hour for a Karpenter-sized pod, and makes the bootstrap story trivial: the cluster starts empty and Karpenter provisions the first EC2 node on demand.
+
+**Control plane endpoint — public + private.**
+
+The EKS API server is accessible via both public (for `kubectl` from the operator's laptop) and private (for in-cluster components) endpoints. Fully private endpoints would require either a bastion host, a VPN, or SSM port forwarding for operator access — all of which add complexity without security benefit in a single-operator lab. Access to the public endpoint is restricted to the operator's IP range via `public_access_cidrs`, which is read from config at deployment time.
+
+**Workload IAM — IAM Roles for Service Accounts (IRSA).**
+
+Every workload pod that needs AWS permissions uses IRSA, not node instance roles. The EKS cluster has an OIDC identity provider; pods annotate their ServiceAccount with a role ARN; AWS SDKs exchange the projected OIDC token for temporary credentials. This is the AWS-recommended pattern and eliminates the need for any long-lived credentials anywhere — consistent with ADR-001's "no static credentials" principle at the pod level, just as OIDC federation enforces it at the CI/CD level.
+
+EKS Pod Identity (the 2023 alternative to IRSA) is considered for a future upgrade but IRSA remains the more portable and better-documented pattern for this project's scope. Pod Identity migration is tracked in Phase 5 backlog.
+
+**Operator access — EKS Access Entries with IAM Identity Center.**
+
+EKS Access Entries (the replacement for the older aws-auth ConfigMap) map AWS IAM principals to Kubernetes RBAC. The `PlatformAdmin` permission set in Identity Center is mapped to the `cluster-admin` ClusterRole. No IAM users, no aws-auth ConfigMap, no static kubeconfig — `aws eks update-kubeconfig` produces a token from the current SSO session. When the operator's SSO session expires, `kubectl` stops working, which is the correct behavior.
+
+**Image registry — ECR for all workload images.**
+
+All container images used by workloads deploy to an ECR repository in the `aegis-staging` account. Public images (CoreDNS, Karpenter, ArgoCD, AWS Load Balancer Controller) are pulled from their original sources during initial install via NAT Gateway; after deployment they are cached in ECR through the EKS image puller. Custom workload images (from `aegis-core`) are built by GitHub Actions and pushed to ECR.
+
+ECR storage costs approximately $0.10/GB/month — pennies for a lab with a handful of images. Cross-AZ pull charges ($0.01/GB) are offset by same-region pull being otherwise free. Compared to pulling public Docker Hub images through NAT, ECR saves NAT data processing fees ($0.045/GB) and eliminates Docker Hub's unauthenticated rate limit (100 pulls per 6 hours), which Karpenter-driven scale-up can easily hit.
+
+**TLS certificate provider — ACM for public endpoints.**
+
+Public-facing services terminate TLS at an AWS-provided load balancer (ALB via AWS Load Balancer Controller) using ACM-issued certificates. ACM is free for public certs, renews automatically, and requires no outbound internet egress from the cluster. The ArgoCD UI, the aegis-core application ingress, and any future public endpoint all use this pattern.
+
+cert-manager is **not** installed in Phase 3. It is deferred to Phase 5 when service mesh mTLS creates an actual requirement for in-cluster certificate issuance. Installing cert-manager earlier solely for the ArgoCD UI cert would be a premature complexity — ACM + ALB covers that case with less operational overhead.
+
+**Ingress controller — AWS Load Balancer Controller.**
+
+AWS Load Balancer Controller watches for `Ingress` and `Service type=LoadBalancer` resources and provisions ALBs or NLBs. ALBs integrate natively with ACM for TLS termination, WAF for filtering, and CloudFront for caching. The controller runs as an in-cluster deployment with an IRSA-bound IAM role granting `elasticloadbalancing:*` and related permissions.
+
+Nginx Ingress, Traefik, and Istio Gateway are all viable K8s-native alternatives, but each terminates TLS inside the cluster and therefore would require cert-manager. This project's staged rollout — ACM in Phase 3, cert-manager in Phase 5 — means AWS Load Balancer Controller is the natural Phase 3 choice.
+
+**GitOps bootstrap — ArgoCD via Terraform Helm, then self-managed via App-of-Apps.**
+
+Terraform installs ArgoCD core via the official Helm chart. After the initial install, ArgoCD's `Application` CRD points at the `aegis-core` repository (per ADR-007) and ArgoCD self-manages all subsequent application deployments. Changes to ArgoCD's own configuration flow through the same GitOps path after bootstrap.
+
+The `App-of-Apps` pattern organizes workload applications: a single root `Application` in this repo points to a directory in `aegis-core` that declares child applications. Adding a new workload is a commit to `aegis-core`, not a Terraform change here.
+
+## Alternatives Considered
+
+**Managed node groups instead of Karpenter.** Rejected. CLAUDE.md explicitly lists Karpenter as a Phase 3 learning goal. Managed node groups work but do not exercise dynamic binpack-based scaling, which is the interesting K8s autoscaling story for the portfolio. The two-year-old debate between Cluster Autoscaler and Karpenter is largely settled in Karpenter's favor for dynamic workload patterns — the portfolio should reflect current practice, not 2022 practice.
+
+**Karpenter plus a small managed node group for system pods.** Considered. Keeps Karpenter simpler (it never needs to bootstrap itself) and provides guaranteed capacity for CoreDNS. Rejected in favor of Fargate because managed node groups have a minimum size of 1 node ($30/month for the smallest instance always-on) while Fargate bills per pod per second. For a lab with teardown after each session, Fargate wins on cost.
+
+**Fargate for all workloads, no EC2.** Rejected. Fargate does not support DaemonSets or privileged pods, restricts volume types, and costs ~20% more per vCPU-hour than EC2. For the two-pod bootstrap (Karpenter + CoreDNS) it is ideal; for general workloads EC2 via Karpenter is cheaper and more flexible.
+
+**Fully private EKS endpoint.** Rejected. Private-only requires a bastion host or SSM session manager for `kubectl` from the operator's laptop — adding infrastructure whose only purpose is reaching a cluster that is already behind an SSO-authenticated IAM role. The public endpoint is locked to the operator's IP via `public_access_cidrs` and secured by the cluster's IAM authentication. The actual attack surface is equivalent to a private endpoint plus bastion, without the bastion's operational cost and complexity.
+
+**Pod Identity instead of IRSA.** Considered. EKS Pod Identity (2023) simplifies the IRSA token exchange and does not require the EKS OIDC provider to be externally trusted. For greenfield clusters it is the recommended approach, but the ecosystem documentation and operator tooling are still IRSA-dominant. This project uses IRSA for Phase 3 and tracks a Pod Identity migration for Phase 5 when service mesh integration might benefit from it.
+
+**aws-auth ConfigMap for operator access.** Rejected. The ConfigMap is the legacy mechanism, deprecated by AWS in favor of Access Entries. New clusters should not use aws-auth unless there is a specific reason (e.g., existing tooling that reads it). There is none here.
+
+**Docker Hub + NAT for public images, skip ECR.** Rejected. Docker Hub's unauthenticated rate limit (100 pulls per 6 hours per source IP) is easily exceeded by Karpenter provisioning five nodes in parallel, each pulling CoreDNS + aws-node + kube-proxy. Even the authenticated tier has a limit. ECR's $0.50/month storage cost is trivial compared to the operational risk of rate-limited image pulls during a demo.
+
+**Let's Encrypt + cert-manager for all TLS.** Rejected for Phase 3, documented as Phase 5 work. See ADR-012 egress strategy and this ADR's TLS section — cert-manager earns its place when service mesh or in-cluster TLS termination creates actual requirements, not for a single ArgoCD UI cert that ACM handles for free.
+
+## Consequences
+
+EKS control plane costs $0.10/hour (~$73/month always-on) and is the largest single line item once the cluster is running. ADR-009's teardown discipline is load-bearing: sessions must end with `terraform destroy` of the `staging/platform` layer, or the monthly bill escalates.
+
+Karpenter-provisioned EC2 instances use Spot by default (configurable per `NodePool`). Spot interruption is acceptable for lab workloads; any stateful workload that arrives later must explicitly opt in to on-demand via a dedicated `NodePool`.
+
+The Fargate-hosted Karpenter pod is a small but continuous cost (~$30/month if left running). The teardown script must include Fargate profile removal. The `soft-teardown-workload.sh` per ADR-009 handles this automatically.
+
+ECR repositories are created in `aegis-staging` by the `staging/platform/` Terraform layer. When the platform layer is destroyed, ECR repositories are preserved (`prevent_destroy = true` on the repository resource) so that image history survives cluster teardown. Only the cluster itself is ephemeral; artifacts persist.
+
+The public EKS endpoint restricted to the operator's IP means the IP must be kept current in config. A mobile operator (different cafe, different VPN exit) either updates the config and re-applies the platform layer (~2 minutes) or falls back to SSM session manager through a bootstrap EC2 instance. Documented as a known operational trade-off of avoiding the bastion.


### PR DESCRIPTION
## Summary
Locks the architectural decisions for Phase 3 before any Terraform code is written.

**ADR-012** — VPC topology, single NAT, Gateway endpoints (S3+DynamoDB), Flow Logs to logarchive. Rejects pure PrivateLink (would force CodeCommit mirror) and three-NAT HA (cost not justified for lab).

**ADR-013** — EKS 1.32, Karpenter only with Karpenter+CoreDNS on Fargate, IRSA, Access Entries, ECR, ACM+ALB, ArgoCD via Helm bootstrap. cert-manager deferred to Phase 5.

Both cite per-session and always-on cost numbers to make lab vs production trade-offs explicit.

## Test plan
- [ ] CI passes (Plan x3 + Checkov)
- [ ] Both ADRs reviewed for cost and security claims accuracy