### PR TITLE
docs: add architecture diagrams + restructure README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,38 +6,55 @@
 
 Demonstrate end-to-end ability to design and build enterprise AWS infrastructure from zero:
 
-- Multi-account AWS Organizations with OUs and SCPs
+- Multi-account AWS Organizations with OUs and custom SCPs
 - AWS Control Tower as managed foundation + Terraform for extensions ([ADR-008](docs/decisions/008-landing-zone-tooling-control-tower-hybrid.md))
-- AWS Identity Center (SSO) — no IAM users, no static credentials
-- GitHub OIDC federation for CI/CD
-- Terraform IaC with S3 backend + native locking ([ADR-003](docs/decisions/003-terraform-backend-bootstrap.md))
-- GitHub Actions CI/CD (plan on PR, apply on merge)
-- EKS cluster with ArgoCD GitOps + Karpenter
-- Observability (Prometheus + Grafana)
-- Security baseline (CloudTrail, Config, GuardDuty)
-- ISO 27001:2022 Annex A as compliance north star ([ADR-005](docs/decisions/005-compliance-framework-iso-27001.md))
+- AWS Identity Center (SSO) — no IAM users, no static credentials ([ADR-001](docs/decisions/001-landing-zone-scope-boundary.md))
+- GitHub OIDC federation for CI/CD — signed commits, branch protection, required status checks
+- Terraform IaC with S3 native state locking ([ADR-003](docs/decisions/003-terraform-backend-bootstrap.md))
+- GitHub Actions pipeline — `terraform plan` on PR, `terraform apply` on merge
+- Checkov IaC security scanning with triaged skip list
+- Centralized IPAM with RAM sharing to member accounts
+- ISO 27001:2022 Annex A alignment ([ADR-005](docs/decisions/005-compliance-framework-iso-27001.md))
+
+**Planned (Phase 3+)**: EKS + Karpenter + ArgoCD, observability stack, service mesh. See Phase table below for current status.
 
 ## Architecture
 
-```
-AWS Organizations (aegis-management)
-│
-├── OU: Security
-│   ├── aegis-security     ← GuardDuty, Security Hub, Config admin
-│   └── aegis-logarchive   ← CloudTrail/Config/Flow Log archive (write-only)
-│
-├── OU: Infrastructure
-│   └── aegis-shared       ← Terraform state, AFT, GitHub OIDC, ECR
-│
-└── OU: Workloads
-    ├── aegis-staging      ← Non-production workloads
-    └── aegis-prod         ← Production workloads
+High-level view. Detailed diagrams (account topology, CI/CD flow, identity, IPAM, deployment order) are in [`docs/architecture.md`](docs/architecture.md).
 
-Regions: eu-central-1 (primary), eu-west-1 (DR)
-SCP denies all other regions.
+```mermaid
+flowchart TB
+  subgraph GH["GitHub (this repository)"]
+    Code["Terraform code<br/>13 ADRs<br/>Runbook"]
+    CI["GitHub Actions<br/>plan + apply + Checkov"]
+  end
+
+  subgraph Org["AWS Organization (o-f5xi4j1hrx)"]
+    direction TB
+    Mgmt["aegis-management<br/>SCPs · SSO · Billing"]
+
+    subgraph Sec["OU: Security (CT-managed)"]
+      Audit["aegis-security"]
+      Log["aegis-logarchive"]
+    end
+
+    subgraph Inf["OU: Infrastructure"]
+      Shared["aegis-shared<br/>Terraform state · IPAM"]
+    end
+
+    subgraph Wrk["OU: Workloads"]
+      Stg["aegis-staging"]
+      Prd["aegis-prod"]
+    end
+  end
+
+  CI -. OIDC federation<br/>(no static creds) .-> Org
+  Mgmt -. SCPs .-> Sec
+  Mgmt -. SCPs .-> Inf
+  Mgmt -. SCPs .-> Wrk
 ```
 
-See [ADR-006](docs/decisions/006-account-taxonomy-and-ou-structure.md) for the full account taxonomy rationale.
+Regions: `eu-central-1` (primary) and `eu-west-1` (DR). Control Tower region-deny SCP blocks all others.
 
 ## Configuration Contract
 
@@ -48,32 +65,34 @@ All deployment-specific values (account IDs, emails, regions, CIDRs) live in `co
 ```bash
 # 1. Copy the template and fill in your values
 cp config/landing-zone.example.yaml config/landing-zone.yaml
-# Edit config/landing-zone.yaml with your account IDs, domain, regions, etc.
 
 # 2. Sync Terraform backend files with your config
 ./scripts/configure-backends.sh
 
-# 3. Initialize and deploy
+# 3. Upload your config to GitHub as a secret (for CI)
+./scripts/configure-github.sh
+
+# 4. Initialize and deploy (manual path — CI can also do this)
 cd terraform/environments/shared/bootstrap
 terraform init && terraform plan
 ```
 
-The script reads your `config/landing-zone.yaml` and updates all `backend.tf` files with the correct S3 bucket name and region. This is necessary because Terraform's backend block [does not support variables](docs/decisions/003-terraform-backend-bootstrap.md) — the only hardcoded values in the repository.
+The `configure-backends.sh` script replaces hardcoded values in `backend.tf` files with values from your `config/landing-zone.yaml`. This step exists because Terraform's backend block [does not support variables](docs/decisions/003-terraform-backend-bootstrap.md) — the only hardcoded values in the repository.
 
 ## Phases
 
+Status is tracked by what actually exists in the main branch, not what is aspirational. Each "Done" phase links to the PR(s) that delivered it.
+
 | Phase | Scope | Cost | Status |
 |-------|-------|------|--------|
-| 0. Bootstrap | AWS account, domain, Control Tower, Identity Center, budget alerts | ~Free | **Done** |
-| 1. Foundation | Config contract, Terraform backend, AFT, SCPs, GitHub OIDC | ~Free | **In progress** |
-| 2. GitOps Pipeline | GitHub Actions workflows, plan/apply automation, Checkov scanning | ~Free | Not started |
-| 3. EKS + ArgoCD + Karpenter | EKS cluster, ArgoCD, Karpenter, cert-manager, Kyverno | ~$5-10/session | Not started |
-| 4. Observability + Security | Prometheus, Grafana, CloudTrail, Config, GuardDuty | ~$5-10/session | Not started |
-| 5. Enterprise Service Mesh & Auth | Istio (mTLS), EKS Pod Identity, External Secrets, Cognito | ~$1-5/session | Not started |
-
-## Runbooks
-
-- [001 — Bootstrap AWS Account](docs/runbooks/001-bootstrap-aws-account.md): Step-by-step from zero to SSO-authenticated CLI, including Control Tower setup, KMS key policy, Identity Center, and all gotchas encountered.
+| 0. Bootstrap | AWS account, domain, Control Tower, Identity Center, budget alerts, KMS key | ~Free | **Done** (pre-PR, via [runbook](docs/runbooks/001-bootstrap-aws-account.md)) |
+| 1. Foundation | Config contract, state bucket, SCPs, OIDC, account provisioning | ~Free | **Done** ([#1](https://github.com/BinHsu/aegis-aws-landing-zone/pull/1)..[#7](https://github.com/BinHsu/aegis-aws-landing-zone/pull/7)) |
+| 2. GitOps Pipeline | plan/apply workflows, Checkov, pre-commit, signed commits | ~Free | **Done** ([#1](https://github.com/BinHsu/aegis-aws-landing-zone/pull/1), [#3](https://github.com/BinHsu/aegis-aws-landing-zone/pull/3), [#4](https://github.com/BinHsu/aegis-aws-landing-zone/pull/4), [#5](https://github.com/BinHsu/aegis-aws-landing-zone/pull/5)) |
+| 3a. Network Foundation | IPAM + RAM sharing, ADR-012 + ADR-013 | ~$0 idle / $0.003/IP/hr allocated | **Done** ([#6](https://github.com/BinHsu/aegis-aws-landing-zone/pull/6), [#7](https://github.com/BinHsu/aegis-aws-landing-zone/pull/7), [#8](https://github.com/BinHsu/aegis-aws-landing-zone/pull/8), [#9](https://github.com/BinHsu/aegis-aws-landing-zone/pull/9)) |
+| 3b. VPC | Staging VPC (3 AZ, 1 NAT, Gateway endpoints, Flow Logs) | ~$0.05/hr NAT | Not started |
+| 3c. EKS Platform | EKS 1.32 + Karpenter on Fargate + ArgoCD + ALB Controller + ACM | ~$0.15/hr | Not started |
+| 4. Observability + Security | Prometheus, Grafana, CloudTrail data events, GuardDuty, Security Hub | TBD | Not started |
+| 5. Enterprise Service Mesh & Auth | Istio (mTLS), cert-manager, EKS Pod Identity, External Secrets, Cognito | TBD | Not started |
 
 ## Architecture Decision Records
 
@@ -93,26 +112,32 @@ The script reads your `config/landing-zone.yaml` and updates all `backend.tf` fi
 | [012](docs/decisions/012-vpc-topology-and-egress-strategy.md) | VPC topology and egress strategy |
 | [013](docs/decisions/013-eks-architecture.md) | EKS architecture |
 
+## Runbooks
+
+- [001 — Bootstrap AWS Account](docs/runbooks/001-bootstrap-aws-account.md): Step-by-step from zero to SSO-authenticated CLI, including Control Tower setup, KMS key policy, Identity Center, Account Factory for staging/prod, GitHub repo configuration, signed commits, and all gotchas encountered.
+
 ## Companion Application Repository
 
-This infrastructure repo is the **Pointer** — it defines VPCs, EKS clusters, OIDC, and hoists ArgoCD. The application workload lives in **[aegis-core](https://github.com/BinHsu/aegis-core)** (the **Payload**). ArgoCD watches `aegis-core` and deploys changes via pull-based GitOps. See [ADR-007](docs/decisions/007-infra-app-repository-split.md).
+This infrastructure repo is the **Pointer** — it defines VPCs, EKS clusters, OIDC, and (Phase 3+) hoists ArgoCD. The application workload lives in **[aegis-core](https://github.com/BinHsu/aegis-core)** (the **Payload**, planned). ArgoCD watches `aegis-core` and deploys changes via pull-based GitOps. See [ADR-007](docs/decisions/007-infra-app-repository-split.md).
 
 ## Cost Management
 
-- **Phase 0-2 are essentially free** (Organizations, SSO, SCPs, S3, GitHub Actions free tier)
-- **Phase 3+ costs money** — spin up only when practicing, destroy after every session via [`soft-teardown-workload.sh`](docs/decisions/009-lifecycle-and-teardown-strategy.md)
-- **Budget alerts**: daily $10, monthly $30
+- **Phases 0-2 are ~free** (Organizations, SSO, SCPs, S3, public-repo GitHub Actions)
+- **Phase 3a (IPAM)**: ~$0 idle, ~$0.003/IP/hr when VPCs allocate — rounds to pennies per session
+- **Phase 3b+ (VPC + EKS)**: ~$3-5 per 4-hour session with [teardown discipline](docs/decisions/009-lifecycle-and-teardown-strategy.md)
+- **Budget alerts**: daily $10, monthly $30 (enforced via AWS Budgets in management account)
 - **NAT Gateway is the hidden cost killer** ($0.045/hr = $32/month if left running)
 - **Persistent baseline**: ~$5/month (Control Tower + Config recorder + CloudTrail)
-- **Per-session ephemeral**: ~$1-2/session (EKS, NAT, compute)
 
 ## Prerequisites
 
 - AWS account (management account) with billing access
-- Domain registered with email routing (see [runbook](docs/runbooks/001-bootstrap-aws-account.md))
-- Terraform CLI >= 1.10.0 (`brew install terraform`)
+- Domain registered with email routing
 - AWS CLI v2 (`brew install awscli`)
-- kubectl (`brew install kubectl`)
+- Terraform CLI >= 1.10 (`brew tap hashicorp/tap && brew install hashicorp/tap/terraform` — default Homebrew is stuck at 1.5.7)
+- `gh` CLI (`brew install gh`)
+- Python 3 with `pyyaml` and `jsonschema` (for pre-commit hook)
+- Signed-commits SSH key (see [Runbook Part 10.4](docs/runbooks/001-bootstrap-aws-account.md))
 
 ## Directory Structure
 
@@ -124,19 +149,33 @@ aegis-aws-landing-zone/
 │   └── schema.json                # JSON Schema validation
 ├── terraform/
 │   └── environments/
-│       ├── management/bootstrap/  # Management account baseline
-│       ├── shared/bootstrap/      # State bucket, IPAM (future)
-│       ├── staging/               # Staging layers (future)
-│       └── prod/                  # Production layers (future)
+│       ├── management/
+│       │   ├── bootstrap/         # Account alias, OIDC, org features
+│       │   └── scps/              # 3 custom SCPs
+│       ├── shared/
+│       │   ├── bootstrap/         # State bucket, OIDC
+│       │   ├── ipam/              # IPAM pools + RAM share
+│       │   └── aft/               # AFT code (not deployed — ADR-011 Path A)
+│       ├── staging/bootstrap/     # Alias + OIDC
+│       └── prod/bootstrap/        # Alias only
+├── scripts/
+│   ├── configure-backends.sh      # Sync backend.tf from config
+│   ├── configure-github.sh        # Upload config to GitHub secret
+│   └── validate-config.py         # JSON Schema validator (pre-commit)
 ├── docs/
-│   ├── decisions/                 # Architecture Decision Records
+│   ├── architecture.md            # Detailed Mermaid diagrams
+│   ├── decisions/                 # Architecture Decision Records (ADRs)
 │   └── runbooks/                  # Operational runbooks
-├── .github/workflows/             # GitHub Actions (future)
-├── k8s-manifests/                 # ArgoCD app-of-apps (future)
+├── .github/workflows/             # plan + apply + checkov
+├── .pre-commit-config.yaml        # Local quality gates
 ├── CLAUDE.md                      # AI operational rules
 └── .terraform-version             # Pinned Terraform version
 ```
 
 ## Author
 
-**Bin Hsu** — Senior Software Architect, 15 years experience (10 years C++ embedded systems, 5 years AWS platform engineering). Building this to prove that system design + hands-on implementation = the same person.
+**Bin Hsu** — Senior Software Architect, 15 years experience (10 years C++ embedded systems at VIVOTEK, 5 years AWS platform engineering at E2 Nova). Building this to prove that system design + hands-on implementation = the same person.
+
+---
+
+**Documentation drift policy**: This README reflects the state of `main` at the commit referenced in the Phase table above. If you find content that does not match reality (missing directories, features that do not work, stale PR links), open a PR titled `docs: fix README drift — <area>`. See the same policy in [`docs/architecture.md`](docs/architecture.md).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ flowchart TB
     direction TB
     Mgmt["aegis-management<br/>SCPs · SSO · Billing"]
 
-    subgraph Sec["OU: Security (CT-managed)"]
+    subgraph Sec["OU: Security (Control Tower-managed)"]
       Audit["aegis-security"]
       Log["aegis-logarchive"]
     end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,201 @@
+# Architecture
+
+This document is the authoritative visual reference for the `aegis-aws-landing-zone` deployment. Every diagram is **Mermaid** (text-based, GitHub-rendered) — no static images, no external renderers, no drift risk. Edit the diagram when you edit the code.
+
+Each diagram is cross-referenced to the Architecture Decision Record (ADR) that owns the underlying reasoning. When the diagram and an ADR disagree, the ADR wins and the diagram needs fixing in the same PR.
+
+---
+
+## 1. Account Topology
+
+AWS Organizations structure with the six accounts, three OUs, and SCP attachment point. See [ADR-006](decisions/006-account-taxonomy-and-ou-structure.md) for rationale.
+
+```mermaid
+flowchart TB
+  Org["AWS Organization<br/>o-f5xi4j1hrx<br/>CT home: eu-central-1"]
+
+  Mgmt["aegis-management<br/><br/>Organizations<br/>SCPs<br/>Identity Center<br/>Billing<br/>RAM org-sharing"]
+
+  subgraph Security["OU: Security (CT-managed)"]
+    Sec["aegis-security<br/><br/>GuardDuty<br/>Security Hub<br/>Config admin"]
+    Log["aegis-logarchive<br/><br/>CloudTrail archive<br/>Config archive<br/>VPC Flow Logs"]
+  end
+
+  subgraph Infra["OU: Infrastructure"]
+    Shared["aegis-shared<br/><br/>Terraform state bucket<br/>IPAM pools<br/>GitHub OIDC<br/>AFT (not deployed)"]
+  end
+
+  subgraph Work["OU: Workloads"]
+    Stg["aegis-staging<br/><br/>Phase 3: EKS (planned)"]
+    Prd["aegis-prod<br/><br/>Phase 3: EKS (planned)"]
+  end
+
+  Org --> Mgmt
+  Org --> Security
+  Org --> Infra
+  Org --> Work
+  Mgmt -. SCPs .-> Security
+  Mgmt -. SCPs .-> Infra
+  Mgmt -. SCPs .-> Work
+```
+
+**Custom SCPs attached to Root** (see [ADR](decisions/006-account-taxonomy-and-ou-structure.md) and [terraform/environments/management/scps](../terraform/environments/management/scps/)):
+
+- `deny-root-user-actions` — blocks root in member accounts (ISO 27001 A.8.2)
+- `deny-iam-user-creation` — SSO-only access (ISO 27001 A.8.2)
+- `deny-leave-organization` — prevents accidental detach (ISO 27001 A.5.1)
+
+Plus Control Tower's mandatory guardrails (Region deny, CloudTrail/Config protection).
+
+---
+
+## 2. CI/CD Data Flow
+
+How changes flow from a developer's laptop to deployed AWS resources, with zero static credentials. See [ADR-001](decisions/001-landing-zone-scope-boundary.md) (no-static-credentials principle) and [.github/workflows/](../.github/workflows/).
+
+```mermaid
+sequenceDiagram
+  actor Dev as Developer
+  participant GH as GitHub
+  participant GHA as GitHub Actions
+  participant OIDC as AWS STS<br/>(OIDC federation)
+  participant TF as Terraform
+  participant AWS as AWS Account<br/>(management/shared/staging)
+
+  Dev->>GH: git push (signed commits)
+  Dev->>GH: open PR to main
+  GH->>GHA: trigger terraform-plan + checkov
+  GHA->>OIDC: AssumeRoleWithWebIdentity<br/>(repo subject claim)
+  OIDC-->>GHA: 1-hour temporary credentials
+  GHA->>TF: terraform plan
+  TF->>AWS: read current state + dry-run changes
+  AWS-->>TF: plan output
+  TF-->>GHA: plan result
+  GHA->>GH: post plan as PR comment
+
+  Note over Dev,GH: Review plan, resolve findings, approve
+
+  Dev->>GH: merge PR (signed merge commit)
+  GH->>GHA: trigger terraform-apply
+  GHA->>OIDC: same OIDC flow, main-branch subject
+  GHA->>TF: terraform apply -auto-approve
+  TF->>AWS: create/update/destroy resources
+  AWS-->>TF: applied state
+```
+
+**Required status checks on main** (branch protection): 5× `Plan ${env}` + `Checkov IaC Security Scan`. See [Runbook Part 10.3](runbooks/001-bootstrap-aws-account.md).
+
+---
+
+## 3. Identity and Access
+
+Who can do what, and how they authenticate. Zero IAM users. Zero long-lived credentials. See [ADR-001](decisions/001-landing-zone-scope-boundary.md).
+
+```mermaid
+flowchart LR
+  subgraph Human["Human Access"]
+    bin["Identity Center user: bin<br/>pcpunkhades@gmail.com"]
+    ps["Permission Set:<br/>PlatformAdmin<br/>(AdministratorAccess policy)"]
+  end
+
+  subgraph CI["CI/CD Access (no static creds)"]
+    gha["GitHub Actions workflow<br/>BinHsu/aegis-aws-landing-zone"]
+    oidc["token.actions<br/>.githubusercontent.com"]
+  end
+
+  subgraph AWS["AWS IAM Principals"]
+    sso_roles["AWSReservedSSO_PlatformAdmin_*<br/>(4 accounts: management,<br/>shared, staging, prod)"]
+    ci_roles["github-actions-terraform<br/>(3 accounts: management,<br/>shared, staging)"]
+  end
+
+  bin --> ps
+  ps -->|aws sso login<br/>8h session| sso_roles
+  gha --> oidc
+  oidc -->|AssumeRoleWithWebIdentity<br/>15min OIDC token → 1h creds| ci_roles
+
+  style Human fill:#e3f2fd,stroke:#1976d2
+  style CI fill:#fff3e0,stroke:#e65100
+  style AWS fill:#e8f5e9,stroke:#2e7d32
+```
+
+**Forbidden (enforced by SCP `deny-iam-user-creation`):** creating IAM users, creating access keys, attaching user policies.
+
+---
+
+## 4. State and IPAM (Shared Services)
+
+What lives in the `aegis-shared` account, and how other accounts consume its services. See [ADR-003](decisions/003-terraform-backend-bootstrap.md), [ADR-004](decisions/004-deployment-configuration-contract.md), [ADR-012](decisions/012-vpc-topology-and-egress-strategy.md).
+
+```mermaid
+flowchart TB
+  subgraph shared["aegis-shared (345895787808)"]
+    direction TB
+
+    bucket["S3: aegis-terraform-state-345895787808<br/>SSE-KMS + versioning<br/>30-day noncurrent expiration<br/>prevent_destroy"]
+
+    ipam["AWS IPAM (Advanced tier)"]
+    top["Top Pool: 10.0.0.0/8"]
+    primary_pool["Regional Pool eu-central-1<br/>10.0.0.0/12"]
+    dr_pool["Regional Pool eu-west-1<br/>10.16.0.0/12"]
+
+    ram["RAM share: aegis-ipam-pools<br/>(org-scoped)"]
+
+    ipam --> top
+    top --> primary_pool
+    top --> dr_pool
+    primary_pool --> ram
+    dr_pool --> ram
+  end
+
+  subgraph consumers["Consumer accounts (via OrgID condition)"]
+    mgmt["management: reads/writes<br/>management/bootstrap/tfstate<br/>management/scps/tfstate"]
+    stg["staging: reads/writes<br/>staging/bootstrap/tfstate<br/>+ allocates from IPAM pools<br/>(Phase 3)"]
+    prd["prod: same pattern<br/>(Phase 3+)"]
+  end
+
+  bucket -. s3:GetObject + PutObject<br/>condition: aws:PrincipalOrgID .-> mgmt
+  bucket -. same .-> stg
+  bucket -. same .-> prd
+  ram -. allocate-cidr .-> stg
+  ram -. allocate-cidr .-> prd
+```
+
+**State key convention:** `<account>/<layer>/terraform.tfstate`. Currently live: management/bootstrap, management/scps, shared/bootstrap, shared/ipam, staging/bootstrap, prod/bootstrap.
+
+---
+
+## 5. Deployment Order and Dependencies
+
+Which Terraform layers must apply first. Encoded in [`.github/workflows/terraform-apply.yml`](../.github/workflows/terraform-apply.yml).
+
+```mermaid
+flowchart LR
+  A["1. management/<br/>bootstrap"]
+  B["2. shared/<br/>bootstrap"]
+  C["3. shared/<br/>ipam"]
+  D["4. staging/<br/>bootstrap"]
+  E["5. management/<br/>scps"]
+
+  A -->|enables RAM<br/>org-sharing| C
+  A -->|OIDC provider| B
+  B -->|state bucket<br/>exists| C
+  B -->|state bucket<br/>exists| D
+  A -.->|SCPs applied<br/>last to avoid<br/>self-locking| E
+```
+
+Rationale documented inline in `terraform-apply.yml`. Violations of this order caused real incidents (PR #8, PR #9).
+
+---
+
+## Cross-references
+
+- All ADRs: [docs/decisions/](decisions/)
+- Setup from zero: [Runbook 001](runbooks/001-bootstrap-aws-account.md)
+- Terraform code: [terraform/environments/](../terraform/environments/)
+- CI workflows: [.github/workflows/](../.github/workflows/)
+
+## Drift policy
+
+**When this file lies, reality wins.** If you edit Terraform code that changes one of these diagrams, update the diagram in the same PR. CI does not enforce this (yet) but PR review must.
+
+If you find a diagram that no longer matches reality, open a PR titled `docs: fix architecture drift — <area>` and fix it. Do not ignore.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,11 +12,11 @@ AWS Organizations structure with the six accounts, three OUs, and SCP attachment
 
 ```mermaid
 flowchart TB
-  Org["AWS Organization<br/>o-f5xi4j1hrx<br/>CT home: eu-central-1"]
+  Org["AWS Organization<br/>o-f5xi4j1hrx<br/>Control Tower home: eu-central-1"]
 
   Mgmt["aegis-management<br/><br/>Organizations<br/>SCPs<br/>Identity Center<br/>Billing<br/>RAM org-sharing"]
 
-  subgraph Security["OU: Security (CT-managed)"]
+  subgraph Security["OU: Security (Control Tower-managed)"]
     Sec["aegis-security<br/><br/>GuardDuty<br/>Security Hub<br/>Config admin"]
     Log["aegis-logarchive<br/><br/>CloudTrail archive<br/>Config archive<br/>VPC Flow Logs"]
   end

--- a/docs/runbooks/001-bootstrap-aws-account.md
+++ b/docs/runbooks/001-bootstrap-aws-account.md
@@ -834,7 +834,7 @@ If Control Tower's **Create account** page shows _"potential drift in your landi
 4. **Important**: The Control Tower UI does not auto-refresh after the update completes. You must navigate back to the previous page and reload the browser before retrying. If you stay on the same page, the stale drift error will persist even though the drift has been cleared.
 5. Retry **Create account** after refreshing.
 
-**Fallback — Service Catalog direct method**: If the CT UI still blocks after re-baseline and refresh, go to **Service Catalog** → **Products** → **AWS Control Tower Account Factory** → **Launch product**. Fill in the same field values from 8.3. This bypasses the CT UI drift check while still applying all CT baseline guardrails — the underlying provisioning product is identical.
+**Fallback — Service Catalog direct method**: If the Control Tower UI still blocks after re-baseline and refresh, go to **Service Catalog** → **Products** → **AWS Control Tower Account Factory** → **Launch product**. Fill in the same field values from 8.3. This bypasses the Control Tower UI drift check while still applying all Control Tower baseline guardrails — the underlying provisioning product is identical.
 
 ### 8.2 Navigate to Account Factory
 

--- a/terraform/environments/management/scps/main.tf
+++ b/terraform/environments/management/scps/main.tf
@@ -8,7 +8,7 @@
 #   - Region deny (ADR-002: only eu-central-1 + eu-west-1)
 #   - CloudTrail protection (disallow changes/deletion)
 #   - AWS Config protection (disallow changes/deletion)
-#   - CT-managed IAM role protection
+#   - Control Tower-managed IAM role protection
 #
 # SCPs do NOT apply to the management account — only member accounts.
 # Management account root user is protected by MFA + cold storage (Runbook Part 3).


### PR DESCRIPTION
## Summary

New \`docs/architecture.md\` with 5 Mermaid diagrams (account topology, CI/CD flow, identity + access, state + IPAM, deployment order) — all text-based, GitHub-rendered, PR-reviewable. Cross-referenced to ADRs.

README restructured for portfolio readers (recruiters / tech leads):
- Mermaid overview replaces ASCII diagram
- Phase table links to actual PRs, not subjective status
- Phase 3 split into 3a (IPAM ✅) / 3b (VPC, pending) / 3c (EKS, pending)
- Prerequisites updated (Terraform HashiCorp tap workaround, gh CLI, signing)
- Directory tree matches reality (no "future" lies)
- aegis-core explicitly marked "planned"
- Drift policy at bottom: "when this file lies, reality wins"

## Test plan
- [ ] Mermaid diagrams render correctly on GitHub (visual check on PR page)
- [ ] All PR links in Phase table resolve
- [ ] All ADR links resolve
- [ ] CI green