### PR TITLE
chore: gitignore .claude/ local session state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ Thumbs.db
 *.swp
 *.swo
 *~
+
+# Claude Code — local session state, schedule locks, per-user settings.
+# Never committed. Includes .claude/settings.local.json which may contain
+# operator-specific paths.
+.claude/


### PR DESCRIPTION
## Summary

The \`.claude/\` directory is written by Claude Code during interactive sessions and contains:
- \`scheduled_tasks.lock\` — session-local schedule state
- \`settings.local.json\` — per-operator paths and preferences

Neither should be committed. Adding the directory to \`.gitignore\` so a future \`git add .\` in a session does not accidentally include it.

No-op for CI / infra.

## Test plan

- [ ] Checkov: passes (no infra changes)
- [ ] Plans: all no-change

🤖 Generated with [Claude Code](https://claude.com/claude-code)