### PR TITLE
docs: reframe README as OSS reference, add LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Bin Hsu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,37 @@
 # Aegis AWS Landing Zone
 
-> Production-grade multi-account AWS landing zone with GitOps, built from scratch as a hands-on portfolio project.
+[![Terraform Apply](https://github.com/BinHsu/aegis-aws-landing-zone/actions/workflows/terraform-apply.yml/badge.svg)](https://github.com/BinHsu/aegis-aws-landing-zone/actions/workflows/terraform-apply.yml)
+[![Checkov](https://github.com/BinHsu/aegis-aws-landing-zone/actions/workflows/checkov.yml/badge.svg)](https://github.com/BinHsu/aegis-aws-landing-zone/actions/workflows/checkov.yml)
+![Terraform](https://img.shields.io/badge/Terraform-%E2%89%A51.10-5C4EE5?logo=terraform)
+![License](https://img.shields.io/badge/License-MIT-yellow.svg)
 
-## Purpose
+> A reference implementation of a production-grade multi-account AWS landing zone, managed entirely through GitOps — for single-operator labs and small-team deployments that want AWS best-practice structure without the enterprise overhead.
 
-Demonstrate end-to-end ability to design and build enterprise AWS infrastructure from zero:
+## Features at a glance
 
-- Multi-account AWS Organizations with OUs and custom SCPs
-- AWS Control Tower as managed foundation + Terraform for extensions ([ADR-008](docs/decisions/008-landing-zone-tooling-control-tower-hybrid.md))
-- AWS Identity Center (SSO) — no IAM users, no static credentials ([ADR-001](docs/decisions/001-landing-zone-scope-boundary.md))
-- GitHub OIDC federation for CI/CD — signed commits, branch protection, required status checks
-- Terraform IaC with S3 native state locking ([ADR-003](docs/decisions/003-terraform-backend-bootstrap.md))
-- GitHub Actions pipeline — `terraform plan` on PR, `terraform apply` on merge
-- Checkov IaC security scanning with triaged skip list
-- Centralized IPAM with RAM sharing to member accounts
-- ISO 27001:2022 Annex A alignment ([ADR-005](docs/decisions/005-compliance-framework-iso-27001.md))
+- **Multi-account AWS Organizations** — 6 accounts under Control Tower, 3 OUs, 3 custom SCPs aligned to ISO 27001:2022 Annex A
+- **Zero static credentials** — AWS IAM Identity Center for humans, GitHub OIDC for CI/CD, IRSA-ready for workloads; no IAM users (enforced by SCP, not just policy)
+- **Terraform 1.14+ with S3 native state locking** — no DynamoDB, Terraservices layered state (ADR-003)
+- **GitHub Actions GitOps pipeline** — plan on PR, apply on merge, Checkov security scan, all required status checks
+- **Signed commits enforced** — branch protection + SSH-key signing
+- **Centralized IPAM with RAM cross-account sharing** — single source of truth for VPC CIDR allocation
+- **Fork-and-deploy by config** — one YAML file + two scripts; no per-deployment forks
+- **Runbook-proven reproducibility** — 10-part runbook documents every manual step plus the gotchas that broke the first attempt
+- **EKS + ArgoCD + Karpenter** — planned (Phase 3b/3c), architectural decisions locked in ADR-012 and ADR-013
 
-**Planned (Phase 3+)**: EKS + Karpenter + ArgoCD, observability stack, service mesh. See Phase table below for current status.
+## Reading guide
+
+| If you want to | Start here |
+|---|---|
+| See the architecture | [`docs/architecture.md`](docs/architecture.md) — 5 Mermaid diagrams |
+| Understand the design choices | [13 ADRs](docs/decisions/) — Context / Decision / Alternatives / Consequences |
+| Reproduce this from zero | [`docs/runbooks/001-bootstrap-aws-account.md`](docs/runbooks/001-bootstrap-aws-account.md) |
+| Fork and deploy to your org | [Configuration Contract](#configuration-contract) section below |
+| Browse the code | [`terraform/environments/`](terraform/environments/) |
 
 ## Architecture
 
-High-level view. Detailed diagrams (account topology, CI/CD flow, identity, IPAM, deployment order) are in [`docs/architecture.md`](docs/architecture.md).
+High-level view. Full diagrams (account topology, CI/CD flow, identity, IPAM, deployment order) are in [`docs/architecture.md`](docs/architecture.md).
 
 ```mermaid
 flowchart TB
@@ -56,6 +67,22 @@ flowchart TB
 
 Regions: `eu-central-1` (primary) and `eu-west-1` (DR). Control Tower region-deny SCP blocks all others.
 
+## Design principles
+
+These are the load-bearing rules the project optimizes for. Every trade-off in the ADRs traces back to one of these.
+
+1. **Trade cost for reproducibility, not vice versa.** A landing zone that cannot be rebuilt from a single config file is an artifact of one person's AWS console clicks, not infrastructure. The [configuration contract (ADR-004)](docs/decisions/004-deployment-configuration-contract.md) and [`scripts/configure-backends.sh`](scripts/configure-backends.sh) exist precisely to make forking and re-deploying a one-file operation.
+
+2. **Document decisions, not just code.** 13 Architecture Decision Records capture *Context / Decision / Alternatives / Consequences* for every load-bearing choice. When the code and an ADR disagree, the ADR wins and the code gets fixed.
+
+3. **Cost-conscious by default.** Single NAT Gateway (not three) for the lab; ACM over cert-manager (free, fewer moving parts); EKS deferred until needed. Always-on baseline is ~$5/month; per-session ephemeral is ~$1–2. See [ADR-009](docs/decisions/009-lifecycle-and-teardown-strategy.md).
+
+4. **Zero static credentials. Anywhere.** IAM Identity Center for humans, OIDC federation for GitHub Actions, IRSA for workloads (planned). No IAM users, no access keys on disk. Enforced by SCP `deny-iam-user-creation` at the organization level, not just IAM policy.
+
+5. **Drift is a bug.** Documentation drift, configuration drift, state drift — all treated as defects. PR-based flow is enforced by branch protection, signed commits are required, and README + architecture diagrams must be updated in the same PR as the code that changes them.
+
+6. **Automate the steady state. Accept one manual break.** `aegis-shared` is created by hand to break the Terraform-state-bucket chicken-and-egg; every other account is either Account Factory console ([Path A](docs/decisions/011-account-provisioning-two-path-strategy.md), current) or AFT pipeline (Path B, tested but not deployed). One conscious manual step, explicitly documented.
+
 ## Configuration Contract
 
 All deployment-specific values (account IDs, emails, regions, CIDRs) live in `config/landing-zone.yaml` (gitignored). A committed template at [`config/landing-zone.example.yaml`](config/landing-zone.example.yaml) shows the expected structure. JSON Schema validation at [`config/schema.json`](config/schema.json) enforces the contract. See [ADR-004](docs/decisions/004-deployment-configuration-contract.md).
@@ -81,14 +108,14 @@ The `configure-backends.sh` script replaces hardcoded values in `backend.tf` fil
 
 ## Phases
 
-Status is tracked by what actually exists in the main branch, not what is aspirational. Each "Done" phase links to the PR(s) that delivered it.
+Status reflects what exists in `main`, not aspirations. Each "Done" row links to the PRs that shipped it.
 
 | Phase | Scope | Cost | Status |
 |-------|-------|------|--------|
 | 0. Bootstrap | AWS account, domain, Control Tower, Identity Center, budget alerts, KMS key | ~Free | **Done** (pre-PR, via [runbook](docs/runbooks/001-bootstrap-aws-account.md)) |
 | 1. Foundation | Config contract, state bucket, SCPs, OIDC, account provisioning | ~Free | **Done** ([#1](https://github.com/BinHsu/aegis-aws-landing-zone/pull/1)..[#7](https://github.com/BinHsu/aegis-aws-landing-zone/pull/7)) |
 | 2. GitOps Pipeline | plan/apply workflows, Checkov, pre-commit, signed commits | ~Free | **Done** ([#1](https://github.com/BinHsu/aegis-aws-landing-zone/pull/1), [#3](https://github.com/BinHsu/aegis-aws-landing-zone/pull/3), [#4](https://github.com/BinHsu/aegis-aws-landing-zone/pull/4), [#5](https://github.com/BinHsu/aegis-aws-landing-zone/pull/5)) |
-| 3a. Network Foundation | IPAM + RAM sharing, ADR-012 + ADR-013 | ~$0 idle / $0.003/IP/hr allocated | **Done** ([#6](https://github.com/BinHsu/aegis-aws-landing-zone/pull/6), [#7](https://github.com/BinHsu/aegis-aws-landing-zone/pull/7), [#8](https://github.com/BinHsu/aegis-aws-landing-zone/pull/8), [#9](https://github.com/BinHsu/aegis-aws-landing-zone/pull/9)) |
+| 3a. Network Foundation | IPAM + RAM sharing, ADR-012 + ADR-013 | ~$0 idle / $0.003/IP/hr allocated | **Done** ([#6](https://github.com/BinHsu/aegis-aws-landing-zone/pull/6)..[#9](https://github.com/BinHsu/aegis-aws-landing-zone/pull/9)) |
 | 3b. VPC | Staging VPC (3 AZ, 1 NAT, Gateway endpoints, Flow Logs) | ~$0.05/hr NAT | Not started |
 | 3c. EKS Platform | EKS 1.32 + Karpenter on Fargate + ArgoCD + ALB Controller + ACM | ~$0.15/hr | Not started |
 | 4. Observability + Security | Prometheus, Grafana, CloudTrail data events, GuardDuty, Security Hub | TBD | Not started |
@@ -116,30 +143,30 @@ Status is tracked by what actually exists in the main branch, not what is aspira
 
 - [001 — Bootstrap AWS Account](docs/runbooks/001-bootstrap-aws-account.md): Step-by-step from zero to SSO-authenticated CLI, including Control Tower setup, KMS key policy, Identity Center, Account Factory for staging/prod, GitHub repo configuration, signed commits, and all gotchas encountered.
 
-## Companion Application Repository
+## Companion application repository
 
-This infrastructure repo is the **Pointer** — it defines VPCs, EKS clusters, OIDC, and (Phase 3+) hoists ArgoCD. The application workload lives in **[aegis-core](https://github.com/BinHsu/aegis-core)** (the **Payload**, planned). ArgoCD watches `aegis-core` and deploys changes via pull-based GitOps. See [ADR-007](docs/decisions/007-infra-app-repository-split.md).
+This repository is the **Pointer** — it defines VPCs, EKS clusters, OIDC, and (Phase 3c+) hoists ArgoCD. The application workload is intended to live in [aegis-core](https://github.com/BinHsu/aegis-core) (the **Payload**, planned). ArgoCD will watch `aegis-core` and deploy changes via pull-based GitOps. See [ADR-007](docs/decisions/007-infra-app-repository-split.md).
 
-## Cost Management
+## Cost management
 
-- **Phases 0-2 are ~free** (Organizations, SSO, SCPs, S3, public-repo GitHub Actions)
-- **Phase 3a (IPAM)**: ~$0 idle, ~$0.003/IP/hr when VPCs allocate — rounds to pennies per session
-- **Phase 3b+ (VPC + EKS)**: ~$3-5 per 4-hour session with [teardown discipline](docs/decisions/009-lifecycle-and-teardown-strategy.md)
-- **Budget alerts**: daily $10, monthly $30 (enforced via AWS Budgets in management account)
-- **NAT Gateway is the hidden cost killer** ($0.045/hr = $32/month if left running)
-- **Persistent baseline**: ~$5/month (Control Tower + Config recorder + CloudTrail)
+- Phases 0–2 are ~free (Organizations, SSO, SCPs, S3, public-repo GitHub Actions)
+- Phase 3a (IPAM): ~$0 idle, ~$0.003/IP/hr when VPCs allocate — rounds to pennies per session
+- Phase 3b+ (VPC + EKS): ~$3–5 per 4-hour session with [teardown discipline](docs/decisions/009-lifecycle-and-teardown-strategy.md)
+- Budget alerts: daily $10, monthly $30 (enforced via AWS Budgets in the management account)
+- NAT Gateway is the hidden cost killer ($0.045/hr = $32/month if left running)
+- Persistent baseline: ~$5/month (Control Tower + Config recorder + CloudTrail)
 
 ## Prerequisites
 
 - AWS account (management account) with billing access
 - Domain registered with email routing
 - AWS CLI v2 (`brew install awscli`)
-- Terraform CLI >= 1.10 (`brew tap hashicorp/tap && brew install hashicorp/tap/terraform` — default Homebrew is stuck at 1.5.7)
+- Terraform CLI ≥ 1.10 (`brew tap hashicorp/tap && brew install hashicorp/tap/terraform` — the default Homebrew formula is stuck at 1.5.7)
 - `gh` CLI (`brew install gh`)
-- Python 3 with `pyyaml` and `jsonschema` (for pre-commit hook)
-- Signed-commits SSH key (see [Runbook Part 10.4](docs/runbooks/001-bootstrap-aws-account.md))
+- Python 3 with `pyyaml` and `jsonschema` (for the pre-commit hook)
+- SSH signing key configured for commit signing (see [Runbook Part 10.4](docs/runbooks/001-bootstrap-aws-account.md))
 
-## Directory Structure
+## Directory structure
 
 ```
 aegis-aws-landing-zone/
@@ -169,13 +196,18 @@ aegis-aws-landing-zone/
 ├── .github/workflows/             # plan + apply + checkov
 ├── .pre-commit-config.yaml        # Local quality gates
 ├── CLAUDE.md                      # AI operational rules
+├── LICENSE                        # MIT
 └── .terraform-version             # Pinned Terraform version
 ```
 
-## Author
+## License
 
-**Bin Hsu** — Senior Software Architect, 15 years experience (10 years C++ embedded systems at VIVOTEK, 5 years AWS platform engineering at E2 Nova). Building this to prove that system design + hands-on implementation = the same person.
+[MIT](LICENSE) — free to fork, modify, and deploy.
+
+## Attribution
+
+Built by [Bin Hsu](https://github.com/BinHsu).
 
 ---
 
-**Documentation drift policy**: This README reflects the state of `main` at the commit referenced in the Phase table above. If you find content that does not match reality (missing directories, features that do not work, stale PR links), open a PR titled `docs: fix README drift — <area>`. See the same policy in [`docs/architecture.md`](docs/architecture.md).
+**Documentation drift policy.** This README reflects the state of `main` at the commit linked in the Phase table above. If you find content that does not match reality (missing directories, features that do not work, stale PR links), open a PR titled `docs: fix README drift — <area>`. The same policy applies to [`docs/architecture.md`](docs/architecture.md).


### PR DESCRIPTION
## Summary
Shifts README narrative from portfolio-first to OSS-first. Adds LICENSE (MIT).

**Structural changes** (top to bottom):
- Badges: Terraform Apply status · Checkov status · Terraform version · License
- New tagline: product-positioned, not self-positioned
- New **Features at a glance** — scannable keyword-rich bullets
- New **Reading guide** — routes each audience (recruiter, tech manager, interviewer, fork user) to the right place
- New **Design principles** — 6 load-bearing rules every ADR traces back to
- Reduced Author to one-line attribution
- Added License section + LICENSE file (MIT)

**Audience flow**:
- Recruiter (5–30s): tagline + features + diagram → pattern-match to JD
- Tech manager (1–5min): reading guide → architecture.md → ADRs
- Interviewer (10–30min): specific ADRs + Terraform + runbook

## Test plan
- [ ] Badges render on GitHub main page
- [ ] Mermaid diagram renders
- [ ] All links in Reading guide + Phase table + ADR index resolve
- [ ] CI green