### PR TITLE
docs(CLAUDE): wire teardown habit into AI operational rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,15 @@ This is a hands-on portfolio project by **Bin Hsu**, a Senior Software Architect
   ```
 - **Rule: AI agents must check `docs/decisions/` before proposing architecture.** If a decision has already been made and recorded, follow it. If you believe it should change, discuss with the user first — do not silently override.
 - **Rule: When a significant design discussion happens in conversation, the AI must remind the user to capture it as an ADR.** Don't let decisions disappear into chat history.
-- **Rule: AI agents must append new incidents to `docs/incidents.md`.** When a deployment failure, state-recovery episode, or non-trivial gotcha occurs, write a postmortem entry using the format at the bottom of that file: Symptom → Root cause → Detection → Resolution → Prevention → Lessons. Runbook troubleshooting entries are *in addition to*, not instead of, the postmortem. Undocumented incidents are technical debt.
+
+### Incident Postmortems
+
+- **Location**: `docs/incidents.md` (append-only)
+- **Format**: Symptom / Root cause / Detection / Resolution / Prevention / Lessons. Each entry is a standalone postmortem, scannable independently.
+- **Rule: AI agents must append a new incident entry to `docs/incidents.md` whenever a deployment failure, state-recovery episode, cross-account permission mistake, or other non-trivial gotcha occurs during the session.** The entry is written after the fact, with the benefit of hindsight, in the existing format.
+- **Rule: Runbook troubleshooting entries are in addition to, not instead of, the postmortem.** The runbook tells future operators "if you see X, do Y"; the incident log tells them "here's the full story of why X happens and how we found it." Both matter.
+- **Rule: AI must remind the user to record the incident before closing out a debugging session.** Untracked incidents are technical debt — the next operator (including future Claude) will repeat the mistake if it is not written down.
+- **Rule: Never edit an existing incident to soften the story after the fact.** Correct factual errors only. The historical record matters more than retroactive polish.
 
 ## Directory Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,12 @@ aws-landing-zone-lab/
 
 ## Cost Guardrails
 
-- **NEVER leave EKS, NAT Gateway, or ALB running overnight.** Always `terraform destroy` after practice.
-- **Set AWS Budget alert at $10/day** before creating any resources.
-- **Phase 1-2 should cost <$5 total.** If costs exceed this, something is wrong — investigate.
-- **Phase 3-4: budget ~$5-10 per practice session** (4 hours). Destroy everything after.
+- **NEVER leave EKS, NAT Gateway, or ALB running overnight.** Always run the soft teardown at session end.
+- **Budget alerts**: daily $10, monthly $30, enforced via AWS Budgets in the management account. See memory.
+- **Phase 0-2 should cost <$5 total.** If Phase 0-2 costs exceed this, something is wrong — investigate before continuing.
+- **Phase 3+: budget ~$5-10 per 4-hour session.** Session is defined as "from `terraform apply` on a workload layer until `./scripts/teardown/soft-teardown-workload.sh <env>` runs."
+- **Rule: AI must remind the user to run the soft teardown at the end of any session that applied workload layers** (network, platform, workloads). The exact command is `./scripts/teardown/soft-teardown-workload.sh <env>`. This is not optional — a session that applies a workload layer and ends without a teardown reminder is a cost incident waiting to happen.
+- **Rule: AI must check whether a cost-incurring resource is about to be created** (NAT Gateway, EKS cluster, EC2, ALB, RDS, etc.) and explicitly note the hourly/monthly cost before proceeding to `terraform apply`. "Cost-incurring" means anything that bills while idle; storage and request-based pricing are lower-priority reminders.
 
 ## Workflow with AI
 


### PR DESCRIPTION
Previous CLAUDE.md said 'Always terraform destroy after practice' but didn't reference the specific teardown script or make it the AI's responsibility to remind the user.

This PR:
- Points to `./scripts/teardown/soft-teardown-workload.sh <env>` as the canonical command
- Adds explicit rule: AI must remind user to run teardown at end of any workload-layer session
- Adds explicit rule: AI must note hourly/monthly cost before applying any idle-billing resource
- Defines 'session' crisply