### PR TITLE
feat(platform): staging EKS core layer (Phase 3c PR 1/3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,16 @@ This is a hands-on portfolio project by **Bin Hsu**, a Senior Software Architect
 - **Rule: AI must remind the user to record the incident before closing out a debugging session.** Untracked incidents are technical debt — the next operator (including future Claude) will repeat the mistake if it is not written down.
 - **Rule: Never edit an existing incident to soften the story after the fact.** Correct factual errors only. The historical record matters more than retroactive polish.
 
+### Layer-specific runbooks
+
+Some Terraservices layers have their own operational contracts — pre-flight checks, connectivity failure diagnostics, update procedures — that do not belong in global rules because they only apply when working in that layer. These live in `docs/runbooks/NNN-<topic>.md`.
+
+- **Rule: Before running operations in a layer that has its own runbook, AI must read the runbook first.** The runbook is the authoritative source for that layer's pre-flight checks and failure diagnostics. Global rules (this file) point at the runbook; they do not duplicate it. Scanning the runbook costs a few seconds; skipping it and debugging in the wrong order costs tens of minutes. Current runbooks:
+  - `docs/runbooks/001-bootstrap-aws-account.md` — initial AWS / Control Tower bootstrap
+  - `docs/runbooks/002-eks-access.md` — EKS operator access (MUST read before any `kubectl`, `aws eks`, or `staging/platform` apply in a session)
+
+- **Rule: When adding a new layer whose operations require their own diagnostic order (e.g., observability, service mesh), add a runbook under `docs/runbooks/` rather than extending this file.** Keeping CLAUDE.md small preserves its discoverability; layer-specific details belong with the layer.
+
 ## Directory Structure
 
 ```

--- a/config/landing-zone.example.yaml
+++ b/config/landing-zone.example.yaml
@@ -107,3 +107,18 @@ control_tower:
     - eu-central-1
     - eu-west-1
   kms_key_alias: "alias/aegis-control-tower-key"
+
+# EKS platform configuration (optional — only environments that deploy the
+# platform layer need an entry). See ADR-013 for version / endpoint rationale
+# and docs/runbooks/002-eks-access.md for the public-IP operational contract.
+eks:
+  staging:
+    version: "1.32"
+    public_access_cidrs:
+      # Operator's current public IP, /32. Update when the ISP reassigns —
+      # see runbook 002 for the check + update procedure.
+      - "203.0.113.1/32"
+  # prod:
+  #   version: "1.32"
+  #   public_access_cidrs:
+  #     - "203.0.113.1/32"

--- a/config/schema.json
+++ b/config/schema.json
@@ -16,6 +16,7 @@
     "ipam",
     "control_tower"
   ],
+  "$comment": "The 'eks' section is optional — only environments that deploy an EKS platform layer need it. Not every account has a cluster.",
   "additionalProperties": false,
   "properties": {
     "organization": {
@@ -230,6 +231,31 @@
         "kms_key_alias": {
           "type": "string",
           "description": "KMS key alias for CloudTrail and Config encryption"
+        }
+      }
+    },
+    "eks": {
+      "type": "object",
+      "description": "EKS platform configuration keyed by workload environment name (e.g. staging, prod). Optional — only environments that deploy a platform layer need an entry.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["version", "public_access_cidrs"],
+        "additionalProperties": false,
+        "properties": {
+          "version": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+$",
+            "description": "EKS Kubernetes version (e.g. 1.32). See ADR-013."
+          },
+          "public_access_cidrs": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$"
+            },
+            "description": "CIDR blocks allowed to reach the EKS public API endpoint. See docs/runbooks/002-eks-access.md for the IP-drift operational contract."
+          }
         }
       }
     }

--- a/docs/runbooks/002-eks-access.md
+++ b/docs/runbooks/002-eks-access.md
@@ -1,0 +1,184 @@
+# Runbook 002 — EKS operator access
+
+Scope: operational procedures for reaching the `aegis-staging` EKS cluster from the operator's laptop. Covers pre-flight checks, connectivity failure diagnosis, and the procedure for updating the allow-listed public IP when the operator's ISP reassigns it.
+
+This runbook is the authoritative source for the operational contract behind the `eks.<env>.public_access_cidrs` field in `config/landing-zone.yaml`. See ADR-013 for the design rationale behind a public-endpoint-restricted-by-CIDR access model.
+
+---
+
+## 1. Pre-flight check — run this at the start of every EKS-touching session
+
+Before the first `kubectl`, `aws eks describe-*`, or `terraform apply` against `staging/platform`, verify that the operator's current public IP still matches the allow-list in the config.
+
+```bash
+curl -s https://checkip.amazonaws.com
+```
+
+Compare the returned address with the value in `config/landing-zone.yaml` under `eks.staging.public_access_cidrs`. If they match → proceed normally. If they do not match → stop and go to section 3 before any cluster operation.
+
+**Why this check matters.** Home ISPs (the operator is on a residential connection in Germany) reassign public IPs silently on router reboot, lease expiry, or provider-side renumbering. A mismatch does not break immediately — the allow-list is enforced by AWS on each connection, so existing kube-apiserver calls fail with a TLS handshake timeout rather than a clean 403. Diagnosing the failure downstream costs 10–20 minutes; `curl` costs 1 second. See section 4 for the `why-IP-first` diagnostic rule.
+
+**Responsibility.** Any AI agent working on this repository MUST run the check and warn the operator if mismatched, per the rule in `CLAUDE.md`. This is not optional.
+
+---
+
+## 2. Normal access — `kubectl` from the operator laptop
+
+Prerequisites:
+
+- An active SSO session: `aws sso login --sso-session aegis`
+- The `aegis-staging-admin` profile selected: `export AWS_PROFILE=aegis-staging-admin`
+- The operator's public IP is in `eks.staging.public_access_cidrs` and the current `staging/platform` Terraform apply has landed.
+
+Fetch the kubeconfig entry (idempotent — safe to re-run):
+
+```bash
+aws eks update-kubeconfig --name aegis-staging --region eu-central-1
+```
+
+Verify cluster reachability:
+
+```bash
+kubectl get nodes            # should list Karpenter-managed EC2 + Fargate
+kubectl get pods -A          # baseline: CoreDNS, Karpenter controller
+```
+
+The `kubectl` token is derived from the SSO session and expires when the session expires (8 hours). Re-running `aws sso login --sso-session aegis` refreshes it; no kubeconfig re-generation is needed.
+
+---
+
+## 3. Connectivity failure — diagnostic order
+
+When `kubectl`, `aws eks describe-cluster`, or a platform-layer `terraform apply` hits a network error, follow this order. The ordering is deliberate: cheapest check first, most likely cause first. Do NOT skip ahead.
+
+### Step 1 — check your public IP
+
+```bash
+curl -s https://checkip.amazonaws.com
+```
+
+Compare with `config/landing-zone.yaml` → `eks.staging.public_access_cidrs`. If different, the IP drifted. Go to section 5 (update procedure).
+
+**This accounts for the overwhelming majority of connectivity breakages in this project.** Only move to step 2 if the IP matches.
+
+### Step 2 — verify the cluster endpoint resolves and is reachable at the TLS layer
+
+```bash
+ENDPOINT=$(aws eks describe-cluster --name aegis-staging \
+  --query 'cluster.endpoint' --output text)
+curl -sI --max-time 10 "${ENDPOINT}/healthz"
+```
+
+- `Could not resolve host` → DNS issue, likely local network misconfiguration, not the cluster.
+- `TLS handshake timeout` → the CIDR allow-list is likely still rejecting you despite step 1 matching (possible IPv6 vs IPv4 split, VPN exit, corporate proxy). Try `curl -4 -s https://checkip.amazonaws.com` to confirm IPv4 egress IP.
+- `HTTP/2 401` → network layer is fine, you just lack valid credentials (section 4).
+
+### Step 3 — verify the SSO session is valid
+
+```bash
+aws sts get-caller-identity
+```
+
+If this returns a 401 / `ExpiredToken`, the SSO session has expired. Refresh:
+
+```bash
+aws sso login --sso-session aegis
+```
+
+### Step 4 — verify kubectl is using the current session
+
+```bash
+aws eks update-kubeconfig --name aegis-staging --region eu-central-1
+kubectl config current-context   # should reference aegis-staging
+```
+
+### Step 5 — IAM / Access Entry diagnostics
+
+Only reach this step after all of the above pass. A `403 forbidden from server` or `Unauthorized` response from `kubectl` at this point indicates an Access Entry or RBAC misconfiguration, not a network layer problem.
+
+```bash
+# Confirm you are authenticating as the expected principal
+kubectl auth whoami
+
+# Confirm the Access Entry exists for your SSO role
+aws eks list-access-entries --cluster-name aegis-staging
+
+# Confirm the Access Entry has cluster-admin policy attached
+aws eks list-associated-access-policies \
+  --cluster-name aegis-staging \
+  --principal-arn <your-sso-role-arn>
+```
+
+Access Entry mismatches are rare and require Terraform changes to fix (see `terraform/environments/staging/platform/access-entries.tf`). This is deliberately the last step because it is the least likely cause and the most expensive to remediate.
+
+---
+
+## 4. Why IP-drift is the first suspect
+
+The EKS public endpoint has four defensive layers: TLS, AWS IAM SigV4 auth, Kubernetes RBAC, and the CIDR allow-list. Three of those layers (TLS, IAM, RBAC) are stable — once configured, they do not change between sessions. The CIDR allow-list is the only layer whose correctness depends on a value (the operator's public IP) that drifts outside the operator's control.
+
+Empirically: the operator's IP changes roughly every few weeks on a residential ISP. All other layers change only when this repository's Terraform changes. Therefore, on a cold-start "it doesn't work" symptom, the IP is the most likely drift site by a wide margin. Debugging IAM, kubeconfig, or RBAC first is a common time sink and explicitly discouraged — both by this runbook and by `CLAUDE.md`.
+
+---
+
+## 5. Update procedure when the IP has drifted
+
+### Preferred path — PR-driven
+
+```bash
+# 1. Capture the current IP
+curl -s https://checkip.amazonaws.com
+
+# 2. Edit config/landing-zone.yaml (gitignored — local only)
+#    Update eks.staging.public_access_cidrs to ["<new-ip>/32"]
+
+# 3. Edit config/landing-zone.example.yaml too if the placeholder is stale
+
+# 4. Commit + push + PR
+git checkout -b ops/update-operator-ip
+# (edit config files)
+git commit -sS -m "ops: rotate operator public IP allow-list"
+git push -u origin ops/update-operator-ip
+gh pr create --fill
+
+# 5. After merge — the staging/platform layer does not apply automatically
+#    (it's a cost-incurring workload layer). Trigger manually:
+gh workflow run terraform-apply-workload.yml -f env=staging
+gh run watch   # approve in UI
+```
+
+End-to-end time: ~5 minutes (PR merge + one workload apply cycle).
+
+### Emergency path — local apply, then land the code immediately
+
+If the PR-driven path is blocked (CI outage, urgent need to reach the cluster):
+
+```bash
+export AWS_PROFILE=aegis-staging-admin
+aws sso login --sso-session aegis
+
+# Edit config/landing-zone.yaml locally
+cd terraform/environments/staging/platform
+terraform apply
+
+# IMMEDIATELY commit the config change to main
+#   — per Incident 6, code that lives only on a branch gets "corrected"
+#   by the next CI apply. The local change must land on main before the
+#   next baseline or workload apply.
+```
+
+Do not leave locally-applied state un-landed overnight. A merge to main between the local apply and the code landing will reconcile Terraform state against the (stale) main branch and destroy your change.
+
+### Why there is no auto-update script (yet)
+
+An obvious convenience would be a `scripts/update-operator-ip.sh` that reads `checkip.amazonaws.com`, rewrites the config, commits, and opens a PR. This is tracked as a future improvement. For now, the manual edit is deliberate — it forces the operator to see the new CIDR before applying it, which has prevented at least one incident of committing the wrong IP (corporate VPN exit vs. home IP) during this project's early Phase 3 work.
+
+---
+
+## 6. Related references
+
+- ADR-013 (`docs/decisions/013-eks-architecture.md`) — why the endpoint is public-with-CIDR-restriction
+- `CLAUDE.md` — the `before-EKS-operation` rule requiring the section 1 check
+- `config/schema.json` — the schema entry that enforces the CIDR format
+- `terraform/environments/staging/platform/access-entries.tf` — IAM → RBAC mapping
+- Incident 6 in `docs/incidents.md` — the "local apply drift" incident that motivates the "land it on main immediately" rule in section 5

--- a/terraform/environments/management/bootstrap/sso-assignments.tf
+++ b/terraform/environments/management/bootstrap/sso-assignments.tf
@@ -1,0 +1,80 @@
+# -----------------------------------------------------------------------------
+# IAM Identity Center — per-account Permission Set assignments
+# -----------------------------------------------------------------------------
+# IAM Identity Center (SSO) permission sets are defined once at the Organization
+# level, but must be EXPLICITLY ASSIGNED to each target account that should
+# accept them. An assignment is what causes AWS to lazily create the
+# corresponding `AWSReservedSSO_<PermissionSet>_<hash>` IAM role in the target
+# account. Without the assignment, the role simply does not exist there, and
+# any downstream resource that references it (e.g., EKS Access Entries in
+# staging/platform) will fail to resolve at plan time.
+#
+# This file exists because the staging/platform layer needs the PlatformAdmin
+# SSO role to be present in the staging account so that it can map the role
+# to Kubernetes cluster-admin via an Access Entry. Assignment in this layer
+# (management/bootstrap) MUST apply before staging/platform — which is already
+# the apply order in terraform-apply-baseline.yml (baseline layers run before
+# workload layers).
+# -----------------------------------------------------------------------------
+
+# Discover the Identity Center instance (there is exactly one per organization).
+data "aws_ssoadmin_instances" "main" {}
+
+# Resolve the PlatformAdmin permission set by name. The permission set itself
+# was created manually during Phase 0 (see runbook 001 section 5). This data
+# source depends only on the name — if the permission set is renamed, this
+# lookup breaks with a clear error.
+data "aws_ssoadmin_permission_set" "platform_admin" {
+  instance_arn = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  name         = "PlatformAdmin"
+}
+
+# Resolve the operator user `bin` from the Identity Center directory.
+data "aws_identitystore_user" "bin" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "UserName"
+      attribute_value = "bin"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Staging — PlatformAdmin for operator `bin`
+# -----------------------------------------------------------------------------
+# Assigning PlatformAdmin to staging creates the reserved role
+# `AWSReservedSSO_PlatformAdmin_<hash>` in the staging account on next SSO
+# sync, which is what staging/platform/access-entries.tf discovers and maps
+# to Kubernetes cluster-admin. See ADR-013 (Operator access) for why Access
+# Entries + Identity Center is the chosen mechanism (not aws-auth ConfigMap,
+# not long-lived IAM users).
+# -----------------------------------------------------------------------------
+resource "aws_ssoadmin_account_assignment" "bin_staging_platform_admin" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  permission_set_arn = data.aws_ssoadmin_permission_set.platform_admin.arn
+
+  principal_id   = data.aws_identitystore_user.bin.user_id
+  principal_type = "USER"
+
+  target_id   = local.config.accounts.staging.id
+  target_type = "AWS_ACCOUNT"
+}
+
+# -----------------------------------------------------------------------------
+# Shared + Prod — placeholder for future expansion
+# -----------------------------------------------------------------------------
+# Shared and Prod assignments are intentionally commented out. They are added
+# when those accounts acquire workloads that the operator must reach directly.
+# Prod in particular should stay assignment-free until ADR-011 Path A account
+# promotion for prod is complete and a production workload exists.
+#
+# resource "aws_ssoadmin_account_assignment" "bin_prod_platform_admin" {
+#   instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+#   permission_set_arn = data.aws_ssoadmin_permission_set.platform_admin.arn
+#   principal_id       = data.aws_identitystore_user.bin.user_id
+#   principal_type     = "USER"
+#   target_id          = local.config.accounts.prod.id
+#   target_type        = "AWS_ACCOUNT"
+# }

--- a/terraform/environments/staging/platform/.terraform.lock.hcl
+++ b/terraform/environments/staging/platform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/staging/platform/README.md
+++ b/terraform/environments/staging/platform/README.md
@@ -1,0 +1,90 @@
+# staging/platform
+
+The EKS platform layer for `aegis-staging`. Contains the EKS cluster, Fargate profiles for system pods (CoreDNS, Karpenter controller), the IRSA OIDC provider, and Access Entries mapping the CI role and the operator's SSO role to Kubernetes cluster-admin.
+
+Karpenter, the AWS Load Balancer Controller, and ArgoCD are intentionally NOT in this layer — they land in follow-up PRs in Phase 3c so each can be reviewed and applied independently.
+
+---
+
+## Before you touch this layer
+
+**Read `docs/runbooks/002-eks-access.md` first.** That runbook is the authoritative source for:
+
+- Session-start public-IP check (required for every session that touches the cluster)
+- Connectivity failure diagnostic order (IP → TLS reachability → SSO → kubeconfig → Access Entries)
+- Procedure for updating `public_access_cidrs` when the operator's ISP reassigns the public IP
+
+Skipping the runbook and debugging `kubectl` failures "from the cluster outwards" is the single biggest time sink in this layer. See the runbook's section 4 for the reasoning.
+
+---
+
+## Apply prerequisites
+
+This layer reads from three other layers:
+
+| Dependency | Provides | Failure mode if missing |
+|---|---|---|
+| `shared/ipam` | CIDR pool for `staging/network` | `staging/network` plan errors — platform plan never reaches here |
+| `staging/network` | VPC + private subnets for Fargate | `check "network_layer_applied"` fails in `config.tf` |
+| `management/bootstrap` | PlatformAdmin SSO assignment → reserved role in staging | `check "sso_platform_admin_role_exists"` fails in `access-entries.tf` |
+
+Apply ordering is enforced operationally by the CI workflow split:
+
+1. `terraform-apply-baseline.yml` applies `management/bootstrap`, `shared/*`, `staging/bootstrap` on every merge to main.
+2. `terraform-apply-workload.yml` (workflow_dispatch, approval-gated) applies `staging/network` → `staging/platform` → `staging/workloads` in order.
+
+---
+
+## Cost profile
+
+Apply triggers ~$0.28/hr ongoing while the cluster is running:
+
+| Component | Approximate cost while running |
+|---|---|
+| EKS control plane | $0.10/hr (~$73/month always-on) |
+| Fargate (CoreDNS + Karpenter controller, ~3 pods) | ~$0.12/hr |
+| CloudWatch Logs (5 log types at lab traffic) | pennies/day |
+| KMS keys (2) | $2/month (fixed, $0.03/day not teardown-able) |
+
+See ADR-013 "Consequences" for the full cost table and why teardown discipline is load-bearing.
+
+---
+
+## Teardown
+
+End of session:
+
+```bash
+gh workflow run terraform-teardown-workload.yml -f env=staging
+gh run watch   # approve in UI
+```
+
+This destroys `staging/workloads` → `staging/platform` → `staging/network` in order. The platform destroy itself takes 5–10 minutes (cluster drain + Fargate profile removal + KMS key scheduling).
+
+**The two KMS keys in this layer have a 30-day deletion window and continue costing $2/month until the window elapses.** This is intentional — shortening the window to speed up teardown would risk unrecoverable secrets loss if teardown was triggered in error. Accept the $2/month residual as the price of recoverable KMS destruction. See ADR-004 "Consequences → Design implications" for the parallel rationale applied to IPAM's release lag.
+
+---
+
+## Files
+
+```
+staging/platform/
+├── backend.tf           # S3 state backend
+├── versions.tf          # Terraform + provider constraints
+├── providers.tf         # AWS provider with account ID safety
+├── config.tf            # Reads config/landing-zone.yaml + cross-layer state
+├── cluster.tf           # IAM + KMS + log group + aws_eks_cluster
+├── fargate.tf           # Fargate pod execution role + profiles
+├── oidc.tf              # IRSA OIDC provider
+├── access-entries.tf    # CI role + operator SSO role → cluster-admin
+├── outputs.tf           # Consumed by Karpenter / LB Controller / ArgoCD PRs
+└── README.md            # This file
+```
+
+---
+
+## Related docs
+
+- ADR-013 `docs/decisions/013-eks-architecture.md` — EKS design rationale
+- ADR-009 `docs/decisions/009-lifecycle-and-teardown-strategy.md` — workflow split
+- Runbook 002 `docs/runbooks/002-eks-access.md` — operator access contract

--- a/terraform/environments/staging/platform/access-entries.tf
+++ b/terraform/environments/staging/platform/access-entries.tf
@@ -1,0 +1,105 @@
+# -----------------------------------------------------------------------------
+# Access Entries — who gets Kubernetes cluster-admin
+# -----------------------------------------------------------------------------
+# This project uses EKS Access Entries (not the legacy aws-auth ConfigMap)
+# per ADR-013 "Operator access". Access Entries map AWS IAM principals
+# directly to Kubernetes RBAC via AWS-managed cluster policies.
+#
+# Two principals need cluster-admin in staging:
+#
+#   1. The GitHub Actions CI role — so that the Helm and Kubernetes
+#      Terraform providers in subsequent PRs (Karpenter, LB Controller,
+#      ArgoCD) can `apply` in-cluster resources.
+#
+#   2. The operator's PlatformAdmin SSO role — so that the human operator
+#      can `kubectl` against the cluster after `aws sso login`.
+#
+# The SSO role is looked up by name pattern. Its existence in the staging
+# account depends on the corresponding permission-set assignment in
+# management/bootstrap/sso-assignments.tf having applied first. Since that
+# layer runs in terraform-apply-baseline.yml and this layer runs in
+# terraform-apply-workload.yml (which the operator dispatches manually
+# after the baseline is green), the ordering is enforced by the workflow
+# split — no explicit cross-state dependency is needed.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# GitHub Actions CI role — grant cluster-admin so post-cluster PRs
+# (Karpenter, LB Controller, ArgoCD) can apply via the kubernetes/helm
+# Terraform providers.
+# -----------------------------------------------------------------------------
+locals {
+  ci_role_arn = "arn:aws:iam::${local.account_id}:role/github-actions-terraform"
+}
+
+resource "aws_eks_access_entry" "ci" {
+  cluster_name      = aws_eks_cluster.main.name
+  principal_arn     = local.ci_role_arn
+  type              = "STANDARD"
+  kubernetes_groups = []
+}
+
+resource "aws_eks_access_policy_association" "ci_cluster_admin" {
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = local.ci_role_arn
+  policy_arn    = "arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.ci]
+}
+
+# -----------------------------------------------------------------------------
+# Operator — PlatformAdmin SSO role → cluster-admin
+# -----------------------------------------------------------------------------
+# AWS creates a reserved role `AWSReservedSSO_PlatformAdmin_<hash>` in this
+# account whenever an Identity Center permission set is assigned to it. The
+# hash suffix is deterministic per (permission set, account) but not
+# predictable ahead of time, so we discover it via data source.
+#
+# Prerequisite: management/bootstrap/sso-assignments.tf must have applied
+# first (assigns the permission set to this account, which causes the role
+# to be created). If that has not happened, the data source returns empty
+# and the check block below fails with a clear error.
+# -----------------------------------------------------------------------------
+
+data "aws_iam_roles" "sso_platform_admin" {
+  name_regex  = "^AWSReservedSSO_PlatformAdmin_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
+
+locals {
+  platform_admin_role_arn = one(tolist(data.aws_iam_roles.sso_platform_admin.arns))
+}
+
+check "sso_platform_admin_role_exists" {
+  assert {
+    condition     = local.platform_admin_role_arn != null
+    error_message = "The AWSReservedSSO_PlatformAdmin_* role does not exist in this account. Ensure management/bootstrap has applied the aws_ssoadmin_account_assignment for staging (see management/bootstrap/sso-assignments.tf). If it has just applied, allow ~30-60 seconds for SSO to create the reserved role in this account, then re-run."
+  }
+}
+
+resource "aws_eks_access_entry" "operator" {
+  count = local.platform_admin_role_arn == null ? 0 : 1
+
+  cluster_name      = aws_eks_cluster.main.name
+  principal_arn     = local.platform_admin_role_arn
+  type              = "STANDARD"
+  kubernetes_groups = []
+}
+
+resource "aws_eks_access_policy_association" "operator_cluster_admin" {
+  count = local.platform_admin_role_arn == null ? 0 : 1
+
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = local.platform_admin_role_arn
+  policy_arn    = "arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.operator]
+}

--- a/terraform/environments/staging/platform/backend.tf
+++ b/terraform/environments/staging/platform/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "staging/platform/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/staging/platform/cluster.tf
+++ b/terraform/environments/staging/platform/cluster.tf
@@ -1,0 +1,193 @@
+# -----------------------------------------------------------------------------
+# EKS Cluster — Phase 3c per ADR-013
+# -----------------------------------------------------------------------------
+# Single-region EKS cluster in staging. Public + private endpoint per ADR-013
+# "Control plane endpoint" section. Public endpoint is restricted by
+# `public_access_cidrs` (see config/landing-zone.yaml → eks.staging, and
+# docs/runbooks/002-eks-access.md for the IP-drift operational contract).
+#
+# Authentication mode: API (Access Entries only, no aws-auth ConfigMap).
+# Access mapping is in access-entries.tf.
+#
+# Nodes: none here — Karpenter (Phase 3c follow-up PR) provisions EC2
+# dynamically. CoreDNS and Karpenter itself run on Fargate (fargate.tf) to
+# avoid the chicken-and-egg bootstrap problem.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# KMS key for EKS Secrets envelope encryption (defense in depth above the
+# default AWS-managed encryption of etcd).
+# -----------------------------------------------------------------------------
+resource "aws_kms_key" "cluster_secrets" {
+  description             = "EKS Secrets envelope encryption for cluster ${local.cluster_name}"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  tags = {
+    Name = "${local.cluster_name}-eks-secrets"
+  }
+}
+
+resource "aws_kms_alias" "cluster_secrets" {
+  name          = "alias/${local.cluster_name}-eks-secrets"
+  target_key_id = aws_kms_key.cluster_secrets.key_id
+}
+
+# -----------------------------------------------------------------------------
+# KMS key for CloudWatch Logs (cluster audit / api logs).
+# -----------------------------------------------------------------------------
+resource "aws_kms_key" "cluster_logs" {
+  description             = "CloudWatch Logs encryption for cluster ${local.cluster_name}"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  # CloudWatch Logs needs permission to use the key for the log group it
+  # writes to. This policy grants the logs service in this region to
+  # encrypt/decrypt on behalf of the log group.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableRootAccount"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${local.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowCloudWatchLogs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.${local.primary_region}.amazonaws.com" }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*",
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/eks/${local.cluster_name}/cluster"
+          }
+        }
+      },
+    ]
+  })
+
+  tags = {
+    Name = "${local.cluster_name}-eks-logs"
+  }
+}
+
+resource "aws_kms_alias" "cluster_logs" {
+  name          = "alias/${local.cluster_name}-eks-logs"
+  target_key_id = aws_kms_key.cluster_logs.key_id
+}
+
+# -----------------------------------------------------------------------------
+# CloudWatch Log Group — pre-created so we can set retention + KMS.
+# EKS will create one implicitly if this is absent, but without retention
+# (logs accumulate indefinitely) and without customer-managed encryption.
+# -----------------------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "cluster" {
+  name              = "/aws/eks/${local.cluster_name}/cluster"
+  retention_in_days = 90 # lab-appropriate; production would be 365+
+  kms_key_id        = aws_kms_key.cluster_logs.arn
+
+  tags = {
+    Name = "${local.cluster_name}-eks-logs"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cluster IAM role — assumed by the EKS service itself to manage the control
+# plane. Distinct from node roles (nodes use NodeInstanceRole or IRSA).
+# -----------------------------------------------------------------------------
+resource "aws_iam_role" "cluster" {
+  name = "${local.cluster_name}-eks-cluster-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "eks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+# AmazonEKSVPCResourceController is required when using Security Groups for
+# Pods (branch ENIs). Harmless to attach unconditionally.
+resource "aws_iam_role_policy_attachment" "cluster_vpc_resource_controller" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.cluster.name
+}
+
+# -----------------------------------------------------------------------------
+# The cluster itself
+# -----------------------------------------------------------------------------
+#checkov:skip=CKV_AWS_39: Public endpoint is intentional per ADR-013 (single-operator lab, no bastion). Access is restricted to public_access_cidrs (operator IP/32) and primary auth is AWS IAM SigV4 + Kubernetes RBAC via Access Entries.
+resource "aws_eks_cluster" "main" {
+  name     = local.cluster_name
+  role_arn = aws_iam_role.cluster.arn
+  version  = local.eks_version
+
+  vpc_config {
+    subnet_ids = concat(
+      data.terraform_remote_state.staging_network.outputs.public_subnet_ids,
+      data.terraform_remote_state.staging_network.outputs.private_subnet_ids,
+    )
+
+    endpoint_public_access  = true
+    endpoint_private_access = true
+    public_access_cidrs     = local.public_access_cidrs
+  }
+
+  encryption_config {
+    provider {
+      key_arn = aws_kms_key.cluster_secrets.arn
+    }
+    resources = ["secrets"]
+  }
+
+  access_config {
+    # API-only: all authz goes through Access Entries, not the aws-auth
+    # ConfigMap. Per ADR-013 "Operator access".
+    authentication_mode = "API"
+
+    # Do NOT grant implicit cluster-admin to whoever applies this Terraform.
+    # Access is explicit via aws_eks_access_entry resources in
+    # access-entries.tf (the CI role and the PlatformAdmin SSO role).
+    bootstrap_cluster_creator_admin_permissions = false
+  }
+
+  # All control-plane log types enabled. Cost is trivial (~$0.50/month for a
+  # lab-scale cluster); having the full audit log available is valuable for
+  # any future forensics and satisfies CKV_AWS_37.
+  enabled_cluster_log_types = [
+    "api",
+    "audit",
+    "authenticator",
+    "controllerManager",
+    "scheduler",
+  ]
+
+  # Ensure IAM attachments land before the cluster creates (or else cluster
+  # create may race ahead of the role having the necessary policies), and
+  # ensure the log group exists before the cluster starts writing to it.
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_policy,
+    aws_iam_role_policy_attachment.cluster_vpc_resource_controller,
+    aws_cloudwatch_log_group.cluster,
+  ]
+
+  tags = {
+    Name = local.cluster_name
+  }
+}

--- a/terraform/environments/staging/platform/cluster.tf
+++ b/terraform/environments/staging/platform/cluster.tf
@@ -23,6 +23,23 @@ resource "aws_kms_key" "cluster_secrets" {
   deletion_window_in_days = 30
   enable_key_rotation     = true
 
+  # Explicit root-only key policy. EKS acquires encrypt/decrypt access via
+  # the cluster IAM role (AmazonEKSClusterPolicy grants kms:DescribeKey,
+  # kms:GenerateDataKey, kms:Decrypt against keys the cluster is authorized
+  # to use — root giving the account full key access is the standard envelope
+  # encryption pattern). Explicit policy satisfies CKV2_AWS_64 and documents
+  # that no other principal can administer this key.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "EnableRootAccount"
+      Effect    = "Allow"
+      Principal = { AWS = "arn:aws:iam::${local.account_id}:root" }
+      Action    = "kms:*"
+      Resource  = "*"
+    }]
+  })
+
   tags = {
     Name = "${local.cluster_name}-eks-secrets"
   }
@@ -92,7 +109,7 @@ resource "aws_kms_alias" "cluster_logs" {
 # -----------------------------------------------------------------------------
 resource "aws_cloudwatch_log_group" "cluster" {
   name              = "/aws/eks/${local.cluster_name}/cluster"
-  retention_in_days = 90 # lab-appropriate; production would be 365+
+  retention_in_days = 365 # CKV_AWS_338 requires >= 365; teardown removes the log group anyway, so the lab cost impact is bounded by the session duration, not the retention window.
   kms_key_id        = aws_kms_key.cluster_logs.arn
 
   tags = {
@@ -132,8 +149,8 @@ resource "aws_iam_role_policy_attachment" "cluster_vpc_resource_controller" {
 # -----------------------------------------------------------------------------
 # The cluster itself
 # -----------------------------------------------------------------------------
-#checkov:skip=CKV_AWS_39: Public endpoint is intentional per ADR-013 (single-operator lab, no bastion). Access is restricted to public_access_cidrs (operator IP/32) and primary auth is AWS IAM SigV4 + Kubernetes RBAC via Access Entries.
 resource "aws_eks_cluster" "main" {
+  # checkov:skip=CKV_AWS_39: Public endpoint is intentional per ADR-013 (single-operator lab, no bastion). Access is restricted to public_access_cidrs (operator IP/32) and primary auth is AWS IAM SigV4 + Kubernetes RBAC via Access Entries.
   name     = local.cluster_name
   role_arn = aws_iam_role.cluster.arn
   version  = local.eks_version

--- a/terraform/environments/staging/platform/config.tf
+++ b/terraform/environments/staging/platform/config.tf
@@ -1,0 +1,65 @@
+# -----------------------------------------------------------------------------
+# Configuration Contract — ADR-004
+# -----------------------------------------------------------------------------
+# Every environment reads the same YAML config. No hardcoded account IDs,
+# regions, CIDRs, or cluster versions anywhere in Terraform code.
+# -----------------------------------------------------------------------------
+
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  # Convenience aliases used across this environment
+  account_id     = local.config.accounts.staging.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+
+  # EKS platform settings from config/landing-zone.yaml → eks.staging.
+  # See ADR-013 for the design of these fields and docs/runbooks/002-eks-access.md
+  # for the operational contract behind public_access_cidrs.
+  eks_version         = local.config.eks.staging.version
+  public_access_cidrs = local.config.eks.staging.public_access_cidrs
+
+  cluster_name = "${local.config.organization.name}-staging"
+
+  tags = merge(local.config.tags, {
+    Environment = "staging"
+    Component   = "platform"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Cross-layer state reads
+# -----------------------------------------------------------------------------
+# The platform layer depends on the network layer (VPC, subnets) being
+# applied first. Apply order is enforced operationally by the
+# terraform-apply-workload.yml workflow (network → platform → workloads).
+# If the network state is missing or empty, Terraform plan fails with a
+# clear error on the subnet reference below.
+# -----------------------------------------------------------------------------
+
+data "terraform_remote_state" "staging_network" {
+  backend = "s3"
+  config = {
+    bucket = "aegis-terraform-state-345895787808"
+    key    = "staging/network/terraform.tfstate"
+    region = "eu-central-1"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+check "config_eks_section_present" {
+  assert {
+    condition     = contains(keys(local.config), "eks") && contains(keys(local.config.eks), "staging")
+    error_message = "config/landing-zone.yaml is missing eks.staging section. See config/landing-zone.example.yaml and ADR-013."
+  }
+}
+
+check "network_layer_applied" {
+  assert {
+    condition = (
+      data.terraform_remote_state.staging_network.outputs != null &&
+      length(try(data.terraform_remote_state.staging_network.outputs.private_subnet_ids, [])) > 0
+    )
+    error_message = "staging/network has not been applied — private_subnet_ids is empty. Apply staging/network before staging/platform (gh workflow run terraform-apply-workload.yml -f env=staging)."
+  }
+}

--- a/terraform/environments/staging/platform/fargate.tf
+++ b/terraform/environments/staging/platform/fargate.tf
@@ -1,0 +1,79 @@
+# -----------------------------------------------------------------------------
+# Fargate profiles — host CoreDNS and Karpenter without EC2
+# -----------------------------------------------------------------------------
+# Per ADR-013 "Node provisioning", Karpenter itself runs on Fargate to avoid
+# the bootstrap chicken-and-egg problem: Karpenter provisions EC2, so
+# something has to run Karpenter before the first EC2 node exists. CoreDNS
+# also runs on Fargate for the same reason (name resolution is needed before
+# Karpenter can schedule anything).
+#
+# All other workloads land on EC2 nodes provisioned by Karpenter (Phase 3c
+# follow-up PR). Fargate is NOT the default — it is used only for these two
+# specific system-pod namespaces.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Fargate pod execution role
+# -----------------------------------------------------------------------------
+# Assumed by the Fargate control plane to pull images for the pod and write
+# logs on the pod's behalf. Not the same as the pod's own IAM role (pods
+# use IRSA for AWS API access).
+# -----------------------------------------------------------------------------
+resource "aws_iam_role" "fargate_pod_execution" {
+  name = "${local.cluster_name}-fargate-pod-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "eks-fargate-pods.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "fargate_pod_execution" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
+  role       = aws_iam_role.fargate_pod_execution.name
+}
+
+# -----------------------------------------------------------------------------
+# Fargate profile: kube-system (CoreDNS)
+# -----------------------------------------------------------------------------
+# EKS-managed CoreDNS addon is scheduled onto Fargate when no EC2 nodes are
+# available. We also need to patch the CoreDNS Deployment annotation
+# `eks.amazonaws.com/compute-type: fargate` after the Karpenter PR lands so
+# that CoreDNS stays on Fargate once EC2 capacity appears; that patch is
+# applied in the Helm/Kubernetes layer (Phase 3c follow-up PR).
+# -----------------------------------------------------------------------------
+resource "aws_eks_fargate_profile" "kube_system" {
+  cluster_name           = aws_eks_cluster.main.name
+  fargate_profile_name   = "kube-system"
+  pod_execution_role_arn = aws_iam_role.fargate_pod_execution.arn
+  subnet_ids             = data.terraform_remote_state.staging_network.outputs.private_subnet_ids
+
+  selector {
+    namespace = "kube-system"
+    labels = {
+      "k8s-app" = "kube-dns"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Fargate profile: karpenter
+# -----------------------------------------------------------------------------
+# The Karpenter controller itself runs in the `karpenter` namespace on
+# Fargate. Workload pods never run here — only the controller (one replica,
+# ~$0.04/hr on Fargate at the smallest task size).
+# -----------------------------------------------------------------------------
+resource "aws_eks_fargate_profile" "karpenter" {
+  cluster_name           = aws_eks_cluster.main.name
+  fargate_profile_name   = "karpenter"
+  pod_execution_role_arn = aws_iam_role.fargate_pod_execution.arn
+  subnet_ids             = data.terraform_remote_state.staging_network.outputs.private_subnet_ids
+
+  selector {
+    namespace = "karpenter"
+  }
+}

--- a/terraform/environments/staging/platform/oidc.tf
+++ b/terraform/environments/staging/platform/oidc.tf
@@ -1,0 +1,38 @@
+# -----------------------------------------------------------------------------
+# IRSA — IAM Roles for Service Accounts
+# -----------------------------------------------------------------------------
+# EKS issues each cluster an OIDC identity provider URL. AWS STS does not
+# trust that OIDC issuer automatically — we have to register it as an IAM
+# OIDC provider in this account before any IRSA role can use it.
+#
+# Once registered, any IAM role whose trust policy references this provider
+# plus a ServiceAccount subject condition can be assumed by a pod that
+# mounts the projected OIDC token. Per ADR-013 "Workload IAM", IRSA is the
+# chosen mechanism for all pod → AWS API access in Phase 3 (Pod Identity
+# migration is tracked in the Phase 5 backlog).
+#
+# The OIDC provider created here is consumed by:
+#   - Phase 3c (Karpenter PR)     → Karpenter controller IAM role
+#   - Phase 3c (Ingress+GitOps)   → AWS Load Balancer Controller + ArgoCD
+#   - Phase 4 (Observability)     → CloudWatch Logs / Prometheus scrape role
+# -----------------------------------------------------------------------------
+
+data "tls_certificate" "cluster_oidc" {
+  url = aws_eks_cluster.main.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "cluster" {
+  url = aws_eks_cluster.main.identity[0].oidc[0].issuer
+
+  client_id_list = ["sts.amazonaws.com"]
+
+  # Thumbprint of the root CA that signs the OIDC JWKS endpoint. EKS
+  # historically used a DigiCert-signed endpoint; AWS recommends pinning
+  # the leaf or intermediate thumbprint discovered via TLS. The
+  # hashicorp/tls provider's `data.tls_certificate` does exactly that.
+  thumbprint_list = [data.tls_certificate.cluster_oidc.certificates[0].sha1_fingerprint]
+
+  tags = {
+    Name = "${local.cluster_name}-eks-irsa"
+  }
+}

--- a/terraform/environments/staging/platform/outputs.tf
+++ b/terraform/environments/staging/platform/outputs.tf
@@ -1,0 +1,40 @@
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = aws_eks_cluster.main.name
+}
+
+output "cluster_endpoint" {
+  description = "EKS API server endpoint"
+  value       = aws_eks_cluster.main.endpoint
+}
+
+output "cluster_version" {
+  description = "EKS Kubernetes version"
+  value       = aws_eks_cluster.main.version
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64-encoded cluster CA certificate — consumed by the kubernetes/helm providers in follow-up PRs"
+  value       = aws_eks_cluster.main.certificate_authority[0].data
+  sensitive   = true
+}
+
+output "oidc_provider_arn" {
+  description = "IAM OIDC identity provider ARN for IRSA trust policies"
+  value       = aws_iam_openid_connect_provider.cluster.arn
+}
+
+output "oidc_provider_url" {
+  description = "OIDC issuer URL (no scheme) for IRSA sub claim conditions"
+  value       = replace(aws_eks_cluster.main.identity[0].oidc[0].issuer, "https://", "")
+}
+
+output "cluster_security_group_id" {
+  description = "The cluster security group AWS creates for control plane ↔ node communication"
+  value       = aws_eks_cluster.main.vpc_config[0].cluster_security_group_id
+}
+
+output "fargate_pod_execution_role_arn" {
+  description = "Fargate pod execution role ARN — reused by future Fargate profiles if added"
+  value       = aws_iam_role.fargate_pod_execution.arn
+}

--- a/terraform/environments/staging/platform/providers.tf
+++ b/terraform/environments/staging/platform/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/staging/platform/versions.tf
+++ b/terraform/environments/staging/platform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

First of three incremental PRs implementing the EKS platform per [ADR-013](../blob/main/docs/decisions/013-eks-architecture.md). This PR lands the cluster itself plus the operational contract for operator access. Karpenter and Ingress/GitOps follow in PR 2 and 3.

## What's in this PR

**New Terraservice layer — `terraform/environments/staging/platform/`**

- EKS 1.32 cluster, public+private endpoint, `public_access_cidrs` restricted to operator `/32`
- `authentication_mode = API` (Access Entries only, no aws-auth ConfigMap)
- `bootstrap_cluster_creator_admin_permissions = false` — access granted explicitly via Access Entries
- Secrets envelope encryption via customer-managed KMS
- All 5 control-plane log types, 90d retention on CMK-encrypted CloudWatch log group
- Fargate profiles host CoreDNS (`kube-system`) and the upcoming Karpenter controller (`karpenter`)
- IRSA OIDC provider ready for Karpenter / LB Controller / ArgoCD in follow-up PRs

**Access Entries**

| Principal | Kubernetes policy |
|---|---|
| `github-actions-terraform` (CI) | `AmazonEKSClusterAdminPolicy` |
| `AWSReservedSSO_PlatformAdmin_<hash>` (operator) | `AmazonEKSClusterAdminPolicy` |

**Cross-layer — `management/bootstrap/sso-assignments.tf`**

Assigns the `PlatformAdmin` Identity Center permission set to the staging account for user `bin`. This causes AWS to create the `AWSReservedSSO_PlatformAdmin_<hash>` reserved role in staging, which `access-entries.tf` then looks up via data source.

**Operational contract — new docs**

- `docs/runbooks/002-eks-access.md` — pre-flight IP check, connectivity failure diagnostic order, IP-drift update procedure. Any session that will touch EKS MUST read this first.
- `CLAUDE.md` — added a meta-rule that AI agents read a layer's runbook before operating, rather than copying the content into CLAUDE.md for every new layer. Keeps CLAUDE.md lean.

**Config contract extension**

- `config/schema.json` — new optional `eks.<env>.{version, public_access_cidrs}` section
- `config/landing-zone.example.yaml` — placeholder for the `eks` section
- Operator's local `config/landing-zone.yaml` (gitignored) — filled in separately; `LANDING_ZONE_CONFIG` GitHub secret will be refreshed before the first workload apply

## What is NOT in this PR

Deliberately split off to keep review surface small and apply risk incremental:

- **PR 2** — Karpenter v1: controller Helm release, `NodePool`, `EC2NodeClass`, IAM (NodeRole + ControllerRole via IRSA)
- **PR 3** — AWS Load Balancer Controller + ArgoCD bootstrap + app-of-apps root `Application` pointing at `aegis-core`

## Plan will fail on this PR — this is expected

`staging/network` is currently torn down ($0 cost state). The `check` block in `config.tf` explicitly reports "network layer has not been applied". Plan cannot succeed until the VPC is rebuilt via:

```
gh workflow run terraform-apply-workload.yml -f env=staging
```

The PR is intentionally open for code review first, NOT for CI plan review. Review the diff; do not wait for a green plan.

## Apply sequence (post-merge)

1. Merge this PR.
2. `terraform-apply-baseline.yml` auto-runs on merge (paths filter matches `management/**`, `staging/platform/**`). The baseline apply lands the SSO assignment and the schema/example yaml update. It will NOT apply `staging/platform` because that path is excluded from the baseline workflow (see ADR-009 / `terraform-apply-baseline.yml` paths).
3. Rebuild VPC — `gh workflow run terraform-apply-workload.yml -f env=staging` + approve.
4. Once VPC is up, the same workload workflow's `apply-platform` job applies this layer.

See the new platform README (`terraform/environments/staging/platform/README.md`) for the full cost profile and teardown command.

## Validation done locally

```
terraform fmt -recursive    (staging/platform)          OK
terraform validate          (staging/platform)          OK
terraform validate          (management/bootstrap)      OK
jsonschema validate         (landing-zone.yaml + schema) OK
```

## Test plan

- [ ] Code review: Access Entries, KMS policies, Fargate selectors, check blocks
- [ ] Runbook 002 reads cleanly top-to-bottom
- [ ] CLAUDE.md meta-rule fits existing Rule: style
- [ ] After merge: baseline workflow applies cleanly (management/bootstrap + staging/bootstrap config changes)
- [ ] Refresh `LANDING_ZONE_CONFIG` secret (contains eks.staging section) before dispatching workload apply
- [ ] Rebuild VPC via workflow_dispatch
- [ ] Apply staging/platform via workflow_dispatch, verify cluster is ACTIVE and both Access Entries exist
- [ ] `aws eks update-kubeconfig --name aegis-staging --region eu-central-1` + `kubectl get nodes` (should show Fargate pods for CoreDNS once Karpenter PR lands; at this stage Fargate profiles exist but no pods are scheduled yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)