### PR TITLE
feat: add aegis-core ECR repository (Phase 3c prep)

### DIFF
--- a/terraform/environments/staging/bootstrap/ecr.tf
+++ b/terraform/environments/staging/bootstrap/ecr.tf
@@ -1,0 +1,56 @@
+# -----------------------------------------------------------------------------
+# ECR Repositories — staging account per ADR-013
+# -----------------------------------------------------------------------------
+# Container images for workloads running in this account. ADR-013 explicitly
+# chose ECR over Docker Hub to avoid anonymous-pull rate limits that
+# Karpenter-driven scaling can hit trivially.
+#
+# Phase 3b preparation: create the aegis-core repository before the EKS
+# platform exists, so CI builds from the companion repo can push images
+# immediately when Phase 3c lands.
+#
+# Encryption: KMS with the AWS-managed aws/ecr key. Free (AWS-managed keys
+# have no charge), scoped to this account (sufficient for workload image
+# scope — no cross-account sharing planned).
+#
+# Image tag policy: IMMUTABLE. Prevents accidental overwrite of a deployed
+# image's tag, which is a known cause of "it worked yesterday" incidents.
+#
+# Lifecycle: keep the 10 most recent images per repo. Older images expire
+# automatically. $0.10/GB/month storage rounds to pennies at this retention.
+# -----------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "aegis_core" {
+  name                 = "aegis-core"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    # kms_key unspecified → uses AWS-managed aws/ecr (free)
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "aegis_core" {
+  repository = aws_ecr_repository.aegis_core.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep only the 10 most recent images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/environments/staging/bootstrap/outputs.tf
+++ b/terraform/environments/staging/bootstrap/outputs.tf
@@ -17,3 +17,13 @@ output "github_ci_role_arn" {
   description = "IAM role ARN for GitHub Actions CI/CD"
   value       = aws_iam_role.github_ci.arn
 }
+
+output "ecr_aegis_core_repository_url" {
+  description = "ECR repository URL for the aegis-core application image"
+  value       = aws_ecr_repository.aegis_core.repository_url
+}
+
+output "ecr_aegis_core_repository_arn" {
+  description = "ECR repository ARN for the aegis-core application image"
+  value       = aws_ecr_repository.aegis_core.arn
+}


### PR DESCRIPTION
## Summary

Minimal Phase 3c preparation per ADR-013: one ECR repository in staging for the aegis-core companion repo's container images. Immutable tags, scan on push, KMS encryption via AWS-managed aws/ecr key, lifecycle policy retaining 10 most recent.

Deliberately scoped down from original prep plan:
- **Dropped ACM cert** — requires Route 53 zone or Cloudflare DNS manual step. Defer to Phase 3c when we actually have an ALB to attach it to.
- **Dropped IAM policy pre-create for Karpenter/ALB Controller** — their Helm charts create IRSA roles + policies as part of install. Pre-creating would be duplicated work.

## Test plan
- [x] Plan shows 2 resources (repository + lifecycle policy)
- [ ] 7 required status checks pass
- [ ] After merge, apply creates ECR repo in staging; cost remains ~\$0 until images pushed

## Breaking changes
None.