### PR TITLE
docs: complete Incident 7 with full 4-step IPAM org integration

### DIFF
--- a/docs/decisions/004-deployment-configuration-contract.md
+++ b/docs/decisions/004-deployment-configuration-contract.md
@@ -56,11 +56,15 @@ Scheme P1 root-scoped emails mean a future migration to subdomain scheme would r
 
 ### Design gap discovered during implementation (Incident 7)
 
-The original decision text described IPAM in `aegis-shared` with RAM cross-account sharing, but did not enumerate the full set of prerequisites needed to make cross-account CIDR allocation work. Two independent org-level mechanisms are required, not one:
+The original decision text described IPAM in `aegis-shared` with RAM cross-account sharing, but did not enumerate the full set of prerequisites needed to make cross-account CIDR allocation work. The final working setup requires **four** independent mechanisms, not one:
 
-1. **RAM sharing enablement** (`aws_ram_sharing_with_organization`) — lets member accounts *see and consume* the IPAM pool.
-2. **IPAM trusted service access + delegated administrator** — lets the IPAM service *monitor* member accounts so `AllocateIpamPoolCidr` API calls from member accounts succeed.
+1. **RAM sharing enablement** — `aws_ram_sharing_with_organization` in `management/bootstrap`. Lets member accounts *see and consume* the IPAM pool via describe APIs.
+2. **Organizations trusted service access for IPAM** — `aws organizations enable-aws-service-access --service-principal ipam.amazonaws.com` (manual CLI — no standalone Terraform resource exists).
+3. **Organizations delegated administrator for IPAM** — `aws_organizations_delegated_administrator` for `ipam.amazonaws.com`, pointing at shared. Terraform in `management/bootstrap`.
+4. **IPAM-specific org admin enablement** — `aws ec2 enable-ipam-organization-admin-account --delegated-admin-account-id <shared>`. A SEPARATE API from #3, also manual CLI. This is what actually triggers IPAM's auto-discovery of org member accounts.
 
-The mental model we used at ADR time ("bucket-policy-plus-PrincipalOrgID is how cross-account works in AWS") did not extend to IPAM, which has its own service-level integration model. RAM visibility ≠ IPAM allocation permission. Discovered the hard way at [Incident 7](../incidents.md#incident-7--ipam-delegated-admin-not-configured-for-cross-account-vpc-allocation).
+Additionally, IPAM's monitoring scope is **fixed at creation time**: an IPAM created before steps 2-4 are complete has single-account scope and must be destroyed and recreated after the org integration is in place. There is no in-place update API.
 
-The lesson generalizes: every AWS multi-account service has its own "org integration" pattern (enable trusted service access, delegate admin, configure service-linked roles). RAM, IPAM, GuardDuty, Security Hub, Config, Macie all have this pattern, and each has subtle differences. Future ADRs that span accounts should explicitly enumerate the org-level prerequisites, not assume them.
+The mental model we used at ADR time ("bucket-policy-plus-PrincipalOrgID is how cross-account works in AWS") did not extend to IPAM at all, which has its own service-level integration model. RAM visibility ≠ IPAM allocation permission. Generic org delegation ≠ IPAM-specific org enablement. Discovered the hard way through three fix PRs and a destroy-recreate cycle, documented at [Incident 7](../incidents.md#incident-7--ipam-delegated-admin-not-configured-for-cross-account-vpc-allocation).
+
+The lesson generalizes: every AWS multi-account service has its own "org integration" pattern. RAM, IPAM, GuardDuty, Security Hub, Config, Macie, CloudTrail Organization, AWS SSO, ECR pull-through cache — all have subtly different enablement requirements. Future ADRs that span accounts should explicitly enumerate the org-level prerequisites, treat generic org delegation as a *starting point* rather than a complete solution, and verify end-to-end with an actual mutation call (not a describe).

--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -310,9 +310,9 @@ Runbook now documents the full recovery sequence.
 
 ## Incident 7 — IPAM delegated admin not configured for cross-account VPC allocation
 
-**Date**: 2026-04-13 (Phase 3b, PR #25 merge)
-**Severity**: S3 (staging/network apply blocked after NAT cost had started)
-**Duration**: ~10 min detect + fix
+**Date**: 2026-04-13 (Phase 3b, PR #25 through PR #33)
+**Severity**: S3 (staging/network apply blocked; fix required three separate PRs and a destroy-recreate of IPAM)
+**Duration**: ~90 min total across multiple failed apply cycles
 
 ### Symptom
 
@@ -341,35 +341,40 @@ Without delegation, IPAM only monitors the account it lives in. RAM-shared pools
 
 Error message named the specific IPAM ID and the specific monitored-account gap. One of the more self-explanatory AWS errors.
 
-### Resolution
+### Resolution (three layers, in order)
 
-Added `aws_organizations_delegated_administrator` in `management/bootstrap/organization-features.tf`:
+This incident was not a single fix — the problem had three independent causes, each surfaced only after the previous one was resolved. The final working setup requires all four of the following:
 
-```hcl
-resource "aws_organizations_delegated_administrator" "ipam" {
-  account_id        = local.config.accounts.shared.id
-  service_principal = "ipam.amazonaws.com"
-}
-```
+1. **RAM sharing with org enabled** (already in place from earlier work) — `aws_ram_sharing_with_organization.main` in `management/bootstrap`. Lets pools be RAM-shareable.
+2. **Organizations trusted service access for IPAM** — `aws organizations enable-aws-service-access --service-principal ipam.amazonaws.com`. One-time CLI, idempotent. The AWS Terraform provider does not expose this as a standalone resource; managing it via `aws_organizations_organization` would conflict with Control Tower's ownership.
+3. **Delegated administrator for IPAM** — `aws_organizations_delegated_administrator` resource for `ipam.amazonaws.com` pointing at shared. Requires step 2 as prerequisite, otherwise fails with `ConstraintViolationException: You must enable service access before you delegate an administrator`.
+4. **IPAM org admin enablement (IPAM-specific API)** — `aws ec2 enable-ipam-organization-admin-account --delegated-admin-account-id <shared>`. This is a DIFFERENT API from step 3. Generic org delegation does not automatically enable IPAM's org integration — IPAM has its own service-specific enablement that auto-creates resource discoveries across org accounts.
 
-Applied from management account. IPAM immediately recognized all org accounts as monitored. `staging/network` apply then succeeded on retry.
+Additionally, **the IPAM had to be destroyed and recreated** after steps 2-4 were in place. An IPAM created before org integration is enabled retains its original (single-account) monitoring scope even after org integration is later enabled. Re-creating the IPAM after all org integration is in place lets it pick up the auto-discovery of member accounts.
+
+The full sequence of fix PRs: #32 (Terraform delegated admin) → #33 (CLI service access + design gap in ADR-004) → manual destroy+recreate of IPAM → manual `enable-ipam-organization-admin-account` → staging/network apply succeeded.
 
 ### Prevention
 
-When setting up IPAM in a non-management account, the delegation is mandatory, not optional. Document both prerequisites up front:
+For any future IPAM in a delegated admin pattern, the order of operations matters:
 
-1. `aws_ram_sharing_with_organization` — for pools to be RAM-shareable
-2. `aws_organizations_delegated_administrator` for `ipam.amazonaws.com` — for IPAM to monitor org accounts
+1. Enable RAM sharing with org
+2. Enable IPAM Organizations service access (`enable-aws-service-access`)
+3. Delegate IPAM admin to the IPAM-hosting account
+4. Enable IPAM-specific org admin (`enable-ipam-organization-admin-account`)
+5. **Only then** create the IPAM itself
 
-Both go in `management/bootstrap`. Both must apply before any cross-account IPAM consumption.
+Creating the IPAM before steps 1-4 produces an IPAM whose monitoring scope is stuck at single-account. Destroy and recreate is the only fix — there is no API to retroactively update an IPAM's monitoring scope.
 
-Runbook troubleshooting now documents this.
+Runbook troubleshooting and ADR-004 Consequences both document this.
 
 ### Lessons
 
-- AWS cross-account features often have multiple independent prerequisites. RAM enablement and IPAM delegation looked redundant on the surface; they are not.
-- "The pool is visible" ≠ "the pool is usable." Describe APIs and mutation APIs can disagree on cross-account state.
-- When a multi-account AWS service has both a "trusted service access" setting and a "delegated admin" setting, both likely need attention. Enabling one without the other is a common gap.
+- **AWS cross-account features often have multiple independent prerequisites.** RAM enablement, generic org delegation, and IPAM-specific enablement all looked redundant on paper. They are not.
+- **"The pool is visible" ≠ "the pool is usable."** Describe APIs and mutation APIs can disagree on cross-account state. Always test end-to-end, not just describe.
+- **Some AWS services have a service-specific enablement API distinct from the generic `aws organizations` delegation.** IPAM, GuardDuty, Security Hub, Config all have this pattern. Each variant needs its own enablement call.
+- **IPAM monitoring scope is sticky at creation time.** Not documented prominently, but consequential: enabling org integration later does not retroactively update IPAMs created earlier.
+- **The design-at-ADR-time model was incomplete.** The original mental model ("RAM share + OrgID condition is how cross-account works") did not cover IPAM, because IPAM monitoring is a service-level concept, not a resource-policy concept. ADR-004 updated with a 'Design gap' note acknowledging this.
 
 ---
 

--- a/docs/runbooks/001-bootstrap-aws-account.md
+++ b/docs/runbooks/001-bootstrap-aws-account.md
@@ -782,20 +782,31 @@ This file should not exist or should be empty of `aegis-*` content. If it does c
 - **RAM resource share fails with `OperationNotPermittedException: can only be shared within your AWS Organization`**: AWS Organizations sharing with RAM is an opt-in org-level feature — disabled by default. Enable it from the management account via the `aws_ram_sharing_with_organization` Terraform resource (in `management/bootstrap`) or `aws ram enable-sharing-with-aws-organization` CLI. Required before any cross-account RAM share (IPAM pools, EC2 image builder, etc.) can be created.
 - **Cross-account `terraform_remote_state` fails with `kms:Decrypt` denied**: If the state bucket uses the default `aws/s3` AWS-managed KMS key, cross-account roles cannot decrypt state written by another account's role — AWS-managed keys are account-scoped. Fix: create a customer-managed KMS key (CMK) in the state bucket's account with a key policy that grants `kms:Decrypt` and `kms:GenerateDataKey*` to organization members via `aws:PrincipalOrgID`. Update the bucket's default encryption to use the CMK's ARN, then re-encrypt existing objects either by running `terraform apply` in each environment (re-writes their own state) or `aws s3 cp s3://bucket/ s3://bucket/ --recursive --sse aws:kms --sse-kms-key-id <arn>` from a role with both source and destination KMS permission. This project's CMK is in [`terraform/environments/shared/bootstrap/kms-state.tf`](../../terraform/environments/shared/bootstrap/kms-state.tf). See also [Incident 5](../incidents.md#incident-5--cross-account-kmsdecrypt-denied-with-the-awss3-default-key).
 - **State bucket KMS key put into "pending deletion" by CI apply**: If you apply Terraform locally from a feature branch that introduces critical infrastructure (e.g., a state bucket KMS CMK) but do not merge that branch before a later PR lands and triggers `terraform-apply`, CI will run with `main` branch code against state that knows about the CMK. Terraform will schedule the CMK for deletion (7–30 day window). All state files encrypted with that key become unreadable. **Recovery, in order**: (1) `aws kms cancel-key-deletion --key-id <arn>`, (2) `aws kms enable-key --key-id <arn>`, (3) `terraform force-unlock <lock-id>` for any stale lock left by the failed CI run, (4) `terraform import aws_kms_key.<name> <arn>` to put the key back in state, (5) `terraform apply` to reconcile the alias (which was fully deleted, not just pending) and the bucket encryption config. **Prevention**: never apply locally from an unmerged branch for long-lived infrastructure. If a local apply is unavoidable (e.g., breaking a bootstrap cycle), land the code on `main` immediately after — before any unrelated CI apply can run. See also [Incident 6](../incidents.md#incident-6--state-bucket-cmk-scheduled-for-deletion-by-ci-apply).
-- **VPC creation fails with `Account <id> is not monitored by IPAM ipam-<id>`**: IPAM RAM-sharing lets member accounts *see and consume* an IPAM pool, but the IPAM service itself needs AWS Organizations integration to *monitor* member accounts (track their VPC CIDR allocations). When IPAM is hosted outside the management account (this project puts it in `aegis-shared` per ADR-004), delegation is required. **Two prerequisites, both must apply**:
-  1. Enable IPAM as a trusted AWS service in the organization (one-time, manual CLI — the AWS Terraform provider does not expose a standalone resource for this, and managing it via `aws_organizations_organization` would conflict with Control Tower's ownership):
+- **VPC creation fails with `Account <id> is not monitored by IPAM ipam-<id>`**: IPAM RAM-sharing lets member accounts *see and consume* an IPAM pool, but cross-account allocation requires a full AWS Organizations integration that has four independent prerequisites (and `aws_organizations_delegated_administrator` alone is not enough). Complete sequence, in order:
+  1. **Enable RAM sharing with org** — `aws_ram_sharing_with_organization.main` in `management/bootstrap` Terraform.
+  2. **Enable Organizations trusted service access for IPAM** (one-time, manual CLI — Terraform provider does not expose this as a standalone resource):
      ```
      aws organizations enable-aws-service-access --service-principal ipam.amazonaws.com
      ```
-     Run once, from the management account, as a one-time org-level setup. Idempotent.
-  2. Delegate IPAM admin to the IPAM-hosting account (Terraform, in `management/bootstrap`):
+  3. **Delegate IPAM admin to the IPAM-hosting account** (Terraform in `management/bootstrap`):
      ```hcl
      resource "aws_organizations_delegated_administrator" "ipam" {
        account_id        = local.config.accounts.shared.id
        service_principal = "ipam.amazonaws.com"
      }
      ```
-  Step 1 must be complete before step 2's Terraform apply. See also [Incident 7](../incidents.md#incident-7--ipam-delegated-admin-not-configured-for-cross-account-vpc-allocation).
+  4. **Enable IPAM-specific org admin** (different API from #3, one-time manual CLI):
+     ```
+     aws ec2 enable-ipam-organization-admin-account \
+       --delegated-admin-account-id <shared-account-id> \
+       --region <home-region>
+     ```
+     This is the step that actually triggers IPAM to auto-create resource discoveries for member accounts.
+  5. **Only then** create the IPAM (in `shared/ipam` Terraform). An IPAM created before steps 1-4 has its monitoring scope stuck at single-account and must be destroyed and recreated to pick up org integration.
+
+  If the IPAM was created out of order, the fix is: complete steps 1-4, then `terraform destroy` and `terraform apply` on `shared/ipam`. Pool IDs change; downstream state (staging/network, etc.) will re-read the new IDs from the remote state.
+
+  See also [Incident 7](../incidents.md#incident-7--ipam-delegated-admin-not-configured-for-cross-account-vpc-allocation) for the full story of discovering this sequence the hard way.
 
 ## Cross-References
 


### PR DESCRIPTION
VPC is now live. Discovered the full IPAM org-integration requirement: not 2 steps but 4, plus IPAM monitoring scope is fixed at creation time (forcing destroy-recreate when integration was enabled after IPAM was created).

Updates Incident 7, runbook troubleshooting, and ADR-004 Design gap section to match the full reality.