### PR TITLE
feat: split apply workflow by cost profile

### DIFF
--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -1,10 +1,24 @@
-name: Terraform Apply
+name: Terraform Apply (Baseline)
+
+# Auto-applies "baseline" Terraservices layers on push to main.
+# Baseline layers are the ones whose always-on cost is negligible
+# (< $10/mo total): account-level bootstrap, SCPs, state bucket, IPAM.
+#
+# Workload layers (network with NAT, platform with EKS, workloads) are
+# deliberately NOT in this workflow. They require explicit operator intent
+# via terraform-apply-workload.yml (workflow_dispatch, approval-gated).
+#
+# See ADR-009 (lifecycle + teardown) and the "workflow split by cost profile"
+# pattern documented there.
 
 on:
   push:
     branches: [main]
     paths:
-      - 'terraform/**'
+      - 'terraform/environments/management/**'
+      - 'terraform/environments/shared/**'
+      - 'terraform/environments/staging/bootstrap/**'
+      - 'terraform/environments/prod/bootstrap/**'
       - 'config/**'
 
 permissions:
@@ -24,14 +38,7 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          # Order matters — dependencies between layers:
-          #   1. management/bootstrap enables aws_ram_sharing_with_organization,
-          #      which shared/ipam depends on for RAM share.
-          #   2. shared/bootstrap creates the state bucket (other layers' state).
-          #   3. shared/ipam shares pools to org (needs RAM enablement above).
-          #   4. workload bootstraps (staging) provide OIDC roles.
-          #   5. management/scps last because SCPs could lock down operations
-          #      mid-apply.
+          # Order documented inline — foundation first, SCPs last
           - env: management/bootstrap
             account_id: "186052668286"
           - env: shared/bootstrap
@@ -39,8 +46,6 @@ jobs:
           - env: shared/ipam
             account_id: "345895787808"
           - env: staging/bootstrap
-            account_id: "251774439261"
-          - env: staging/network
             account_id: "251774439261"
           - env: management/scps
             account_id: "186052668286"

--- a/.github/workflows/terraform-apply-workload.yml
+++ b/.github/workflows/terraform-apply-workload.yml
@@ -1,0 +1,205 @@
+name: Terraform Apply (Workload)
+
+# workflow_dispatch-only. Applies cost-incurring workload layers for a
+# specified environment. Each job is gated by the `workload-apply` GitHub
+# Environment which requires an explicit approval click by the operator.
+#
+# Start-of-session command:
+#   gh workflow run terraform-apply-workload.yml -f env=staging
+#   gh run watch   # approve when prompted in UI
+#
+# See ADR-009 and scripts/teardown/README.md for the full lifecycle model.
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Workload environment to apply"
+        required: true
+        type: choice
+        options:
+          - staging
+          - prod
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TF_VERSION: "1.14.8"
+  AWS_REGION: "eu-central-1"
+
+jobs:
+  # Network layer runs first. Creates VPC, NAT Gateway, subnets, Gateway
+  # endpoints. Cost starts as soon as NAT Gateway exists (~$0.045/hr).
+  apply-network:
+    name: Apply ${{ inputs.env }}/network
+    runs-on: ubuntu-latest
+    environment: workload-apply
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - name: Resolve target account ID
+        id: acct
+        run: |
+          ACCOUNT_ID=$(python3 -c "
+          import yaml
+          c = yaml.safe_load(open('config/landing-zone.yaml'))
+          print(c['accounts']['${{ inputs.env }}']['id'])
+          ")
+          if [[ -z "${ACCOUNT_ID}" ]]; then
+            echo "::error::accounts.${{ inputs.env }}.id is empty in config"
+            exit 1
+          fi
+          echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Check layer exists
+        id: exists
+        run: |
+          if [[ -d "terraform/environments/${{ inputs.env }}/network" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::network layer does not exist for ${{ inputs.env }} — nothing to apply"
+          fi
+
+      - name: Terraform Init
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/network
+        run: terraform init -input=false
+
+      - name: Terraform Apply
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/network
+        run: terraform apply -auto-approve -input=false -no-color
+
+  # Platform layer runs after network. Creates EKS cluster, Karpenter on
+  # Fargate, ArgoCD, AWS Load Balancer Controller, etc. Phase 3c and beyond.
+  # Currently this layer does not exist — job will skip gracefully.
+  apply-platform:
+    name: Apply ${{ inputs.env }}/platform
+    needs: apply-network
+    runs-on: ubuntu-latest
+    environment: workload-apply
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - name: Resolve target account ID
+        id: acct
+        run: |
+          ACCOUNT_ID=$(python3 -c "
+          import yaml
+          c = yaml.safe_load(open('config/landing-zone.yaml'))
+          print(c['accounts']['${{ inputs.env }}']['id'])
+          ")
+          echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Check layer exists
+        id: exists
+        run: |
+          if [[ -d "terraform/environments/${{ inputs.env }}/platform" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::platform layer does not exist for ${{ inputs.env }} — nothing to apply"
+          fi
+
+      - name: Terraform Init
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/platform
+        run: terraform init -input=false
+
+      - name: Terraform Apply
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/platform
+        run: terraform apply -auto-approve -input=false -no-color
+
+  # Workloads layer — application-specific resources. Phase 3c+.
+  apply-workloads:
+    name: Apply ${{ inputs.env }}/workloads
+    needs: apply-platform
+    runs-on: ubuntu-latest
+    environment: workload-apply
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - name: Resolve target account ID
+        id: acct
+        run: |
+          ACCOUNT_ID=$(python3 -c "
+          import yaml
+          c = yaml.safe_load(open('config/landing-zone.yaml'))
+          print(c['accounts']['${{ inputs.env }}']['id'])
+          ")
+          echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Check layer exists
+        id: exists
+        run: |
+          if [[ -d "terraform/environments/${{ inputs.env }}/workloads" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::workloads layer does not exist for ${{ inputs.env }} — nothing to apply"
+          fi
+
+      - name: Terraform Init
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/workloads
+        run: terraform init -input=false
+
+      - name: Terraform Apply
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/workloads
+        run: terraform apply -auto-approve -input=false -no-color

--- a/.github/workflows/terraform-teardown-workload.yml
+++ b/.github/workflows/terraform-teardown-workload.yml
@@ -1,0 +1,199 @@
+name: Terraform Teardown (Workload)
+
+# workflow_dispatch-only. Destroys cost-incurring workload layers for a
+# specified environment. Gated by the `workload-teardown` GitHub Environment
+# which requires an explicit approval click by the operator.
+#
+# End-of-session command:
+#   gh workflow run terraform-teardown-workload.yml -f env=staging
+#   gh run watch   # approve when prompted in UI
+#
+# Destruction order (reverse of apply):
+#   workloads → platform → network
+#
+# Preserves bootstrap layer, shared services, all other accounts.
+# Equivalent in scope to scripts/teardown/soft-teardown-workload.sh.
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "Workload environment to destroy"
+        required: true
+        type: choice
+        options:
+          - staging
+          - prod
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TF_VERSION: "1.14.8"
+  AWS_REGION: "eu-central-1"
+
+jobs:
+  destroy-workloads:
+    name: Destroy ${{ inputs.env }}/workloads
+    runs-on: ubuntu-latest
+    environment: workload-teardown
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - name: Resolve target account ID
+        id: acct
+        run: |
+          ACCOUNT_ID=$(python3 -c "
+          import yaml
+          c = yaml.safe_load(open('config/landing-zone.yaml'))
+          print(c['accounts']['${{ inputs.env }}']['id'])
+          ")
+          echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Check layer exists
+        id: exists
+        run: |
+          if [[ -d "terraform/environments/${{ inputs.env }}/workloads" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::workloads layer does not exist for ${{ inputs.env }} — skipping"
+          fi
+
+      - name: Terraform Init
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/workloads
+        run: terraform init -input=false
+
+      - name: Terraform Destroy
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/workloads
+        run: terraform destroy -auto-approve -input=false -no-color
+
+  destroy-platform:
+    name: Destroy ${{ inputs.env }}/platform
+    needs: destroy-workloads
+    runs-on: ubuntu-latest
+    environment: workload-teardown
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - name: Resolve target account ID
+        id: acct
+        run: |
+          ACCOUNT_ID=$(python3 -c "
+          import yaml
+          c = yaml.safe_load(open('config/landing-zone.yaml'))
+          print(c['accounts']['${{ inputs.env }}']['id'])
+          ")
+          echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Check layer exists
+        id: exists
+        run: |
+          if [[ -d "terraform/environments/${{ inputs.env }}/platform" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::platform layer does not exist for ${{ inputs.env }} — skipping"
+          fi
+
+      - name: Terraform Init
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/platform
+        run: terraform init -input=false
+
+      - name: Terraform Destroy
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/platform
+        run: terraform destroy -auto-approve -input=false -no-color
+
+  destroy-network:
+    name: Destroy ${{ inputs.env }}/network
+    needs: destroy-platform
+    runs-on: ubuntu-latest
+    environment: workload-teardown
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - name: Resolve target account ID
+        id: acct
+        run: |
+          ACCOUNT_ID=$(python3 -c "
+          import yaml
+          c = yaml.safe_load(open('config/landing-zone.yaml'))
+          print(c['accounts']['${{ inputs.env }}']['id'])
+          ")
+          echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Check layer exists
+        id: exists
+        run: |
+          if [[ -d "terraform/environments/${{ inputs.env }}/network" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::network layer does not exist for ${{ inputs.env }} — skipping"
+          fi
+
+      - name: Terraform Init
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/network
+        run: terraform init -input=false
+
+      - name: Terraform Destroy
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/network
+        run: terraform destroy -auto-approve -input=false -no-color

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,14 @@ aws-landing-zone-lab/
 - **NEVER leave EKS, NAT Gateway, or ALB running overnight.** Always run the soft teardown at session end.
 - **Budget alerts**: daily $10, monthly $30, enforced via AWS Budgets in the management account. See memory.
 - **Phase 0-2 should cost <$5 total.** If Phase 0-2 costs exceed this, something is wrong — investigate before continuing.
-- **Phase 3+: budget ~$5-10 per 4-hour session.** Session is defined as "from `terraform apply` on a workload layer until `./scripts/teardown/soft-teardown-workload.sh <env>` runs."
-- **Rule: AI must remind the user to run the soft teardown at the end of any session that applied workload layers** (network, platform, workloads). The exact command is `./scripts/teardown/soft-teardown-workload.sh <env>`. This is not optional — a session that applies a workload layer and ends without a teardown reminder is a cost incident waiting to happen.
+- **Phase 3+: budget ~$5-10 per 4-hour session.** A session is framed as "from `gh workflow run terraform-apply-workload.yml` until `gh workflow run terraform-teardown-workload.yml`." Both are approval-gated via GitHub Environments.
+- **Rule: AI must remind the user to run the workload teardown at the end of any session that applied workload layers.** Preferred path (portfolio-visible audit trail):
+  ```
+  gh workflow run terraform-teardown-workload.yml -f env=<env>
+  gh run watch   # then approve when GitHub prompts
+  ```
+  Fallback if CI unavailable: `./scripts/teardown/soft-teardown-workload.sh <env>` (same effect locally). Not optional — a session that applied workload layers and ends without a teardown reminder is a cost incident waiting to happen.
+- **Rule: Workload layers are NOT auto-applied on merge to main.** Baseline layers (bootstrap, scps, ipam) apply automatically via `terraform-apply-baseline.yml`. Cost-incurring layers (network, platform, workloads) require explicit `gh workflow run terraform-apply-workload.yml -f env=<env>` with human approval. Changing this without an ADR is a design regression.
 - **Rule: AI must check whether a cost-incurring resource is about to be created** (NAT Gateway, EKS cluster, EC2, ALB, RDS, etc.) and explicitly note the hourly/monthly cost before proceeding to `terraform apply`. "Cost-incurring" means anything that bills while idle; storage and request-based pricing are lower-priority reminders.
 
 ## Workflow with AI


### PR DESCRIPTION
Implements the 'workflow split by cost profile' pattern referenced in ADR-009. Baseline layers auto-apply on merge; workload layers require workflow_dispatch + GitHub Environment approval.

Three workflows replace the single `terraform-apply.yml`:
- **terraform-apply-baseline.yml** (auto): bootstrap, SCPs, IPAM, state bucket
- **terraform-apply-workload.yml** (manual, approval-gated): network, platform, workloads
- **terraform-teardown-workload.yml** (manual, approval-gated): reverse-order destroy

GitHub Environments `workload-apply` and `workload-teardown` configured with BinHsu as required reviewer.

## Test plan
- [x] All 7 plan checks pass on this PR
- [ ] After merge: baseline apply runs (no-op expected, nothing changed)
- [ ] After merge: workload apply does NOT auto-trigger
- [ ] Manual test: `gh workflow run terraform-teardown-workload.yml -f env=staging` triggers teardown, approval prompt appears in GitHub Actions UI, NAT Gateway destroyed end-to-end

This PR IS the end-to-end test of the teardown workflow — the current staging NAT Gateway (created in PR #25) will be destroyed by triggering the new workflow.