### PR TITLE
fix: single approval gate per workflow (not per layer)

### DIFF
--- a/.github/workflows/terraform-apply-workload.yml
+++ b/.github/workflows/terraform-apply-workload.yml
@@ -93,11 +93,13 @@ jobs:
   # Platform layer runs after network. Creates EKS cluster, Karpenter on
   # Fargate, ArgoCD, AWS Load Balancer Controller, etc. Phase 3c and beyond.
   # Currently this layer does not exist — job will skip gracefully.
+  # No `environment:` — approval was granted at apply-network. Subsequent
+  # layers run automatically once the first layer's gate opens. This trades
+  # per-layer approval for a single session-level intent confirmation.
   apply-platform:
     name: Apply ${{ inputs.env }}/platform
     needs: apply-network
     runs-on: ubuntu-latest
-    environment: workload-apply
 
     steps:
       - uses: actions/checkout@v4
@@ -149,11 +151,11 @@ jobs:
         run: terraform apply -auto-approve -input=false -no-color
 
   # Workloads layer — application-specific resources. Phase 3c+.
+  # No `environment:` — see apply-platform rationale.
   apply-workloads:
     name: Apply ${{ inputs.env }}/workloads
     needs: apply-platform
     runs-on: ubuntu-latest
-    environment: workload-apply
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/terraform-teardown-workload.yml
+++ b/.github/workflows/terraform-teardown-workload.yml
@@ -88,11 +88,12 @@ jobs:
         working-directory: terraform/environments/${{ inputs.env }}/workloads
         run: terraform destroy -auto-approve -input=false -no-color
 
+  # No `environment:` — approval was granted at destroy-workloads. Subsequent
+  # layers run automatically once the session-level gate opens.
   destroy-platform:
     name: Destroy ${{ inputs.env }}/platform
     needs: destroy-workloads
     runs-on: ubuntu-latest
-    environment: workload-teardown
 
     steps:
       - uses: actions/checkout@v4
@@ -143,11 +144,11 @@ jobs:
         working-directory: terraform/environments/${{ inputs.env }}/platform
         run: terraform destroy -auto-approve -input=false -no-color
 
+  # No `environment:` — see destroy-platform rationale.
   destroy-network:
     name: Destroy ${{ inputs.env }}/network
     needs: destroy-platform
     runs-on: ubuntu-latest
-    environment: workload-teardown
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Reduces approval clicks from 6 per session to 2. Approval now signals session-level intent, not per-layer confirmation. Subsequent jobs run via needs: chain once the entry job's gate opens.

Trade-off noted: no mid-workflow stop via approval. Acceptable for single-operator lab.