### PR TITLE
feat(platform): Karpenter v1 (Phase 3c PR 2/3)

### DIFF
--- a/terraform/environments/staging/platform/.terraform.lock.hcl
+++ b/terraform/environments/staging/platform/.terraform.lock.hcl
@@ -24,6 +24,46 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.17"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.2.1"
   constraints = "~> 4.0"

--- a/terraform/environments/staging/platform/README.md
+++ b/terraform/environments/staging/platform/README.md
@@ -1,8 +1,8 @@
 # staging/platform
 
-The EKS platform layer for `aegis-staging`. Contains the EKS cluster, Fargate profiles for system pods (CoreDNS, Karpenter controller), the IRSA OIDC provider, and Access Entries mapping the CI role and the operator's SSO role to Kubernetes cluster-admin.
+The EKS platform layer for `aegis-staging`. Contains the EKS cluster, Fargate profiles for system pods (CoreDNS, Karpenter controller), the IRSA OIDC provider, Access Entries mapping the CI role and operator SSO role to Kubernetes cluster-admin, and **Karpenter v1** (controller on Fargate + default NodePool + EC2NodeClass).
 
-Karpenter, the AWS Load Balancer Controller, and ArgoCD are intentionally NOT in this layer — they land in follow-up PRs in Phase 3c so each can be reviewed and applied independently.
+The AWS Load Balancer Controller and ArgoCD are intentionally NOT in this layer — they land in Phase 3c PR 3 so each can be reviewed and applied independently.
 
 ---
 
@@ -37,12 +37,15 @@ Apply ordering is enforced operationally by the CI workflow split:
 
 ## Cost profile
 
-Apply triggers ~$0.28/hr ongoing while the cluster is running:
+Apply triggers ~$0.30/hr ongoing while the cluster is running:
 
 | Component | Approximate cost while running |
 |---|---|
 | EKS control plane | $0.10/hr (~$73/month always-on) |
 | Fargate (CoreDNS + Karpenter controller, ~3 pods) | ~$0.12/hr |
+| Karpenter-managed Spot EC2 (when there are workloads) | ~$0.01/hr per small instance |
+| SQS (Karpenter interruption queue) | $0 at lab message volume |
+| EventBridge rules (4x) | $0 at lab event volume |
 | CloudWatch Logs (5 log types at lab traffic) | pennies/day |
 | KMS keys (2) | $2/month (fixed, $0.03/day not teardown-able) |
 
@@ -69,16 +72,20 @@ This destroys `staging/workloads` → `staging/platform` → `staging/network` i
 
 ```
 staging/platform/
-├── backend.tf           # S3 state backend
-├── versions.tf          # Terraform + provider constraints
-├── providers.tf         # AWS provider with account ID safety
-├── config.tf            # Reads config/landing-zone.yaml + cross-layer state
-├── cluster.tf           # IAM + KMS + log group + aws_eks_cluster
-├── fargate.tf           # Fargate pod execution role + profiles
-├── oidc.tf              # IRSA OIDC provider
-├── access-entries.tf    # CI role + operator SSO role → cluster-admin
-├── outputs.tf           # Consumed by Karpenter / LB Controller / ArgoCD PRs
-└── README.md            # This file
+├── backend.tf                    # S3 state backend
+├── versions.tf                   # Terraform + provider constraints (aws, tls, helm, kubernetes)
+├── providers.tf                  # AWS + Helm + Kubernetes providers (exec plugin for EKS auth)
+├── config.tf                     # Reads config/landing-zone.yaml + cross-layer state
+├── cluster.tf                    # IAM + KMS + log group + aws_eks_cluster
+├── fargate.tf                    # Fargate pod execution role + profiles
+├── oidc.tf                       # IRSA OIDC provider
+├── access-entries.tf             # CI role + operator SSO role → cluster-admin
+├── karpenter-iam.tf              # Node role + controller IRSA role + EC2_LINUX access entry
+├── karpenter-interruption.tf     # SQS queue + EventBridge rules for Spot interruption handling
+├── karpenter-helm.tf             # Karpenter controller Helm release on Fargate
+├── karpenter-nodepool.tf         # Default NodePool + EC2NodeClass (Spot, 4 vCPU cap, Bottlerocket)
+├── outputs.tf                    # Consumed by LB Controller / ArgoCD PRs
+└── README.md                     # This file
 ```
 
 ---

--- a/terraform/environments/staging/platform/config.tf
+++ b/terraform/environments/staging/platform/config.tf
@@ -12,6 +12,10 @@ locals {
   account_id     = local.config.accounts.staging.id
   primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
 
+  # Zones for the primary region, consumed by Karpenter NodePool topology
+  # constraints (karpenter-nodepool.tf).
+  primary_zones = [for r in local.config.regions : r.zones if r.name == local.primary_region][0]
+
   # EKS platform settings from config/landing-zone.yaml → eks.staging.
   # See ADR-013 for the design of these fields and docs/runbooks/002-eks-access.md
   # for the operational contract behind public_access_cidrs.

--- a/terraform/environments/staging/platform/karpenter-helm.tf
+++ b/terraform/environments/staging/platform/karpenter-helm.tf
@@ -1,0 +1,84 @@
+# -----------------------------------------------------------------------------
+# Karpenter controller — Helm install
+# -----------------------------------------------------------------------------
+# Installs the Karpenter controller via the official OCI Helm chart. The
+# chart manages the ServiceAccount, Deployment, webhooks, RBAC, and CRDs
+# (NodePool, NodeClaim, EC2NodeClass) that karpenter-nodepool.tf consumes.
+#
+# The controller runs in the `karpenter` namespace, which is hosted on
+# Fargate via the Fargate profile created in fargate.tf (PR 1). This
+# breaks the chicken-and-egg bootstrap: Karpenter provisions EC2, so it
+# has to run somewhere that is NOT on an EC2 node it provisions itself.
+#
+# Chart version is pinned. Bumping requires a PR that both updates the
+# pin and verifies the release notes for breaking changes (Karpenter v1
+# made several breaking changes vs v0.x; treat minor bumps as suspect).
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "karpenter" {
+  name       = "karpenter"
+  namespace  = "karpenter"
+  repository = "oci://public.ecr.aws/karpenter"
+  chart      = "karpenter"
+  version    = "1.0.8"
+
+  # Ensure the namespace and Fargate profile exist before installing.
+  # The Fargate profile won't match pods until after install because Helm
+  # creates the Deployment in the same transaction — Kubernetes schedules
+  # the pods onto Fargate once the profile's namespace selector matches.
+
+  values = [
+    yamlencode({
+      # Chart settings block controls Karpenter's cluster connection.
+      settings = {
+        clusterName       = aws_eks_cluster.main.name
+        clusterEndpoint   = aws_eks_cluster.main.endpoint
+        interruptionQueue = aws_sqs_queue.karpenter_interruption.name
+        # featureGates expected to stabilize further in v1.x; leave defaults.
+      }
+
+      # ServiceAccount is annotated with the IRSA role ARN. Karpenter's
+      # AWS SDK calls will use temporary credentials derived from the
+      # cluster's OIDC token.
+      serviceAccount = {
+        name = "karpenter"
+        annotations = {
+          "eks.amazonaws.com/role-arn" = aws_iam_role.karpenter_controller.arn
+        }
+      }
+
+      # Controller must tolerate scheduling on Fargate. Fargate pods do
+      # not have the typical node taints, so this is a no-op in practice
+      # but keeps the chart behavior explicit for reviewers.
+      controller = {
+        resources = {
+          requests = {
+            cpu    = "250m"
+            memory = "512Mi"
+          }
+          limits = {
+            cpu    = "500m"
+            memory = "512Mi"
+          }
+        }
+      }
+
+      # Replica count = 1 on Fargate. Karpenter's leader-election handles
+      # HA when running multiple replicas on EC2, but on Fargate each
+      # replica is a separate billed pod. For a lab, single replica is
+      # sufficient; a production deployment would set replicas = 2 across
+      # AZs (which requires EC2-backed nodes or a wider Fargate profile).
+      replicas = 1
+    }),
+  ]
+
+  # Explicit dependencies on upstream prerequisites. Terraform doesn't
+  # infer these automatically because the Helm provider's "kubernetes
+  # needs to be reachable" is a coarser check than "the Fargate profile
+  # admits this namespace's pods".
+  depends_on = [
+    aws_eks_cluster.main,
+    aws_eks_fargate_profile.karpenter,
+    aws_iam_role_policy.karpenter_controller,
+  ]
+}

--- a/terraform/environments/staging/platform/karpenter-iam.tf
+++ b/terraform/environments/staging/platform/karpenter-iam.tf
@@ -1,0 +1,356 @@
+# -----------------------------------------------------------------------------
+# Karpenter IAM — node role + controller IRSA role
+# -----------------------------------------------------------------------------
+# Two roles:
+#
+#   1. Node role — attached to EC2 instances Karpenter provisions. Standard
+#      EKS worker role (the same policies a managed node group would have).
+#      The cluster admits these instances via an aws_eks_access_entry of
+#      type "EC2_LINUX", which is the Access Entry replacement for the
+#      aws-auth ConfigMap's system:nodes mapping.
+#
+#   2. Controller role — assumed by the Karpenter controller pod via IRSA.
+#      Wide-ranging but scoped by resource tags to only act on EC2
+#      resources tagged with this cluster. Policy structure follows the
+#      Karpenter v1 official template.
+#
+# See ADR-013 "Workload IAM" for the IRSA rationale.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Node role — carries workload nodes' AWS permissions
+# -----------------------------------------------------------------------------
+resource "aws_iam_role" "karpenter_node" {
+  name = "${local.cluster_name}-karpenter-node"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_node_worker" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.karpenter_node.name
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_node_cni" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.karpenter_node.name
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_node_ecr" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.karpenter_node.name
+}
+
+# SSM access so the operator can troubleshoot a node via AWS Systems Manager
+# Session Manager (no SSH key pair, no bastion).
+resource "aws_iam_role_policy_attachment" "karpenter_node_ssm" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.karpenter_node.name
+}
+
+resource "aws_iam_instance_profile" "karpenter_node" {
+  name = "${local.cluster_name}-karpenter-node"
+  role = aws_iam_role.karpenter_node.name
+}
+
+# -----------------------------------------------------------------------------
+# Controller role — assumed by the Karpenter controller pod via IRSA
+# -----------------------------------------------------------------------------
+# Trust policy: federated via the cluster's OIDC provider, scoped to the
+# ServiceAccount `karpenter/karpenter` that the Helm chart creates. No other
+# pod can assume this role.
+# -----------------------------------------------------------------------------
+resource "aws_iam_role" "karpenter_controller" {
+  name = "${local.cluster_name}-karpenter-controller"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = aws_iam_openid_connect_provider.cluster.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.oidc_host}:aud" = "sts.amazonaws.com"
+          "${local.oidc_host}:sub" = "system:serviceaccount:karpenter:karpenter"
+        }
+      }
+    }]
+  })
+}
+
+locals {
+  oidc_host = replace(aws_eks_cluster.main.identity[0].oidc[0].issuer, "https://", "")
+}
+
+# -----------------------------------------------------------------------------
+# Controller inline policy — Karpenter v1 canonical, scoped by cluster tag
+# -----------------------------------------------------------------------------
+# All EC2/fleet/launch-template actions are conditioned on the resource or
+# request carrying `aws:RequestTag/kubernetes.io/cluster/<cluster-name>=owned`
+# or `aws:ResourceTag/kubernetes.io/cluster/<cluster-name>=owned`. This is
+# how Karpenter's IAM scope remains "only this cluster" even though the
+# role has broad service-level permissions.
+#
+# Source: https://karpenter.sh/v1.0/reference/cloudformation/
+# -----------------------------------------------------------------------------
+resource "aws_iam_role_policy" "karpenter_controller" {
+  name = "${local.cluster_name}-karpenter-controller"
+  role = aws_iam_role.karpenter_controller.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowScopedEC2InstanceAccessActions"
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:ec2:${local.primary_region}::image/*",
+          "arn:aws:ec2:${local.primary_region}::snapshot/*",
+          "arn:aws:ec2:${local.primary_region}:*:security-group/*",
+          "arn:aws:ec2:${local.primary_region}:*:subnet/*",
+          "arn:aws:ec2:${local.primary_region}:*:capacity-reservation/*",
+        ]
+        Action = ["ec2:RunInstances", "ec2:CreateFleet"]
+      },
+      {
+        Sid      = "AllowScopedEC2LaunchTemplateAccessActions"
+        Effect   = "Allow"
+        Resource = "arn:aws:ec2:${local.primary_region}:*:launch-template/*"
+        Action   = ["ec2:RunInstances", "ec2:CreateFleet"]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.cluster_name}" = "owned"
+          }
+          StringLike = {
+            "aws:ResourceTag/karpenter.sh/nodepool" = "*"
+          }
+        }
+      },
+      {
+        Sid    = "AllowScopedEC2InstanceActionsWithTags"
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:ec2:${local.primary_region}:*:fleet/*",
+          "arn:aws:ec2:${local.primary_region}:*:instance/*",
+          "arn:aws:ec2:${local.primary_region}:*:volume/*",
+          "arn:aws:ec2:${local.primary_region}:*:network-interface/*",
+          "arn:aws:ec2:${local.primary_region}:*:launch-template/*",
+          "arn:aws:ec2:${local.primary_region}:*:spot-instances-request/*",
+        ]
+        Action = ["ec2:RunInstances", "ec2:CreateFleet", "ec2:CreateLaunchTemplate"]
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/kubernetes.io/cluster/${local.cluster_name}" = "owned"
+          }
+          StringLike = {
+            "aws:RequestTag/karpenter.sh/nodepool" = "*"
+          }
+        }
+      },
+      {
+        Sid    = "AllowScopedResourceCreationTagging"
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:ec2:${local.primary_region}:*:fleet/*",
+          "arn:aws:ec2:${local.primary_region}:*:instance/*",
+          "arn:aws:ec2:${local.primary_region}:*:volume/*",
+          "arn:aws:ec2:${local.primary_region}:*:network-interface/*",
+          "arn:aws:ec2:${local.primary_region}:*:launch-template/*",
+          "arn:aws:ec2:${local.primary_region}:*:spot-instances-request/*",
+        ]
+        Action = "ec2:CreateTags"
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/kubernetes.io/cluster/${local.cluster_name}" = "owned"
+            "ec2:CreateAction" = [
+              "RunInstances",
+              "CreateFleet",
+              "CreateLaunchTemplate",
+            ]
+          }
+          StringLike = {
+            "aws:RequestTag/karpenter.sh/nodepool" = "*"
+          }
+        }
+      },
+      {
+        Sid      = "AllowScopedResourceTagging"
+        Effect   = "Allow"
+        Resource = "arn:aws:ec2:${local.primary_region}:*:instance/*"
+        Action   = "ec2:CreateTags"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.cluster_name}" = "owned"
+          }
+          StringLike = {
+            "aws:ResourceTag/karpenter.sh/nodepool" = "*"
+          }
+          StringEqualsIfExists = {
+            "aws:RequestTag/karpenter.sh/nodeclaim" = "*"
+          }
+          "ForAllValues:StringEquals" = {
+            "aws:TagKeys" = ["karpenter.sh/nodeclaim", "Name"]
+          }
+        }
+      },
+      {
+        Sid    = "AllowScopedDeletion"
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:ec2:${local.primary_region}:*:instance/*",
+          "arn:aws:ec2:${local.primary_region}:*:launch-template/*",
+        ]
+        Action = ["ec2:TerminateInstances", "ec2:DeleteLaunchTemplate"]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.cluster_name}" = "owned"
+          }
+          StringLike = {
+            "aws:ResourceTag/karpenter.sh/nodepool" = "*"
+          }
+        }
+      },
+      {
+        Sid      = "AllowRegionalReadActions"
+        Effect   = "Allow"
+        Resource = "*"
+        Action = [
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceTypeOfferings",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeLaunchTemplates",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSpotPriceHistory",
+          "ec2:DescribeSubnets",
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:RequestedRegion" = local.primary_region
+          }
+        }
+      },
+      {
+        Sid      = "AllowSSMReadActions"
+        Effect   = "Allow"
+        Resource = "arn:aws:ssm:${local.primary_region}::parameter/aws/service/*"
+        Action   = "ssm:GetParameter"
+      },
+      {
+        Sid      = "AllowPricingReadActions"
+        Effect   = "Allow"
+        Resource = "*"
+        Action   = "pricing:GetProducts"
+      },
+      {
+        Sid      = "AllowInterruptionQueueActions"
+        Effect   = "Allow"
+        Resource = aws_sqs_queue.karpenter_interruption.arn
+        Action = [
+          "sqs:DeleteMessage",
+          "sqs:GetQueueUrl",
+          "sqs:ReceiveMessage",
+        ]
+      },
+      {
+        Sid      = "AllowPassingInstanceRole"
+        Effect   = "Allow"
+        Resource = aws_iam_role.karpenter_node.arn
+        Action   = "iam:PassRole"
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = ["ec2.amazonaws.com"]
+          }
+        }
+      },
+      {
+        Sid      = "AllowScopedInstanceProfileCreationActions"
+        Effect   = "Allow"
+        Resource = "arn:aws:iam::${local.account_id}:instance-profile/*"
+        Action   = ["iam:CreateInstanceProfile"]
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/kubernetes.io/cluster/${local.cluster_name}" = "owned"
+            "aws:RequestTag/topology.kubernetes.io/region"               = local.primary_region
+          }
+          StringLike = {
+            "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass" = "*"
+          }
+        }
+      },
+      {
+        Sid      = "AllowScopedInstanceProfileTagActions"
+        Effect   = "Allow"
+        Resource = "arn:aws:iam::${local.account_id}:instance-profile/*"
+        Action   = ["iam:TagInstanceProfile"]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.cluster_name}" = "owned"
+            "aws:ResourceTag/topology.kubernetes.io/region"               = local.primary_region
+            "aws:RequestTag/kubernetes.io/cluster/${local.cluster_name}"  = "owned"
+            "aws:RequestTag/topology.kubernetes.io/region"                = local.primary_region
+          }
+          StringLike = {
+            "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass" = "*"
+            "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass"  = "*"
+          }
+        }
+      },
+      {
+        Sid      = "AllowScopedInstanceProfileActions"
+        Effect   = "Allow"
+        Resource = "arn:aws:iam::${local.account_id}:instance-profile/*"
+        Action = [
+          "iam:AddRoleToInstanceProfile",
+          "iam:RemoveRoleFromInstanceProfile",
+          "iam:DeleteInstanceProfile",
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/kubernetes.io/cluster/${local.cluster_name}" = "owned"
+            "aws:ResourceTag/topology.kubernetes.io/region"               = local.primary_region
+          }
+          StringLike = {
+            "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass" = "*"
+          }
+        }
+      },
+      {
+        Sid      = "AllowInstanceProfileReadActions"
+        Effect   = "Allow"
+        Resource = "arn:aws:iam::${local.account_id}:instance-profile/*"
+        Action   = "iam:GetInstanceProfile"
+      },
+      {
+        Sid      = "AllowAPIServerEndpointDiscovery"
+        Effect   = "Allow"
+        Resource = aws_eks_cluster.main.arn
+        Action   = "eks:DescribeCluster"
+      },
+    ]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Access Entry — admits Karpenter-provisioned EC2 instances to the cluster
+# -----------------------------------------------------------------------------
+# Access Entry type EC2_LINUX grants the node role a built-in bundle
+# of K8s permissions equivalent to the legacy system:nodes mapping in
+# aws-auth. No policy association is needed.
+# -----------------------------------------------------------------------------
+resource "aws_eks_access_entry" "karpenter_node" {
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = aws_iam_role.karpenter_node.arn
+  type          = "EC2_LINUX"
+}

--- a/terraform/environments/staging/platform/karpenter-interruption.tf
+++ b/terraform/environments/staging/platform/karpenter-interruption.tf
@@ -1,0 +1,130 @@
+# -----------------------------------------------------------------------------
+# Karpenter spot interruption handling — SQS + EventBridge
+# -----------------------------------------------------------------------------
+# Karpenter provisions Spot instances by default (per ADR-013 Consequences).
+# Spot instances can be reclaimed by AWS with 2 minutes of warning. When that
+# happens, AWS publishes a SpotInterruption event on the default EventBridge
+# bus. Karpenter watches for these events via an SQS queue it polls, and
+# proactively cordon-drains the about-to-be-reclaimed node while launching
+# a replacement — converting a surprise interruption into a graceful drain.
+#
+# Without this wiring, Spot reclamation just terminates the instance and
+# whatever was scheduled on it disappears. With it, workloads get a clean
+# eviction notice and typically migrate before the underlying node dies.
+#
+# The queue + rule are cluster-scoped: the Karpenter controller IAM policy
+# (karpenter-iam.tf) grants `sqs:ReceiveMessage` / `sqs:DeleteMessage` only
+# on THIS queue's ARN. Per-cluster isolation, even when multiple clusters
+# run in the same account.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# SQS queue — the target for EventBridge rules below
+# -----------------------------------------------------------------------------
+# The queue name is bounded by SQS's 80-character limit; prefixing with the
+# cluster name keeps it unique without hashing.
+# -----------------------------------------------------------------------------
+resource "aws_sqs_queue" "karpenter_interruption" {
+  name                      = "${local.cluster_name}-karpenter-interruption"
+  message_retention_seconds = 300 # 5 min — interruption notices are only
+  # actionable within the 2-minute warning window; retaining longer is
+  # pointless and just widens the DLQ candidate window.
+  sqs_managed_sse_enabled = true
+
+  tags = {
+    Name = "${local.cluster_name}-karpenter-interruption"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Queue policy — only the EventBridge rules we define below may send to it
+# -----------------------------------------------------------------------------
+resource "aws_sqs_queue_policy" "karpenter_interruption" {
+  queue_url = aws_sqs_queue.karpenter_interruption.url
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AllowEventBridge"
+      Effect = "Allow"
+      Principal = {
+        Service = [
+          "events.amazonaws.com",
+          "sqs.amazonaws.com",
+        ]
+      }
+      Action   = "sqs:SendMessage"
+      Resource = aws_sqs_queue.karpenter_interruption.arn
+    }]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# EventBridge rules — four event types route to the same queue
+# -----------------------------------------------------------------------------
+# 1. Spot interruption warning — AWS will reclaim the instance in ~2 min.
+# 2. Scheduled change — AWS-initiated retirement (hardware failure, etc.).
+# 3. Instance state change — instance is Terminated / Stopping outside
+#    Karpenter's control. Karpenter reconciles its view of nodes.
+# 4. Rebalance recommendation — low-severity hint that Spot capacity is
+#    under pressure; Karpenter can preemptively move workloads.
+# -----------------------------------------------------------------------------
+resource "aws_cloudwatch_event_rule" "karpenter_spot_interruption" {
+  name        = "${local.cluster_name}-karpenter-spot-interruption"
+  description = "Spot interruption warning → Karpenter interruption queue"
+
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Spot Instance Interruption Warning"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "karpenter_spot_interruption" {
+  rule = aws_cloudwatch_event_rule.karpenter_spot_interruption.name
+  arn  = aws_sqs_queue.karpenter_interruption.arn
+}
+
+resource "aws_cloudwatch_event_rule" "karpenter_scheduled_change" {
+  name        = "${local.cluster_name}-karpenter-scheduled-change"
+  description = "AWS Health scheduled change → Karpenter interruption queue"
+
+  event_pattern = jsonencode({
+    source      = ["aws.health"]
+    detail-type = ["AWS Health Event"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "karpenter_scheduled_change" {
+  rule = aws_cloudwatch_event_rule.karpenter_scheduled_change.name
+  arn  = aws_sqs_queue.karpenter_interruption.arn
+}
+
+resource "aws_cloudwatch_event_rule" "karpenter_instance_state_change" {
+  name        = "${local.cluster_name}-karpenter-instance-state-change"
+  description = "EC2 instance state change → Karpenter interruption queue"
+
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Instance State-change Notification"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "karpenter_instance_state_change" {
+  rule = aws_cloudwatch_event_rule.karpenter_instance_state_change.name
+  arn  = aws_sqs_queue.karpenter_interruption.arn
+}
+
+resource "aws_cloudwatch_event_rule" "karpenter_rebalance" {
+  name        = "${local.cluster_name}-karpenter-rebalance"
+  description = "EC2 rebalance recommendation → Karpenter interruption queue"
+
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Instance Rebalance Recommendation"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "karpenter_rebalance" {
+  rule = aws_cloudwatch_event_rule.karpenter_rebalance.name
+  arn  = aws_sqs_queue.karpenter_interruption.arn
+}

--- a/terraform/environments/staging/platform/karpenter-nodepool.tf
+++ b/terraform/environments/staging/platform/karpenter-nodepool.tf
@@ -1,0 +1,155 @@
+# -----------------------------------------------------------------------------
+# Karpenter default NodePool + EC2NodeClass
+# -----------------------------------------------------------------------------
+# A NodePool declares the constraints Karpenter uses when choosing which
+# EC2 instances to launch for pending pods (instance types, zones, capacity
+# type — spot vs on-demand). An EC2NodeClass declares AWS-specific launch
+# parameters shared across NodePools (subnet / SG selection, AMI family,
+# instance profile).
+#
+# Defaults chosen here:
+#   - Spot capacity first, On-Demand fallback disabled (lab cost tuning).
+#     Workloads that require stable capacity should define their own
+#     NodePool with `capacity-type: on-demand`.
+#   - Instance size capped at 4 vCPU / 16 GiB. A lab does not need 8xlarge
+#     and this prevents a misbehaving deployment from inadvertently
+#     launching large Spot instances.
+#   - Bottlerocket AMI family — minimal, immutable, container-optimized.
+#     Reduces node attack surface vs AL2023.
+#   - Subnets and security groups discovered by tag. The network layer
+#     (staging/network) tags private subnets with
+#     `kubernetes.io/role/internal-elb = 1` — we reuse that tag here.
+#   - 30-minute node lifecycle — nodes are recycled at least every 30
+#     minutes to pick up AMI patches and security updates.
+# -----------------------------------------------------------------------------
+
+# Server-side apply is required for Karpenter v1 manifests because the
+# API ships OpenAPI schema validation that `kubernetes_manifest` uses at
+# plan time. Requires a running cluster to plan.
+resource "kubernetes_manifest" "karpenter_default_ec2nodeclass" {
+  manifest = {
+    apiVersion = "karpenter.k8s.aws/v1"
+    kind       = "EC2NodeClass"
+    metadata = {
+      name = "default"
+    }
+    spec = {
+      amiFamily = "Bottlerocket"
+
+      # Use the latest Karpenter-resolved Bottlerocket AMI for the cluster's
+      # Kubernetes minor version. The `@latest` alias follows AWS's published
+      # SSM parameters and picks up patched AMIs on next node roll.
+      amiSelectorTerms = [{
+        alias = "bottlerocket@latest"
+      }]
+
+      subnetSelectorTerms = [{
+        tags = {
+          "kubernetes.io/role/internal-elb" = "1"
+        }
+      }]
+
+      securityGroupSelectorTerms = [{
+        tags = {
+          "aws:eks:cluster-name" = aws_eks_cluster.main.name
+        }
+      }]
+
+      role = aws_iam_role.karpenter_node.name
+
+      tags = merge(local.tags, {
+        "karpenter.sh/discovery"                             = aws_eks_cluster.main.name
+        "kubernetes.io/cluster/${aws_eks_cluster.main.name}" = "owned"
+        "topology.kubernetes.io/region"                      = local.primary_region
+      })
+    }
+  }
+
+  depends_on = [helm_release.karpenter]
+}
+
+resource "kubernetes_manifest" "karpenter_default_nodepool" {
+  manifest = {
+    apiVersion = "karpenter.sh/v1"
+    kind       = "NodePool"
+    metadata = {
+      name = "default"
+    }
+    spec = {
+      template = {
+        spec = {
+          nodeClassRef = {
+            group = "karpenter.k8s.aws"
+            kind  = "EC2NodeClass"
+            name  = "default"
+          }
+
+          # Instance-class constraints.
+          requirements = [
+            {
+              key      = "karpenter.k8s.aws/instance-category"
+              operator = "In"
+              values   = ["t", "m", "c"] # general-purpose / compute
+            },
+            {
+              key      = "karpenter.k8s.aws/instance-generation"
+              operator = "Gt"
+              values   = ["2"] # no gen-2 or older (t2, m3, etc.)
+            },
+            {
+              key      = "karpenter.k8s.aws/instance-cpu"
+              operator = "In"
+              values   = ["2", "4"] # cap at 4 vCPU
+            },
+            {
+              key      = "kubernetes.io/arch"
+              operator = "In"
+              values   = ["amd64"] # arm64 can be added once workloads support it
+            },
+            {
+              key      = "kubernetes.io/os"
+              operator = "In"
+              values   = ["linux"]
+            },
+            {
+              key      = "karpenter.sh/capacity-type"
+              operator = "In"
+              values   = ["spot"] # lab cost tuning — no on-demand fallback
+            },
+            {
+              key      = "topology.kubernetes.io/zone"
+              operator = "In"
+              values   = local.primary_zones
+            },
+          ]
+
+          # Nodes expire and recycle after 30 minutes. Forces regular
+          # AMI patch pickup and prevents Spot instances from staying
+          # attached indefinitely.
+          expireAfter = "30m"
+        }
+      }
+
+      # When no pods need a node, Karpenter deletes it after 30 seconds.
+      # Aggressive vs production (where you'd keep warm capacity); appropriate
+      # for a lab that teardowns between sessions.
+      disruption = {
+        consolidationPolicy = "WhenEmptyOrUnderutilized"
+        consolidateAfter    = "30s"
+      }
+
+      # Hard ceiling — even if many pods pile up, never launch more than
+      # 4 vCPU and 16 GiB total across this pool. This is the cost
+      # back-stop: anything past this limit blocks scheduling rather than
+      # spending money.
+      limits = {
+        cpu    = "4"
+        memory = "16Gi"
+      }
+    }
+  }
+
+  depends_on = [
+    kubernetes_manifest.karpenter_default_ec2nodeclass,
+  ]
+}

--- a/terraform/environments/staging/platform/outputs.tf
+++ b/terraform/environments/staging/platform/outputs.tf
@@ -38,3 +38,23 @@ output "fargate_pod_execution_role_arn" {
   description = "Fargate pod execution role ARN — reused by future Fargate profiles if added"
   value       = aws_iam_role.fargate_pod_execution.arn
 }
+
+# -----------------------------------------------------------------------------
+# Karpenter outputs — consumed by downstream PRs (LB Controller discovers
+# node role tags; ArgoCD may reference the NodePool name for app placement).
+# -----------------------------------------------------------------------------
+
+output "karpenter_node_role_arn" {
+  description = "Karpenter-managed EC2 node IAM role ARN"
+  value       = aws_iam_role.karpenter_node.arn
+}
+
+output "karpenter_controller_role_arn" {
+  description = "Karpenter controller IAM role ARN (IRSA-bound to karpenter/karpenter SA)"
+  value       = aws_iam_role.karpenter_controller.arn
+}
+
+output "karpenter_interruption_queue_name" {
+  description = "SQS queue name Karpenter polls for Spot / scheduled-change events"
+  value       = aws_sqs_queue.karpenter_interruption.name
+}

--- a/terraform/environments/staging/platform/providers.tf
+++ b/terraform/environments/staging/platform/providers.tf
@@ -7,3 +7,40 @@ provider "aws" {
 
   allowed_account_ids = [local.account_id]
 }
+
+# -----------------------------------------------------------------------------
+# Kubernetes / Helm providers — authenticate to the EKS cluster via the AWS
+# CLI `get-token` exec plugin. This mirrors what `aws eks update-kubeconfig`
+# writes to a human operator's kubeconfig, but keeps the authentication
+# dynamic: when this Terraform runs in CI under the github-actions-terraform
+# role (which is mapped to cluster-admin via access-entries.tf), that is the
+# identity used for Kubernetes API calls. When run locally by the operator,
+# the PlatformAdmin SSO session is used.
+#
+# The exec block, rather than a static token, avoids storing short-lived
+# credentials in the plan and keeps this configuration independent of which
+# principal applies the layer.
+# -----------------------------------------------------------------------------
+provider "kubernetes" {
+  host                   = aws_eks_cluster.main.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.main.certificate_authority[0].data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.main.name, "--region", local.primary_region]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = aws_eks_cluster.main.endpoint
+    cluster_ca_certificate = base64decode(aws_eks_cluster.main.certificate_authority[0].data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.main.name, "--region", local.primary_region]
+    }
+  }
+}

--- a/terraform/environments/staging/platform/versions.tf
+++ b/terraform/environments/staging/platform/versions.tf
@@ -10,5 +10,13 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds dynamic node provisioning via Karpenter v1.0.8 on the staging EKS cluster from PR #39. Second of three incremental Phase 3c PRs; PR 3 (AWS Load Balancer Controller + ArgoCD) follows.

## Design

Per ADR-013 "Node provisioning":
- **Controller on Fargate** (the Fargate profile was pre-created in PR #39 for exactly this reason). Breaks the chicken-and-egg: Karpenter provisions EC2, so it cannot depend on EC2 itself.
- **Spot-first workload pool**. The default NodePool is spot-only; workloads needing stable capacity will need their own on-demand NodePool (not in scope here).
- **Cluster-scoped IAM**. Controller permissions scoped via \`aws:ResourceTag/kubernetes.io/cluster/<name>=owned\` + \`aws:RequestTag/karpenter.sh/nodepool=*\`. The role has broad EC2 action surface but cannot act on resources belonging to other clusters or out-of-scope workloads.
- **Proactive interruption handling**. SQS + EventBridge rules surface Spot interruption warnings, AWS Health events, instance state changes, and rebalance recommendations to Karpenter, which cordon-drains instances before AWS reclaims them.

## What's new in this PR

| File | Purpose |
|---|---|
| \`karpenter-iam.tf\` | Node role (worker/CNI/ECR-read/SSM) + instance profile + controller IRSA role + cluster-scoped inline policy + EC2_LINUX access entry |
| \`karpenter-interruption.tf\` | SQS queue + 4 EventBridge rules (spot interruption / AWS Health / state change / rebalance) |
| \`karpenter-helm.tf\` | \`helm_release\` pinned to Karpenter v1.0.8 from public ECR, ServiceAccount annotated with IRSA ARN, single replica |
| \`karpenter-nodepool.tf\` | Default \`EC2NodeClass\` (Bottlerocket@latest, subnet/SG discovery by tag) + default \`NodePool\` (t/m/c, gen > 2, cap 4 vCPU, Spot only, 30m expiry, 30s consolidation) |
| \`providers.tf\` + \`versions.tf\` | Add hashicorp/helm ~> 2.17 and hashicorp/kubernetes ~> 2.35, authenticated via \`aws eks get-token\` exec plugin |
| \`config.tf\` | Add \`local.primary_zones\` for NodePool topology constraint |
| \`outputs.tf\` | Karpenter node role ARN, controller role ARN, interruption queue name |
| \`README.md\` | Cost table + file list updated |

## Cost backstop in the NodePool

\`\`\`hcl
limits = {
  cpu    = "4"
  memory = "16Gi"
}
\`\`\`

Even if a misbehaving deployment loops pod creation, Karpenter refuses to launch more than 4 vCPU and 16 GiB total across the pool. Pods past the limit sit Pending. This is the real-money safety net, backing up the NAT-related budget alert.

## Plan on this PR WILL fail — this is expected

Per the Option A strategy in progress (all three 3c PRs land code-only, one apply session brings up the full stack), staging/platform is not yet applied. The following resources in this PR cannot plan without a live cluster:

- \`helm_release.karpenter\` (needs cluster API)
- \`kubernetes_manifest.karpenter_default_ec2nodeclass\` (needs CRDs)
- \`kubernetes_manifest.karpenter_default_nodepool\` (needs CRDs)

Even the IAM/SQS/EventBridge resources will plan red because of cross-referenced outputs. Review the diff, not the plan.

## Apply sequence (after PR 3 also merges)

\`\`\`bash
# One approval, one workflow run, full stack comes up
gh workflow run terraform-apply-workload.yml -f env=staging
gh run watch   # approve workload-apply

# Expected runtime:
#   apply-network  ~5 min  (VPC + NAT)
#   apply-platform ~20 min (EKS ~12 min + Fargate + Helm + NodePool = rest)
# Total ~25 min end-to-end for VPC + EKS + Karpenter + LB Ctrl + ArgoCD
\`\`\`

## Test plan

- [ ] Code review: cluster-scope tags on the controller policy, exec plugin auth, Fargate namespace match, expireAfter / consolidateAfter values
- [ ] Checkov: passes (no new resources Checkov flags outside the existing skip/justification set)
- [ ] Baseline plan (mgmt/bootstrap, etc.): no changes
- [ ] Platform plan: fails as expected (cluster not applied)
- [ ] At the final apply session (PR 3 + this + PR 1 together), verify:
  - Karpenter pod running on Fargate in \`karpenter\` namespace
  - \`kubectl get nodepool,ec2nodeclass\` returns the default pair, \`Ready: True\`
  - A sample deployment with 1 pod of 500m CPU triggers Karpenter to launch a Spot instance
  - The provisioned EC2 joins the cluster (confirms EC2_LINUX access entry works)
  - Scaling the deployment to 0 triggers consolidation — node drains within 30 seconds of emptiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)