### PR TITLE
feat: IPAM (shared) + staging OIDC for CI

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -27,10 +27,14 @@ jobs:
           # Order matters: bootstrap before scps (dependencies)
           - env: shared/bootstrap
             account_id: "345895787808"
+          - env: shared/ipam
+            account_id: "345895787808"
           - env: management/bootstrap
             account_id: "186052668286"
           - env: management/scps
             account_id: "186052668286"
+          - env: staging/bootstrap
+            account_id: "251774439261"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -27,6 +27,10 @@ jobs:
             account_id: "186052668286"
           - env: shared/bootstrap
             account_id: "345895787808"
+          - env: shared/ipam
+            account_id: "345895787808"
+          - env: staging/bootstrap
+            account_id: "251774439261"
 
     steps:
       - uses: actions/checkout@v4

--- a/terraform/environments/shared/ipam/.terraform.lock.hcl
+++ b/terraform/environments/shared/ipam/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/environments/shared/ipam/backend.tf
+++ b/terraform/environments/shared/ipam/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "shared/ipam/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/shared/ipam/config.tf
+++ b/terraform/environments/shared/ipam/config.tf
@@ -1,0 +1,17 @@
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.shared.id
+  org_arn        = "arn:aws:organizations::${local.config.accounts.management.id}:organization/${local.config.organization.id}"
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+  dr_region      = [for r in local.config.regions : r.name if r.role == "dr"][0]
+  operating_regions = [for r in local.config.regions : r.name]
+
+  top_cidr     = local.config.ipam.top_cidr
+  pool_cidrs   = local.config.ipam.pools  # map: region → { cidr = "..." }
+
+  tags = merge(local.config.tags, {
+    Environment = "shared"
+    Component   = "ipam"
+  })
+}

--- a/terraform/environments/shared/ipam/main.tf
+++ b/terraform/environments/shared/ipam/main.tf
@@ -1,0 +1,125 @@
+# -----------------------------------------------------------------------------
+# AWS IPAM — Cross-Account CIDR Allocation (ADR-004 Mode B, ADR-012)
+# -----------------------------------------------------------------------------
+# Hierarchy:
+#   IPAM (private scope)
+#     └── Top-level pool (10.0.0.0/8)
+#           ├── Regional pool eu-central-1 (10.0.0.0/12)  ← shared via RAM
+#           └── Regional pool eu-west-1    (10.16.0.0/12) ← shared via RAM
+#
+# Workload accounts (staging, prod, future sandboxes) allocate VPC CIDRs from
+# the regional pools. IPAM enforces non-overlap at the API level — no human
+# CIDR planning required.
+#
+# Cost: IPAM Advanced Tier — $0.0027/IP/hour for active IPs allocated by IPAM.
+# Idle pools cost $0. A staging /20 VPC running 24/7 costs ~$8/month;
+# per-session (4-hour) cost is ~$0.04. See ADR-004 + ADR-012.
+# -----------------------------------------------------------------------------
+
+resource "aws_vpc_ipam" "main" {
+  description = "Aegis organization-wide IPAM for VPC CIDR allocation"
+  tier        = "advanced"  # Required for cross-account RAM sharing
+
+  dynamic "operating_regions" {
+    for_each = local.operating_regions
+    content {
+      region_name = operating_regions.value
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Top-level pool — 10.0.0.0/8, source for all regional pools
+# -----------------------------------------------------------------------------
+
+resource "aws_vpc_ipam_pool" "top" {
+  description    = "Top-level pool — entire RFC1918 10.0.0.0/8 space"
+  address_family = "ipv4"
+  ipam_scope_id  = aws_vpc_ipam.main.private_default_scope_id
+  # Top-level pool is not locale-locked; regional pools cascade from it
+}
+
+resource "aws_vpc_ipam_pool_cidr" "top" {
+  ipam_pool_id = aws_vpc_ipam_pool.top.id
+  cidr         = local.top_cidr
+}
+
+# -----------------------------------------------------------------------------
+# Regional pool: eu-central-1 (primary)
+# -----------------------------------------------------------------------------
+
+resource "aws_vpc_ipam_pool" "primary" {
+  description         = "Regional pool — ${local.primary_region}"
+  address_family      = "ipv4"
+  ipam_scope_id       = aws_vpc_ipam.main.private_default_scope_id
+  source_ipam_pool_id = aws_vpc_ipam_pool.top.id
+  locale              = local.primary_region
+  auto_import         = false
+}
+
+resource "aws_vpc_ipam_pool_cidr" "primary" {
+  ipam_pool_id = aws_vpc_ipam_pool.primary.id
+  cidr         = local.pool_cidrs[local.primary_region].cidr
+
+  depends_on = [aws_vpc_ipam_pool_cidr.top]
+}
+
+# -----------------------------------------------------------------------------
+# Regional pool: eu-west-1 (DR)
+# -----------------------------------------------------------------------------
+
+resource "aws_vpc_ipam_pool" "dr" {
+  description         = "Regional pool — ${local.dr_region}"
+  address_family      = "ipv4"
+  ipam_scope_id       = aws_vpc_ipam.main.private_default_scope_id
+  source_ipam_pool_id = aws_vpc_ipam_pool.top.id
+  locale              = local.dr_region
+  auto_import         = false
+}
+
+resource "aws_vpc_ipam_pool_cidr" "dr" {
+  ipam_pool_id = aws_vpc_ipam_pool.dr.id
+  cidr         = local.pool_cidrs[local.dr_region].cidr
+
+  depends_on = [aws_vpc_ipam_pool_cidr.top]
+}
+
+# -----------------------------------------------------------------------------
+# RAM Sharing — make regional pools available to all org member accounts
+# -----------------------------------------------------------------------------
+# Without RAM sharing, only the shared account can allocate from these pools.
+# Sharing org-wide means staging/prod/future accounts can request CIDR
+# allocations directly via aws_vpc_ipam_pool_cidr_allocation.
+#
+# Pool-level sharing (not VPC-level) — accounts get the right to draw from
+# the pool, IPAM still enforces non-overlap centrally.
+# -----------------------------------------------------------------------------
+
+resource "aws_ram_resource_share" "ipam_pools" {
+  name                      = "aegis-ipam-pools"
+  allow_external_principals = false
+}
+
+resource "aws_ram_principal_association" "org" {
+  resource_share_arn = aws_ram_resource_share.ipam_pools.arn
+  principal          = local.org_arn
+}
+
+resource "aws_ram_resource_association" "primary_pool" {
+  resource_share_arn = aws_ram_resource_share.ipam_pools.arn
+  resource_arn       = aws_vpc_ipam_pool.primary.arn
+}
+
+resource "aws_ram_resource_association" "dr_pool" {
+  resource_share_arn = aws_ram_resource_share.ipam_pools.arn
+  resource_arn       = aws_vpc_ipam_pool.dr.arn
+}
+
+data "aws_caller_identity" "current" {}
+
+check "config_account_id_not_empty" {
+  assert {
+    condition     = local.account_id != ""
+    error_message = "accounts.shared.id in landing-zone.yaml is empty."
+  }
+}

--- a/terraform/environments/shared/ipam/outputs.tf
+++ b/terraform/environments/shared/ipam/outputs.tf
@@ -1,0 +1,34 @@
+output "ipam_id" {
+  description = "IPAM resource ID"
+  value       = aws_vpc_ipam.main.id
+}
+
+output "ipam_arn" {
+  description = "IPAM resource ARN"
+  value       = aws_vpc_ipam.main.arn
+}
+
+output "primary_pool_id" {
+  description = "Regional IPAM pool ID for primary region"
+  value       = aws_vpc_ipam_pool.primary.id
+}
+
+output "primary_pool_arn" {
+  description = "Regional IPAM pool ARN for primary region"
+  value       = aws_vpc_ipam_pool.primary.arn
+}
+
+output "dr_pool_id" {
+  description = "Regional IPAM pool ID for DR region"
+  value       = aws_vpc_ipam_pool.dr.id
+}
+
+output "dr_pool_arn" {
+  description = "Regional IPAM pool ARN for DR region"
+  value       = aws_vpc_ipam_pool.dr.arn
+}
+
+output "ram_resource_share_arn" {
+  description = "RAM share ARN for IPAM pools"
+  value       = aws_ram_resource_share.ipam_pools.arn
+}

--- a/terraform/environments/shared/ipam/providers.tf
+++ b/terraform/environments/shared/ipam/providers.tf
@@ -1,0 +1,22 @@
+# Primary region provider
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}
+
+# DR region provider — needed for the eu-west-1 regional pool
+provider "aws" {
+  alias  = "eu_west_1"
+  region = local.dr_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/shared/ipam/versions.tf
+++ b/terraform/environments/shared/ipam/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+      configuration_aliases = [aws.eu_west_1]
+    }
+  }
+}

--- a/terraform/environments/staging/bootstrap/oidc-github.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github.tf
@@ -1,0 +1,57 @@
+# -----------------------------------------------------------------------------
+# GitHub OIDC Federation — staging account CI access
+# -----------------------------------------------------------------------------
+# Same pattern as management/bootstrap and shared/bootstrap. Allows GitHub
+# Actions to deploy staging resources (network, platform, workloads layers)
+# without static credentials.
+# -----------------------------------------------------------------------------
+
+locals {
+  github_org        = local.config.github.org
+  github_infra_repo = local.config.github.infra_repo
+  github_oidc_url   = "https://token.actions.githubusercontent.com"
+
+  github_oidc_subjects = [
+    "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main",
+    "repo:${local.github_org}/${local.github_infra_repo}:pull_request",
+  ]
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = local.github_oidc_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+resource "aws_iam_role" "github_ci" {
+  name = "github-actions-terraform"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = local.github_oidc_subjects
+          }
+        }
+      }
+    ]
+  })
+}
+
+# Staging CI role permissions are AdministratorAccess for lab simplicity.
+# Production should scope down per Terraservices layer (network, platform,
+# workloads) using least-privilege custom policies.
+resource "aws_iam_role_policy_attachment" "github_ci" {
+  role       = aws_iam_role.github_ci.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/terraform/environments/staging/bootstrap/outputs.tf
+++ b/terraform/environments/staging/bootstrap/outputs.tf
@@ -7,3 +7,13 @@ output "account_alias" {
   description = "IAM account alias"
   value       = aws_iam_account_alias.this.account_alias
 }
+
+output "github_oidc_provider_arn" {
+  description = "GitHub OIDC identity provider ARN"
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+
+output "github_ci_role_arn" {
+  description = "IAM role ARN for GitHub Actions CI/CD"
+  value       = aws_iam_role.github_ci.arn
+}


### PR DESCRIPTION
## Summary
- **shared/ipam** — new Terraservices layer with central IPAM, regional pools, and RAM share to org. Implements ADR-004 Mode B and ADR-012 IPAM strategy. Cost: \$0 idle, \$0.0027/IP/hr when VPCs allocate.
- **staging/bootstrap** — adds GitHub OIDC provider + CI role (already applied locally). Same pattern as management+shared. Now CI can plan/apply staging layers.
- **CI matrix** — adds shared/ipam and staging/bootstrap to plan + apply workflows.
- **Branch protection** — 6 required status checks (was 4).

## Test plan
- [ ] All 6 status checks pass
- [ ] Plan shared/ipam shows 11 to add (1 IPAM, 3 pools, 3 CIDRs, 4 RAM)
- [ ] Plan staging/bootstrap shows no changes (already applied locally)