### PR TITLE
chore: repo hardening — codeowners, dependabot, security, contributing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Something in this repository does not work as described
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the problem.
+      placeholder: When I run `./scripts/configure-backends.sh`, it fails with...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimum steps that let someone else see the bug.
+      placeholder: |
+        1. Clone the repo
+        2. cp config/landing-zone.example.yaml config/landing-zone.yaml
+        3. Run ...
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Paste error messages, relevant log lines, or screenshots.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - OS: macOS 15.x / Ubuntu 22.04 / ...
+        - Terraform: 1.14.8
+        - AWS CLI: 2.x
+        - gh CLI: 2.x
+
+  - type: textarea
+    id: relates
+    attributes:
+      label: Related ADRs or docs
+      description: If this bug contradicts a documented behavior, link the ADR.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/BinHsu/aegis-aws-landing-zone/security/advisories/new
+    about: Please use Private Vulnerability Reporting for security issues. Do NOT open a public issue.
+  - name: Question or discussion
+    url: https://github.com/BinHsu/aegis-aws-landing-zone/discussions
+    about: For questions, design discussions, or usage help, please open a Discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Propose a new capability or an improvement aligned with project scope
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before opening:** this project targets single-operator and small-team deployments. Enterprise-scale features (e.g., multi-tenant SaaS controls, custom Config rules for GDPR-B2B audit) are intentionally out of scope — see [`CONTRIBUTING.md`](../CONTRIBUTING.md) for scope boundaries and [AWS Landing Zone Accelerator](https://github.com/awslabs/landing-zone-accelerator-on-aws) for the enterprise path.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What use case are you hitting that the current design does not serve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you add or change? Sketch the code shape if you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What did you try or think about before proposing this?
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope impact
+      description: Would this change the scope boundaries in ADR-001? Require a new ADR? Break any design principle in the README?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,91 @@
+# =============================================================================
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+# =============================================================================
+# Why this file exists:
+#   - GitHub Actions versions age quickly (Node.js 20 deprecation warnings
+#     are already visible in CI). Weekly updates keep the runtime current.
+#   - Terraform providers release security fixes between major versions.
+#     Dependabot opens PRs; CI validates them; reviewer decides.
+#
+# Update cadence: weekly. Aggressive enough to catch security fixes,
+# conservative enough to batch cosmetic changes.
+# =============================================================================
+
+version: 2
+updates:
+  # GitHub Actions used in .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+
+  # Terraform providers and modules per environment (each has its own lock file)
+  - package-ecosystem: "terraform"
+    directory: "/terraform/environments/management/bootstrap"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "terraform"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/environments/management/scps"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "terraform"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/environments/shared/bootstrap"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "terraform"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/environments/shared/ipam"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "terraform"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/environments/shared/aft"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "aft"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/environments/staging/bootstrap"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "terraform"
+
+  - package-ecosystem: "terraform"
+    directory: "/terraform/environments/prod/bootstrap"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "terraform"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- One paragraph: what does this PR do, and why? -->
+
+## Changes
+
+<!-- Bullet list of concrete changes. Keep PRs focused. -->
+
+## Related
+
+<!-- Link to ADR, Issue, or prior PR if applicable. -->
+- ADR:
+- Issue:
+- Prior PR:
+
+## Test plan
+
+- [ ] Required status checks pass (5× Terraform Plan + Checkov)
+- [ ] Relevant ADR updated (if decision changed)
+- [ ] README / `docs/architecture.md` updated (if structure changed)
+- [ ] Runbook updated (if operational steps changed)
+- [ ] Commits are signed
+
+## Breaking changes
+
+<!-- List anything that requires manual operator action after merge. -->
+
+None / <describe>

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,14 @@
+# CODEOWNERS
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Currently a single-operator repository. The `*` pattern assigns every file
+# to @BinHsu. When the project grows to multiple maintainers, split by path:
+#
+#   /terraform/environments/management/  @platform-admins
+#   /terraform/environments/shared/      @platform-admins
+#   /docs/decisions/                     @architects
+#   /.github/workflows/                  @ci-maintainers
+#
+# ADR-001 (scope boundary) informs who should own what at scale.
+
+* @BinHsu

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing
+
+Thanks for taking the time to look at this repository. Before opening an issue or a PR, please read this whole file.
+
+## Project scope
+
+This project targets **single-operator labs and small-team deployments**. It is an opinionated reference implementation, not a general-purpose framework. If you need enterprise-scale features — multi-tenant SaaS controls, custom Config rules for complex audit frameworks, complex team-level OU splits — please use:
+
+- [AWS Landing Zone Accelerator](https://github.com/awslabs/landing-zone-accelerator-on-aws) for AWS-native enterprise coverage
+- [Gruntwork Reference Architecture](https://gruntwork.io/reference-architecture) for a commercially supported option
+
+Scope boundaries are documented in [ADR-001](docs/decisions/001-landing-zone-scope-boundary.md). Changes that require expanding scope need an accompanying ADR that supersedes or extends ADR-001.
+
+## What contributions are welcome
+
+- **Bug reports** — something does not work as documented
+- **Documentation fixes** — diagram or runbook drifted from reality, typos, unclear prose
+- **Scope-aligned enhancements** — small features that serve the single-operator use case better
+- **Security findings** — use Private Vulnerability Reporting, not a public issue (see [SECURITY.md](SECURITY.md))
+
+## What contributions will likely be declined
+
+- Enterprise features outside the scope boundary (listed above)
+- Feature flags / configuration toggles that make a design principle opt-out
+- Changes that violate a design principle (see README) without a new ADR justifying the shift
+
+## Development workflow
+
+1. **Open an issue first** if the change is non-trivial. Describe the use case. This saves everyone time.
+2. **Fork and branch** — create a branch from `main` with a descriptive prefix (`feat/`, `fix/`, `docs/`).
+3. **Read the relevant ADRs** before making decisions that touch their territory.
+4. **Follow the design principles** listed in the [README](README.md#design-principles).
+5. **Add or update an ADR** if you are making a load-bearing decision (something a future reader would need to understand).
+6. **Update affected documentation** in the same PR — README, `docs/architecture.md`, runbooks. Drift is a bug per the project's stated policy.
+7. **Open a PR** against `main`. The PR template ([`.github/pull_request_template.md`](.github/pull_request_template.md)) guides what is expected.
+8. **CI must pass** — 5× Terraform Plan + Checkov. Required by branch protection, not waivable.
+9. **Commits must be signed** — SSH or GPG, verified by GitHub. Required by branch protection.
+
+## ADR process
+
+Architecture Decision Records live in `docs/decisions/NNN-title.md`. The required sections are:
+
+- **Status** — `Accepted`, `Superseded by NNN`, or `Deprecated`
+- **Context** — what problem are you solving, what constraints exist
+- **Decision** — what you chose, specifically
+- **Alternatives Considered** — what you rejected and why
+- **Consequences** — trade-offs accepted, what becomes easier, what becomes harder
+
+If your change conflicts with an existing ADR, **supersede it**: update the old ADR's Status to `Superseded by NNN` and write the new ADR explaining the shift. Do not silently override.
+
+Numbering is sequential, zero-padded (001, 002, ...). The next available number can be found by sorting `docs/decisions/`.
+
+## Code style
+
+- **Terraform**: `terraform fmt` is enforced by the pre-commit hook. Resource names use `snake_case`. Prefer descriptive over abbreviated names (`deny_non_eu_regions`, not `dne`).
+- **Shell scripts**: `set -euo pipefail` at the top. Validate inputs. Keep scripts self-contained — no sourcing shared libraries.
+- **Markdown**: match the existing tone. Prefer full sentences over bullet lists when explaining reasoning. Bullets are for lists of equivalent items.
+- **Mermaid diagrams**: keep nodes minimal, annotations sparse. If a diagram needs more than ~10 nodes, split it.
+
+## Commit messages
+
+Follow Conventional Commits loosely:
+
+- `feat: ...` — new capability or resource
+- `fix: ...` — correction to something that was wrong
+- `docs: ...` — documentation-only change
+- `refactor: ...` — code reorganization without behavior change
+- `test: ...` — test-only change (limited use in this project)
+- `chore: ...` — dependency updates, tooling tweaks
+
+Keep the first line under 72 characters. Body explains *why*, not *what* — the diff shows what changed.
+
+## Reviewing PRs (for maintainers)
+
+- Does CI pass? If not, fix CI before reviewing code.
+- Does the PR touch a documented decision? Is the ADR updated?
+- Does the change introduce drift between code and documentation? Call it out.
+- Does the PR respect the design principles?
+- If the PR is security-sensitive (SCPs, IAM, OIDC, state bucket), explicitly note that a second pair of eyes would be ideal even if not strictly required by branch protection.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+This project is a reference implementation, not a released product. Only the `main` branch is supported.
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in this repository, please **do not open a public issue**.
+
+Use GitHub's [Private Vulnerability Reporting](https://github.com/BinHsu/aegis-aws-landing-zone/security/advisories/new) to submit the report. The maintainer will acknowledge within 48 hours. Fixes are prepared in a private branch and disclosed publicly only after the fix is deployed.
+
+## Security controls in this repository
+
+This project enforces defense-in-depth controls at multiple layers. A security finding here means one of these controls failed:
+
+- **Zero static credentials** — IAM Identity Center for humans, OIDC federation for CI, IRSA for workloads (planned). No IAM users, no access keys. Enforced by SCP `deny-iam-user-creation`, not just IAM policy.
+- **Signed commits required on `main`** — every commit is cryptographically signed with a key the author controls. Required by branch protection.
+- **Branch protection** with 5 required status checks (Terraform plan × 4 environments + Checkov). No direct pushes to `main`.
+- **Admin bypass allowed but logged** — single-operator workflow; every bypass appears in GitHub's branch protection events.
+- **IaC security scanning** — Checkov runs on every PR with a triaged skip list. New findings fail the build; documented skips require inline justification. See [`.github/workflows/checkov.yml`](.github/workflows/checkov.yml).
+- **Schema validation on the configuration contract** — JSON Schema enforced by pre-commit hook. Blocks invalid config before commit.
+- **State encryption at rest** — S3 state bucket with SSE-KMS (AWS-managed key), versioning, 30-day noncurrent version retention. Cross-account access restricted to the AWS Organization via `aws:PrincipalOrgID` condition. See [ADR-003](docs/decisions/003-terraform-backend-bootstrap.md).
+- **ISO 27001:2022 Annex A alignment** — controls mapped in [ADR-005](docs/decisions/005-compliance-framework-iso-27001.md) and cited in SCP Terraform comments.
+
+## Responsible disclosure
+
+If you are a security researcher testing AWS resources described in this repository, note that the live deployment is a personal lab environment belonging to the author. Active testing (scanning, credential stuffing, privilege escalation attempts) against the AWS accounts referenced in ADRs is **not authorized**. Please report findings through Private Vulnerability Reporting instead of attempting live exploitation.
+
+## Secrets handling
+
+- No real secrets are committed to this repository. Account IDs, Organization IDs, ARNs, and SSO URLs are metadata, not secrets (see [CLAUDE.md — Security](CLAUDE.md) for the full classification).
+- The only secret that exists is `LANDING_ZONE_CONFIG` — an encrypted GitHub secret containing the contents of `config/landing-zone.yaml` so CI workflows can write it to the runner. See [`scripts/configure-github.sh`](scripts/configure-github.sh).
+- If you discover a real secret (access key, private key, password) committed to this repository, report it immediately via Private Vulnerability Reporting and assume it is compromised.


### PR DESCRIPTION
## Summary

Standard OSS hygiene files added in one batch:
- CODEOWNERS
- .github/dependabot.yml (github-actions + 7 terraform envs, weekly)
- .github/pull_request_template.md
- .github/ISSUE_TEMPLATE/{config,bug_report,feature_request}
- SECURITY.md (Private Vulnerability Reporting + 8 defense-in-depth controls enumerated)
- CONTRIBUTING.md (scope policy, ADR process, dev workflow)

## Related

- ADR-001 scope boundary (referenced in CONTRIBUTING)
- ADR-005 ISO 27001 (referenced in SECURITY)
- All existing SCP and OIDC ADRs (referenced in SECURITY controls section)

## Test plan
- [ ] CI passes (5× Plan + Checkov)
- [ ] Dependabot picks up and opens its first PRs within a week
- [ ] GitHub repo sidebar shows Security Policy, Contributing
- [ ] Private Vulnerability Reporting enabled (done separately via \`gh api\`)
- [ ] Discussions enabled (done separately via \`gh repo edit\`)

## Breaking changes

None. All net-new files.