### PR TITLE
feat: teardown scripts per ADR-009 (soft, hard, nuke)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This repository is the **Pointer** — it defines VPCs, EKS clusters, OIDC, and 
 
 - Phases 0–2 are ~free (Organizations, SSO, SCPs, S3, public-repo GitHub Actions)
 - Phase 3a (IPAM): ~$0 idle, ~$0.003/IP/hr when VPCs allocate — rounds to pennies per session
-- Phase 3b+ (VPC + EKS): ~$3–5 per 4-hour session with [teardown discipline](docs/decisions/009-lifecycle-and-teardown-strategy.md)
+- Phase 3b+ (VPC + EKS): ~$3–5 per 4-hour session with [teardown discipline](docs/decisions/009-lifecycle-and-teardown-strategy.md) — end each session with [`./scripts/teardown/soft-teardown-workload.sh <env>`](scripts/teardown/README.md)
 - Budget alerts: daily $10, monthly $30 (enforced via AWS Budgets in the management account)
 - NAT Gateway is the hidden cost killer ($0.045/hr = $32/month if left running)
 - Persistent baseline: ~$5/month (Control Tower + Config recorder + CloudTrail)

--- a/scripts/emergency/nuke-workload-account.sh
+++ b/scripts/emergency/nuke-workload-account.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nuke-workload-account.sh — emergency cleanup for drifted workload account
+# =============================================================================
+# Wraps Gruntwork's cloud-nuke tool to destroy all resources in a workload
+# account when Terraform state has drifted from reality (e.g., after a manual
+# console change created resources Terraform does not know about).
+#
+# Can ONLY target workload accounts (staging, prod, sandbox). Explicitly
+# refuses to target management, security, logarchive, or shared accounts —
+# the damage there would be unrecoverable.
+#
+# Dry-run by default. Use --destroy to actually delete.
+#
+# Prerequisites:
+#   - cloud-nuke installed (brew install cloud-nuke)
+#   - AWS_PROFILE set and SSO session valid
+#
+# Usage:
+#   ./scripts/emergency/nuke-workload-account.sh staging              # dry-run
+#   ./scripts/emergency/nuke-workload-account.sh staging --destroy    # real
+#
+# See ADR-009.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV="${1:-}"
+MODE="${2:---dry-run}"
+
+# --- Validation ---
+
+if [[ ! -t 0 ]]; then
+  echo "ERROR: This script requires an interactive TTY." >&2
+  exit 1
+fi
+
+if [[ -z "${ENV}" ]]; then
+  echo "Usage: $0 <environment> [--dry-run|--destroy]" >&2
+  echo "Default mode is --dry-run." >&2
+  exit 1
+fi
+
+# Strict allowlist — workload environments only
+case "${ENV}" in
+  staging|prod|sandbox|sandbox-*)
+    ;;
+  management|security|logarchive|shared)
+    echo "ERROR: '${ENV}' is a protected foundation account and cannot be nuked." >&2
+    echo "This script intentionally refuses to damage foundation accounts." >&2
+    exit 1
+    ;;
+  *)
+    echo "ERROR: '${ENV}' is not a recognized workload environment." >&2
+    echo "Allowed: staging, prod, sandbox, sandbox-*" >&2
+    exit 1
+    ;;
+esac
+
+case "${MODE}" in
+  --dry-run|--destroy)
+    ;;
+  *)
+    echo "ERROR: Unknown mode '${MODE}'. Use --dry-run or --destroy." >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v cloud-nuke >/dev/null 2>&1; then
+  echo "ERROR: cloud-nuke binary not found on PATH." >&2
+  echo "Install with: brew install cloud-nuke" >&2
+  exit 1
+fi
+
+# AWS_PROFILE must match target env
+EXPECTED_PROFILE="aegis-${ENV}-admin"
+if [[ "${AWS_PROFILE:-}" != "${EXPECTED_PROFILE}" ]]; then
+  echo "ERROR: AWS_PROFILE is '${AWS_PROFILE:-unset}', expected '${EXPECTED_PROFILE}'." >&2
+  exit 1
+fi
+
+# Verify caller identity
+CONFIG_ACCT=$(python3 -c "
+import yaml
+c = yaml.safe_load(open('${REPO_ROOT}/config/landing-zone.yaml'))
+print(c['accounts']['${ENV}']['id'])
+")
+
+ACTUAL_ACCT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null) || {
+  echo "ERROR: 'aws sts get-caller-identity' failed. Run 'aws sso login --sso-session aegis'." >&2
+  exit 1
+}
+
+if [[ "${ACTUAL_ACCT}" != "${CONFIG_ACCT}" ]]; then
+  echo "ERROR: Current AWS session is account ${ACTUAL_ACCT}, expected ${CONFIG_ACCT}." >&2
+  exit 1
+fi
+
+# --- Confirmation ---
+
+if [[ "${MODE}" == "--destroy" ]]; then
+  echo ""
+  echo "=============================================================================="
+  echo "CLOUD-NUKE — ${ENV} (${CONFIG_ACCT})"
+  echo "=============================================================================="
+  echo ""
+  echo "DESTRUCTIVE MODE: cloud-nuke will attempt to delete ALL resources"
+  echo "in account ${CONFIG_ACCT} across the governed regions."
+  echo ""
+  echo "This bypasses Terraform state entirely. Any resources Terraform knows"
+  echo "about will also be destroyed, and Terraform state will become invalid."
+  echo ""
+  echo "Type the account name '${ENV}' to confirm, anything else to abort:"
+  read -r CONFIRM
+  if [[ "${CONFIRM}" != "${ENV}" ]]; then
+    echo "Aborted."
+    exit 1
+  fi
+fi
+
+# --- Execute cloud-nuke ---
+
+REGIONS="eu-central-1,eu-west-1"
+
+if [[ "${MODE}" == "--dry-run" ]]; then
+  echo ""
+  echo "Running cloud-nuke in DRY-RUN mode (no resources will be deleted)."
+  echo "Regions: ${REGIONS}"
+  echo ""
+  cloud-nuke aws \
+    --region "${REGIONS//,/ --region }" \
+    --dry-run \
+    --log-level info
+else
+  echo ""
+  echo "Running cloud-nuke in DESTROY mode."
+  echo "Regions: ${REGIONS}"
+  echo ""
+  cloud-nuke aws \
+    --region "${REGIONS//,/ --region }" \
+    --log-level info \
+    --force
+fi
+
+echo ""
+echo "=============================================================================="
+echo "Done. Remember to:"
+echo "  1. Re-run terraform init in each affected layer"
+echo "  2. Inspect state drift with 'terraform plan'"
+echo "  3. Either re-apply or remove resources from state with 'terraform state rm'"
+echo "=============================================================================="

--- a/scripts/teardown/README.md
+++ b/scripts/teardown/README.md
@@ -1,0 +1,89 @@
+# Teardown scripts
+
+Three scripts, three different risk profiles. Pick based on what you actually want to destroy. See [ADR-009](../../docs/decisions/009-lifecycle-and-teardown-strategy.md) for the full strategy and rationale.
+
+## Decision tree
+
+```
+Did you create something you want to tear down?
+├── Yes, workload layers in one environment (end-of-session)     → soft-teardown-workload.sh
+├── Yes, the entire project (project-end)                        → hard-teardown-landing-zone.sh
+└── Terraform state drifted from reality, need to reset account  → ../emergency/nuke-workload-account.sh
+```
+
+## `soft-teardown-workload.sh` — common case
+
+**Destroys:** `workloads`, `platform`, `network` layers in one environment.
+**Preserves:** `bootstrap` layer, shared services, all other accounts, Control Tower.
+
+**Safety features:**
+- Requires interactive TTY (no pipe, no CI)
+- Requires clean git working tree
+- Validates `AWS_PROFILE` matches target environment
+- Verifies live AWS session matches `config/landing-zone.yaml` account ID
+- Requires typed confirmation of the environment name
+
+**Usage:**
+
+```bash
+export AWS_PROFILE=aegis-staging-admin
+aws sso login --sso-session aegis
+./scripts/teardown/soft-teardown-workload.sh staging
+```
+
+**When to use:** At the end of every session where you stood up EKS / NAT / workloads. Returns monthly cost from session-spike levels back to the ~$5 baseline.
+
+## `hard-teardown-landing-zone.sh` — project end
+
+**Destroys:** All workload layers in all environments, management SCPs, shared IPAM, all bootstrap layers, Control Tower landing zone. **Calls CloseAccount on all member accounts** — they enter AWS's 90-day suspension period.
+
+**Safety features (triple-confirmed):**
+1. Full-sentence acknowledgement of the 90-day rule
+2. Type the management account ID (forces operator to switch windows and look it up)
+3. Type a specific destruction phrase
+4. 10-second final countdown with `Ctrl-C` cancel
+
+**Additional restrictions:**
+- Refuses to run if any CI environment variable is set (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, `BUILDKITE`, `CIRCLECI`)
+- Refuses to run without a real TTY on both stdin and stdout
+- Requires running locally from the developer's terminal
+
+**When to use:** Exactly once, when the project is genuinely over. This is not a session-level teardown — it permanently suspends AWS accounts for 90 days.
+
+**After running:** The management account itself cannot be closed via CLI. Sign in as the root user via the AWS Console to close it manually.
+
+## `../emergency/nuke-workload-account.sh` — drift recovery
+
+**Destroys:** All AWS resources in a single workload account (staging, prod, or future sandbox), bypassing Terraform state entirely. Wraps [Gruntwork's cloud-nuke](https://github.com/gruntwork-io/cloud-nuke).
+
+**Safety features:**
+- Strict allowlist: **only** staging / prod / sandbox accounts. Refuses management / security / logarchive / shared.
+- Dry-run by default (`--dry-run`); `--destroy` required for actual deletion
+- Requires cloud-nuke binary installed locally (`brew install cloud-nuke`)
+- Validates `AWS_PROFILE` matches target
+- Requires typed confirmation of account name (destroy mode only)
+
+**Usage:**
+
+```bash
+export AWS_PROFILE=aegis-staging-admin
+aws sso login --sso-session aegis
+
+# Always dry-run first:
+./scripts/emergency/nuke-workload-account.sh staging
+
+# After reviewing the dry-run output, actually destroy:
+./scripts/emergency/nuke-workload-account.sh staging --destroy
+```
+
+**When to use:** When Terraform state has desynchronized from reality (e.g., someone made changes via the AWS Console) and you need to reset the target account before re-applying Terraform from scratch. Terraform state will be invalid afterward — re-run `terraform init` and re-apply in each layer.
+
+## Cost model
+
+| Action | Cost impact |
+|--------|-------------|
+| Never run teardown | NAT ($32/month) + EKS ($73/month) accumulate indefinitely |
+| `soft-teardown-workload.sh` at session end | Session cost ~$1-2 one-time; baseline ~$5/month retained |
+| `hard-teardown-landing-zone.sh` | One-time; after completion, monthly cost drops to $0 |
+
+Per ADR-009: teardown discipline is the difference between a $10/month lab and a $150/month forgotten-infrastructure bill.

--- a/scripts/teardown/hard-teardown-landing-zone.sh
+++ b/scripts/teardown/hard-teardown-landing-zone.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# =============================================================================
+# hard-teardown-landing-zone.sh — one-time project decommission
+# =============================================================================
+# Destroys EVERYTHING:
+#   - All workload layers in staging and prod
+#   - Management SCPs, shared IPAM, all bootstrap layers
+#   - Control Tower landing zone
+#   - All member accounts via CloseAccount API
+#
+# After this runs, member accounts enter AWS's 90-day suspension period and
+# cannot be reopened or reused. This is project-end, not session-end.
+#
+# Safeguards (triple-confirmed):
+#   1. Full-sentence acknowledgement of the 90-day rule
+#   2. Type the management account ID (forces operator to switch windows)
+#   3. Type a specific destruction phrase
+#   4. Ten-second final countdown with cancel option
+#
+# Refuses to run in CI. Refuses to run via pipe. Requires local TTY.
+#
+# The management account itself cannot be closed via CLI — the script prints
+# instructions for manual closure via root login as the last step.
+#
+# See ADR-009 for the full rationale.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# --- Anti-CI + anti-pipe ---
+
+if [[ -n "${CI:-}" ]] || [[ -n "${GITHUB_ACTIONS:-}" ]] || [[ -n "${GITLAB_CI:-}" ]] || \
+   [[ -n "${JENKINS_URL:-}" ]] || [[ -n "${BUILDKITE:-}" ]] || [[ -n "${CIRCLECI:-}" ]]; then
+  echo "ERROR: CI environment detected. This script is local-terminal-only by design." >&2
+  exit 1
+fi
+
+if [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
+  echo "ERROR: Requires a real interactive TTY on both stdin and stdout." >&2
+  exit 1
+fi
+
+# --- Read config ---
+
+if [[ ! -f "${REPO_ROOT}/config/landing-zone.yaml" ]]; then
+  echo "ERROR: config/landing-zone.yaml not found." >&2
+  exit 1
+fi
+
+MGMT_ID=$(python3 -c "
+import yaml
+c = yaml.safe_load(open('${REPO_ROOT}/config/landing-zone.yaml'))
+print(c['accounts']['management']['id'])
+")
+
+ALL_MEMBER_IDS=$(python3 -c "
+import yaml
+c = yaml.safe_load(open('${REPO_ROOT}/config/landing-zone.yaml'))
+for name, acct in c['accounts'].items():
+    if name != 'management' and acct['id']:
+        print(acct['id'])
+")
+
+# --- Confirmation 1: full-sentence acknowledgement ---
+
+REQUIRED_SENTENCE="I understand closed accounts are locked for 90 days and the emails cannot be reused"
+
+echo ""
+echo "=============================================================================="
+echo "HARD TEARDOWN — PROJECT DECOMMISSION"
+echo "=============================================================================="
+echo ""
+echo "This destroys the ENTIRE landing zone and closes all member accounts."
+echo "Closed accounts enter AWS's 90-day suspension period."
+echo ""
+echo "Type the following sentence EXACTLY to proceed:"
+echo ""
+echo "  ${REQUIRED_SENTENCE}"
+echo ""
+read -r INPUT_SENTENCE
+if [[ "${INPUT_SENTENCE}" != "${REQUIRED_SENTENCE}" ]]; then
+  echo "Aborted (sentence did not match)."
+  exit 1
+fi
+
+# --- Confirmation 2: management account ID ---
+
+echo ""
+echo "Type the management account ID (12 digits):"
+read -r INPUT_ACCT
+if [[ "${INPUT_ACCT}" != "${MGMT_ID}" ]]; then
+  echo "Aborted (account ID did not match)."
+  exit 1
+fi
+
+# --- Confirmation 3: destruction phrase ---
+
+REQUIRED_PHRASE="permanently destroy aegis landing zone"
+
+echo ""
+echo "Type the destruction phrase EXACTLY:"
+echo ""
+echo "  ${REQUIRED_PHRASE}"
+echo ""
+read -r INPUT_PHRASE
+if [[ "${INPUT_PHRASE}" != "${REQUIRED_PHRASE}" ]]; then
+  echo "Aborted (phrase did not match)."
+  exit 1
+fi
+
+# --- 10-second countdown with cancel ---
+
+echo ""
+echo "Last chance to cancel. Starting destruction in 10 seconds."
+echo "Press Ctrl-C to abort."
+for i in 10 9 8 7 6 5 4 3 2 1; do
+  echo -n "${i}... "
+  sleep 1
+done
+echo ""
+echo ""
+echo "Proceeding with destruction."
+echo ""
+
+# --- Destruction ---
+
+# Helper: destroy a layer if the directory exists
+destroy_layer() {
+  local ACCT="$1"
+  local ENV="$2"
+  local LAYER="$3"
+  local LAYER_DIR="${REPO_ROOT}/terraform/environments/${ENV}/${LAYER}"
+
+  if [[ ! -d "${LAYER_DIR}" ]]; then
+    return
+  fi
+
+  echo "Destroying ${ENV}/${LAYER} (account ${ACCT})..."
+  (
+    cd "${LAYER_DIR}"
+    AWS_PROFILE="aegis-${ENV}-admin" terraform init -input=false -upgrade
+    AWS_PROFILE="aegis-${ENV}-admin" terraform destroy -auto-approve -input=false
+  )
+}
+
+# Workload environments: all layers top-down
+for ENV in staging prod; do
+  ACCT=$(python3 -c "
+import yaml
+c = yaml.safe_load(open('${REPO_ROOT}/config/landing-zone.yaml'))
+print(c['accounts']['${ENV}']['id'])
+")
+  [[ -z "${ACCT}" ]] && continue
+
+  for LAYER in workloads platform network bootstrap; do
+    destroy_layer "${ACCT}" "${ENV}" "${LAYER}"
+  done
+done
+
+# Shared services
+destroy_layer "shared" "shared" "aft"
+destroy_layer "shared" "shared" "ipam"
+destroy_layer "shared" "shared" "bootstrap"
+
+# Management (SCPs before bootstrap so SCPs don't interfere with closure)
+destroy_layer "management" "management" "scps"
+destroy_layer "management" "management" "bootstrap"
+
+# --- Control Tower decommission ---
+
+echo ""
+echo "Decommissioning Control Tower landing zone..."
+LZ_ARN=$(AWS_PROFILE="aegis-management-admin" \
+  aws controltower list-landing-zones --region eu-central-1 \
+  --query 'landingZones[0].arn' --output text)
+
+if [[ -n "${LZ_ARN}" ]] && [[ "${LZ_ARN}" != "None" ]]; then
+  AWS_PROFILE="aegis-management-admin" \
+    aws controltower delete-landing-zone \
+    --landing-zone-identifier "${LZ_ARN}" \
+    --region eu-central-1
+  echo "Control Tower deletion initiated. This takes approximately 30 minutes."
+else
+  echo "No Control Tower landing zone found. Skipping decommission."
+fi
+
+# --- Close member accounts ---
+
+echo ""
+echo "Closing member accounts via CloseAccount API..."
+while IFS= read -r ACCT; do
+  [[ -z "${ACCT}" ]] && continue
+  echo "  Closing ${ACCT}..."
+  AWS_PROFILE="aegis-management-admin" \
+    aws organizations close-account --account-id "${ACCT}" || \
+    echo "  WARNING: CloseAccount failed for ${ACCT}. Continue manually."
+done <<< "${ALL_MEMBER_IDS}"
+
+# --- Management account: manual step ---
+
+echo ""
+echo "=============================================================================="
+echo "Automated destruction complete."
+echo "=============================================================================="
+echo ""
+echo "REMAINING MANUAL STEP:"
+echo ""
+echo "The management account (${MGMT_ID}) cannot be closed via CLI. To close it:"
+echo ""
+echo "  1. Sign in to the management account via root user (not SSO)."
+echo "  2. Navigate to Account Settings → Close Account."
+echo "  3. Follow the prompts."
+echo ""
+echo "All member accounts are now suspended. They will be permanently deleted"
+echo "in 90 days. Their email addresses cannot be reused until then."
+echo ""
+echo "Project end. Goodbye."

--- a/scripts/teardown/soft-teardown-workload.sh
+++ b/scripts/teardown/soft-teardown-workload.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# =============================================================================
+# soft-teardown-workload.sh — destroy workload layers only
+# =============================================================================
+# Destroys workload Terraservices layers (workloads, platform, network) in a
+# specified environment. Preserves the bootstrap layer, shared-services
+# account, security/logarchive accounts, and the Control Tower landing zone.
+#
+# Use this at the end of a session to return cost to baseline:
+#   - Before:  NAT Gateway + EKS control plane + EC2 nodes running = ~$5/day
+#   - After:   ~$5/month (CT + Config + CloudTrail baseline)
+#
+# Safe to run multiple times. Layers that don't exist are skipped gracefully.
+#
+# Usage:
+#   export AWS_PROFILE=aegis-staging-admin
+#   aws sso login --sso-session aegis
+#   ./scripts/teardown/soft-teardown-workload.sh staging
+#
+# See ADR-009 for the full teardown strategy.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV="${1:-}"
+
+# Workload layers in destruction order (reverse of apply order).
+# Bootstrap is intentionally NOT in this list.
+LAYERS=(workloads platform network)
+
+# --- Validation ---
+
+if [[ ! -t 0 ]]; then
+  echo "ERROR: This script requires an interactive TTY. Cannot run via pipe or CI." >&2
+  exit 1
+fi
+
+if [[ -z "${ENV}" ]]; then
+  echo "Usage: $0 <environment>" >&2
+  echo "Example: $0 staging" >&2
+  exit 1
+fi
+
+# Allowlist — only workload environments can be soft-torn-down
+case "${ENV}" in
+  staging|prod|sandbox|sandbox-*)
+    ;;
+  *)
+    echo "ERROR: '${ENV}' is not an allowed workload environment." >&2
+    echo "Allowed: staging, prod, sandbox, sandbox-*" >&2
+    echo "For foundation accounts (management/shared/security/logarchive)," >&2
+    echo "use hard-teardown-landing-zone.sh (rare, triple-confirmed)." >&2
+    exit 1
+    ;;
+esac
+
+# Git clean check — refuse if uncommitted changes exist
+cd "${REPO_ROOT}"
+if ! git diff-index --quiet HEAD --; then
+  echo "ERROR: Git working tree has uncommitted changes. Commit or stash first." >&2
+  git status --short >&2
+  exit 1
+fi
+
+# AWS_PROFILE check
+if [[ -z "${AWS_PROFILE:-}" ]]; then
+  echo "ERROR: AWS_PROFILE not set. Export: AWS_PROFILE=aegis-${ENV}-admin" >&2
+  exit 1
+fi
+
+EXPECTED_PROFILE="aegis-${ENV}-admin"
+if [[ "${AWS_PROFILE}" != "${EXPECTED_PROFILE}" ]]; then
+  echo "ERROR: AWS_PROFILE is '${AWS_PROFILE}', expected '${EXPECTED_PROFILE}'." >&2
+  exit 1
+fi
+
+# Verify caller identity matches the expected account
+CONFIG_ACCT=$(python3 -c "
+import yaml
+c = yaml.safe_load(open('${REPO_ROOT}/config/landing-zone.yaml'))
+print(c['accounts']['${ENV}']['id'])
+" 2>/dev/null) || {
+  echo "ERROR: Could not read accounts.${ENV}.id from config/landing-zone.yaml" >&2
+  exit 1
+}
+
+if [[ -z "${CONFIG_ACCT}" ]]; then
+  echo "ERROR: accounts.${ENV}.id is empty in config/landing-zone.yaml" >&2
+  exit 1
+fi
+
+ACTUAL_ACCT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null) || {
+  echo "ERROR: 'aws sts get-caller-identity' failed. Run 'aws sso login --sso-session aegis'." >&2
+  exit 1
+}
+
+if [[ "${ACTUAL_ACCT}" != "${CONFIG_ACCT}" ]]; then
+  echo "ERROR: Current AWS session is account ${ACTUAL_ACCT}, expected ${CONFIG_ACCT}." >&2
+  exit 1
+fi
+
+# --- Confirmation ---
+
+echo ""
+echo "=============================================================================="
+echo "SOFT TEARDOWN — ${ENV} (${CONFIG_ACCT})"
+echo "=============================================================================="
+echo ""
+echo "Will destroy workload layers (in order):"
+for LAYER in "${LAYERS[@]}"; do
+  LAYER_DIR="${REPO_ROOT}/terraform/environments/${ENV}/${LAYER}"
+  if [[ -d "${LAYER_DIR}" ]]; then
+    echo "  - ${ENV}/${LAYER}  (will be destroyed)"
+  else
+    echo "  - ${ENV}/${LAYER}  (does not exist, will skip)"
+  fi
+done
+echo ""
+echo "Preserved:"
+echo "  - ${ENV}/bootstrap (account alias, OIDC provider, CI role)"
+echo "  - Other accounts (management, shared, security, logarchive, prod/staging)"
+echo "  - Shared services (Terraform state bucket, IPAM)"
+echo "  - Control Tower landing zone"
+echo ""
+echo "Type the environment name '${ENV}' to confirm, anything else to abort:"
+read -r CONFIRM
+if [[ "${CONFIRM}" != "${ENV}" ]]; then
+  echo "Aborted."
+  exit 1
+fi
+
+# --- Destruction ---
+
+echo ""
+for LAYER in "${LAYERS[@]}"; do
+  LAYER_DIR="${REPO_ROOT}/terraform/environments/${ENV}/${LAYER}"
+  if [[ ! -d "${LAYER_DIR}" ]]; then
+    echo "Skipping ${ENV}/${LAYER}: directory does not exist."
+    continue
+  fi
+
+  echo "------------------------------------------------------------------------"
+  echo "Destroying ${ENV}/${LAYER}..."
+  echo "------------------------------------------------------------------------"
+
+  cd "${LAYER_DIR}"
+  terraform init -input=false -upgrade
+  terraform destroy -auto-approve -input=false
+  echo ""
+done
+
+echo "=============================================================================="
+echo "Soft teardown complete for ${ENV}."
+echo "Bootstrap layer preserved. Run this script again at the next session end."
+echo "=============================================================================="


### PR DESCRIPTION
## Summary

Three teardown scripts with differentiated safety UX, delivering ADR-009's teardown strategy. Lands **before** PR #25 (staging VPC + NAT) so the safety net exists before the first NAT cost is incurred.

## Scripts

| Script | Purpose | Safety |
|--------|---------|--------|
| \`scripts/teardown/soft-teardown-workload.sh\` | End-of-session cleanup | TTY, clean git, profile match, typed env name |
| \`scripts/teardown/hard-teardown-landing-zone.sh\` | Project end | Anti-CI, triple confirmation, 10s countdown |
| \`scripts/emergency/nuke-workload-account.sh\` | Drift recovery via cloud-nuke | Allowlist, dry-run default |

## Related
- ADR-009 (Lifecycle and Teardown Strategy) — full rationale

## Test plan
- [x] \`bash -n\` syntax check passes for all three scripts
- [ ] CI (7 required checks) green — pure additive change, no Terraform touched
- [ ] After merge, PR #25 (VPC+NAT) can proceed with safety net ready

## Breaking changes
None. Net-new files.