### PR TITLE
feat(platform): AWS LB Controller + ArgoCD (Phase 3c PR 3/3)

### DIFF
--- a/terraform/environments/staging/platform/README.md
+++ b/terraform/environments/staging/platform/README.md
@@ -1,8 +1,8 @@
 # staging/platform
 
-The EKS platform layer for `aegis-staging`. Contains the EKS cluster, Fargate profiles for system pods (CoreDNS, Karpenter controller), the IRSA OIDC provider, Access Entries mapping the CI role and operator SSO role to Kubernetes cluster-admin, and **Karpenter v1** (controller on Fargate + default NodePool + EC2NodeClass).
+The EKS platform layer for `aegis-staging`. Contains the EKS cluster, Fargate profiles for system pods (CoreDNS, Karpenter controller), the IRSA OIDC provider, Access Entries mapping the CI role and operator SSO role to Kubernetes cluster-admin, **Karpenter v1** (controller on Fargate + default NodePool + EC2NodeClass), the **AWS Load Balancer Controller** (Ingress / Service-type-LoadBalancer → ALB / NLB with ACM TLS), and **ArgoCD** with an app-of-apps root Application pointing at `aegis-core/apps/staging/`.
 
-The AWS Load Balancer Controller and ArgoCD are intentionally NOT in this layer — they land in Phase 3c PR 3 so each can be reviewed and applied independently.
+With Phase 3c PR 3 landed, this layer contains the full platform surface area that `aegis-core` application PRs can assume: IRSA-able OIDC, Access-Entry-gated Kubernetes API, Karpenter-provisioned node capacity, ALB provisioning via `Ingress`, and a GitOps controller that auto-syncs any commit to `aegis-core`.
 
 ---
 
@@ -37,13 +37,14 @@ Apply ordering is enforced operationally by the CI workflow split:
 
 ## Cost profile
 
-Apply triggers ~$0.30/hr ongoing while the cluster is running:
+Apply triggers ~$0.35/hr ongoing while the cluster is running:
 
 | Component | Approximate cost while running |
 |---|---|
 | EKS control plane | $0.10/hr (~$73/month always-on) |
 | Fargate (CoreDNS + Karpenter controller, ~3 pods) | ~$0.12/hr |
-| Karpenter-managed Spot EC2 (when there are workloads) | ~$0.01/hr per small instance |
+| Karpenter-managed Spot EC2 (LB Controller + ArgoCD + workloads) | ~$0.02/hr (typically one small Spot instance) |
+| ALB (per Ingress provisioned by LB Controller) | $0.025/hr + LCU, mostly pennies at lab traffic |
 | SQS (Karpenter interruption queue) | $0 at lab message volume |
 | EventBridge rules (4x) | $0 at lab event volume |
 | CloudWatch Logs (5 log types at lab traffic) | pennies/day |
@@ -84,7 +85,11 @@ staging/platform/
 ├── karpenter-interruption.tf     # SQS queue + EventBridge rules for Spot interruption handling
 ├── karpenter-helm.tf             # Karpenter controller Helm release on Fargate
 ├── karpenter-nodepool.tf         # Default NodePool + EC2NodeClass (Spot, 4 vCPU cap, Bottlerocket)
-├── outputs.tf                    # Consumed by LB Controller / ArgoCD PRs
+├── lb-controller-iam.tf          # AWS LB Controller IRSA role (policy loaded from JSON)
+├── lb-controller-policy.json     # Canonical AWS LB Controller IAM policy (v2.8.2)
+├── lb-controller.tf              # AWS LB Controller Helm release in kube-system
+├── argocd.tf                     # ArgoCD Helm release + app-of-apps root Application
+├── outputs.tf                    # Cluster + Karpenter + LB Controller + ArgoCD outputs
 └── README.md                     # This file
 ```
 

--- a/terraform/environments/staging/platform/argocd.tf
+++ b/terraform/environments/staging/platform/argocd.tf
@@ -1,0 +1,150 @@
+# -----------------------------------------------------------------------------
+# ArgoCD — GitOps bootstrap via Helm + app-of-apps root Application
+# -----------------------------------------------------------------------------
+# Per ADR-013 "GitOps bootstrap", Terraform installs ArgoCD once. After
+# that install, ArgoCD's own `Application` resource points at the
+# aegis-core repository, and every subsequent workload deployment is a
+# commit to aegis-core — not a Terraform change here.
+#
+# The root Application below targets `apps/staging/` in aegis-core,
+# following the App-of-Apps pattern (CLAUDE.md): the root Application's
+# manifest is a directory of child Applications, each of which points at
+# its own manifest location in the same repo.
+#
+# Authentication: ArgoCD accesses the public aegis-core repo anonymously.
+# When aegis-core becomes private (Phase 4+) or when cross-account image
+# pulls need per-environment secrets, add a repository credential via
+# `argocd-cm` and an SSH/HTTPS credential via `argocd-secret`. Not in
+# scope here because aegis-core is currently a public repo.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# ArgoCD namespace is created by the chart; use a dedicated namespace so
+# teardown of ArgoCD is a clean namespace delete.
+# -----------------------------------------------------------------------------
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  namespace        = "argocd"
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "7.6.12" # ArgoCD 2.12.x — pinned for reproducibility
+
+  values = [
+    yamlencode({
+      # Controller + repo server + application controller sizing for a lab
+      # with a handful of apps. Keep it small to fit on one Karpenter EC2.
+      controller = {
+        replicas = 1
+        resources = {
+          requests = { cpu = "100m", memory = "256Mi" }
+          limits   = { cpu = "500m", memory = "512Mi" }
+        }
+      }
+
+      server = {
+        replicas = 1
+        resources = {
+          requests = { cpu = "50m", memory = "128Mi" }
+          limits   = { cpu = "200m", memory = "256Mi" }
+        }
+
+        # Internal-only Service for now. Phase 3c PR 3 establishes the
+        # controller but not the public ingress; a follow-up PR adds an
+        # Ingress resource with ACM TLS once DNS is wired up.
+        service = {
+          type = "ClusterIP"
+        }
+      }
+
+      repoServer = {
+        replicas = 1
+        resources = {
+          requests = { cpu = "50m", memory = "128Mi" }
+          limits   = { cpu = "200m", memory = "256Mi" }
+        }
+      }
+
+      # Redis (cached application manifests). Single replica lab-sized.
+      redis = {
+        resources = {
+          requests = { cpu = "50m", memory = "64Mi" }
+          limits   = { cpu = "200m", memory = "128Mi" }
+        }
+      }
+
+      # Dex (SSO proxy) disabled — we do not wire up external SSO to
+      # ArgoCD in this phase. The admin password is stored in the
+      # `argocd-initial-admin-secret` Secret and can be read via
+      # `kubectl -n argocd get secret argocd-initial-admin-secret \
+      #   -o jsonpath='{.data.password}' | base64 -d`
+      dex = {
+        enabled = false
+      }
+    }),
+  ]
+
+  depends_on = [
+    helm_release.karpenter, # ArgoCD needs EC2 capacity to schedule on
+  ]
+}
+
+# -----------------------------------------------------------------------------
+# App-of-Apps root Application
+# -----------------------------------------------------------------------------
+# The root Application points at a directory in aegis-core that contains
+# child Application manifests. ArgoCD discovers and manages them
+# automatically. Adding a new workload is a commit to aegis-core —
+# no Terraform change here.
+#
+# Auto-sync is enabled (per CLAUDE.md: "Auto-sync for staging, manual
+# sync for prod"). `selfHeal = true` re-applies drift; `prune = true`
+# deletes child resources removed from the repo.
+# -----------------------------------------------------------------------------
+resource "kubernetes_manifest" "argocd_root_app" {
+  manifest = {
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "Application"
+    metadata = {
+      name      = "root"
+      namespace = "argocd"
+      # The `finalizer` ensures ArgoCD cascades deletion of child apps
+      # when the root is deleted (cleaner teardown).
+      finalizers = [
+        "resources-finalizer.argocd.argoproj.io",
+      ]
+    }
+    spec = {
+      project = "default"
+
+      source = {
+        repoURL        = "https://github.com/${local.config.github.org}/${local.config.github.app_repo}.git"
+        targetRevision = "main"
+        # Child applications live under apps/staging/ in aegis-core. The
+        # directory is read with `recurse: true` so sub-directories can
+        # structure apps (e.g. apps/staging/observability/).
+        path = "apps/staging"
+        directory = {
+          recurse = true
+        }
+      }
+
+      destination = {
+        server    = "https://kubernetes.default.svc"
+        namespace = "argocd"
+      }
+
+      syncPolicy = {
+        automated = {
+          prune    = true
+          selfHeal = true
+        }
+        syncOptions = [
+          "CreateNamespace=true",
+        ]
+      }
+    }
+  }
+
+  depends_on = [helm_release.argocd]
+}

--- a/terraform/environments/staging/platform/lb-controller-iam.tf
+++ b/terraform/environments/staging/platform/lb-controller-iam.tf
@@ -1,0 +1,46 @@
+# -----------------------------------------------------------------------------
+# AWS Load Balancer Controller — IAM (IRSA)
+# -----------------------------------------------------------------------------
+# The controller running in-cluster needs to call AWS APIs to manage ALBs,
+# NLBs, Security Groups, and their tag-based lifecycle. The IAM role below
+# is trusted ONLY by the `kube-system/aws-load-balancer-controller` service
+# account via the cluster's OIDC provider — no other pod can assume it.
+#
+# The attached policy is the canonical policy published by the
+# kubernetes-sigs/aws-load-balancer-controller project. It is deliberately
+# lengthy; the length is the point — every action is scoped by resource
+# tags or by AWS request conditions, following least-privilege. When the
+# upstream policy changes (usually with each minor controller release),
+# the JSON file should be refreshed and the controller chart version pinned
+# below should be bumped in lockstep.
+#
+# Source: https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.8.2/docs/install/iam_policy.json
+# Controller chart version: see lb-controller.tf
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "lb_controller" {
+  name = "${local.cluster_name}-aws-lb-controller"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = aws_iam_openid_connect_provider.cluster.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.oidc_host}:aud" = "sts.amazonaws.com"
+          "${local.oidc_host}:sub" = "system:serviceaccount:kube-system:aws-load-balancer-controller"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "lb_controller" {
+  name   = "${local.cluster_name}-aws-lb-controller"
+  role   = aws_iam_role.lb_controller.id
+  policy = file("${path.module}/lb-controller-policy.json")
+}

--- a/terraform/environments/staging/platform/lb-controller-policy.json
+++ b/terraform/environments/staging/platform/lb-controller-policy.json
@@ -1,0 +1,233 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["iam:CreateServiceLinkedRole"],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeInstances",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeTags",
+        "ec2:GetCoipPoolUsage",
+        "ec2:DescribeCoipPools",
+        "ec2:GetSecurityGroupsForVpc",
+        "ec2:DescribeIpamPools",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTrustStores",
+        "elasticloadbalancing:DescribeListenerAttributes",
+        "elasticloadbalancing:DescribeCapacityReservation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient",
+        "acm:ListCertificates",
+        "acm:DescribeCertificate",
+        "iam:ListServerCertificates",
+        "iam:GetServerCertificate",
+        "waf-regional:GetWebACL",
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL",
+        "wafv2:GetWebACL",
+        "wafv2:GetWebACLForResource",
+        "wafv2:AssociateWebACL",
+        "wafv2:DisassociateWebACL",
+        "shield:GetSubscriptionState",
+        "shield:DescribeProtection",
+        "shield:CreateProtection",
+        "shield:DeleteProtection"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:CreateSecurityGroup"],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:CreateTags"],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "CreateSecurityGroup"
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:CreateTags", "ec2:DeleteTags"],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:DeleteSecurityGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:DeleteRule"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["elasticloadbalancing:AddTags", "elasticloadbalancing:RemoveTags"],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["elasticloadbalancing:AddTags", "elasticloadbalancing:RemoveTags"],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:ModifyListenerAttributes",
+        "elasticloadbalancing:ModifyCapacityReservation",
+        "elasticloadbalancing:ModifyIpPools"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["elasticloadbalancing:AddTags"],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "elasticloadbalancing:CreateAction": [
+            "CreateTargetGroup",
+            "CreateLoadBalancer"
+          ]
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets"
+      ],
+      "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:SetWebAcl",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:SetRulePriorities"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/terraform/environments/staging/platform/lb-controller.tf
+++ b/terraform/environments/staging/platform/lb-controller.tf
@@ -1,0 +1,69 @@
+# -----------------------------------------------------------------------------
+# AWS Load Balancer Controller — Helm install
+# -----------------------------------------------------------------------------
+# Watches for Kubernetes Ingress and Service (type=LoadBalancer) resources
+# and provisions ALBs / NLBs on AWS. Integrates with ACM for TLS, enabling
+# the "public services terminate TLS at ACM, not cert-manager" pattern
+# described in ADR-013 "TLS certificate provider".
+#
+# The controller runs in the `kube-system` namespace (AWS convention, matches
+# the upstream chart default). It schedules onto whatever node capacity is
+# available — Karpenter-provisioned EC2 is fine. The Fargate profile for
+# kube-system (PR 1) is narrowed to CoreDNS only via the `k8s-app=kube-dns`
+# label selector, so this controller does NOT land on Fargate.
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "aws_lb_controller" {
+  name       = "aws-load-balancer-controller"
+  namespace  = "kube-system"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  version    = "1.8.2" # tracks controller v2.8.2 — match to policy file
+
+  values = [
+    yamlencode({
+      clusterName = aws_eks_cluster.main.name
+
+      serviceAccount = {
+        create = true
+        name   = "aws-load-balancer-controller"
+        annotations = {
+          "eks.amazonaws.com/role-arn" = aws_iam_role.lb_controller.arn
+        }
+      }
+
+      # Region must be explicit when running outside the cluster's default
+      # region discovery path (which is fine for this project, but explicit
+      # is better).
+      region = local.primary_region
+      vpcId  = data.terraform_remote_state.staging_network.outputs.vpc_id
+
+      # Single replica for the lab. Controller is stateless; leader election
+      # handles multi-replica HA in production (replicaCount = 2 + topology
+      # spread constraints).
+      replicaCount = 1
+
+      # Resource requests keep the controller well-behaved on constrained
+      # node capacity (single small Karpenter EC2 while idle).
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "128Mi"
+        }
+        limits = {
+          cpu    = "200m"
+          memory = "256Mi"
+        }
+      }
+    }),
+  ]
+
+  depends_on = [
+    aws_iam_role_policy.lb_controller,
+    # Karpenter must be installed first so that when the controller pod
+    # schedules, there is a way to provision EC2 capacity for it.
+    # (If Karpenter fails, the controller pod sits Pending and the apply
+    # hangs, which is actually the correct diagnostic signal.)
+    helm_release.karpenter,
+  ]
+}

--- a/terraform/environments/staging/platform/outputs.tf
+++ b/terraform/environments/staging/platform/outputs.tf
@@ -58,3 +58,22 @@ output "karpenter_interruption_queue_name" {
   description = "SQS queue name Karpenter polls for Spot / scheduled-change events"
   value       = aws_sqs_queue.karpenter_interruption.name
 }
+
+# -----------------------------------------------------------------------------
+# Ingress + GitOps outputs (Phase 3c PR 3)
+# -----------------------------------------------------------------------------
+
+output "lb_controller_role_arn" {
+  description = "AWS Load Balancer Controller IAM role ARN (IRSA-bound)"
+  value       = aws_iam_role.lb_controller.arn
+}
+
+output "argocd_namespace" {
+  description = "Namespace where ArgoCD is installed"
+  value       = helm_release.argocd.namespace
+}
+
+output "argocd_initial_admin_password_hint" {
+  description = "Command to retrieve the initial ArgoCD admin password"
+  value       = "kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d"
+}


### PR DESCRIPTION
## Summary

Final incremental PR of Phase 3c. Adds ingress (AWS Load Balancer Controller) and GitOps (ArgoCD with app-of-apps root) on top of the EKS cluster (#39) and Karpenter (#42). After this PR lands and is applied, \`staging/platform\` contains the complete EKS platform surface area that \`aegis-core\` application PRs can assume is present.

## Design (per ADR-013)

**AWS Load Balancer Controller**

Installed via Helm chart \`aws-load-balancer-controller\` v1.8.2 (tracks controller v2.8.2). IRSA role trusted only by the \`kube-system/aws-load-balancer-controller\` ServiceAccount. Policy is the canonical upstream policy kept as a separate JSON file (\`lb-controller-policy.json\`) so upstream updates are a single-file diff that maintainers can review against [the upstream source](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.8.2/docs/install/iam_policy.json).

The controller runs in \`kube-system\` (AWS convention). The Fargate profile for \`kube-system\` (created in PR #39) narrows to \`k8s-app=kube-dns\`, so LB Controller lands on Karpenter-provisioned EC2 — not Fargate.

**ArgoCD + App-of-Apps**

Installed via Helm chart \`argo-cd\` v7.6.12 (ArgoCD 2.12.x) in a dedicated \`argocd\` namespace. Per CLAUDE.md "Auto-sync for staging, manual sync for prod", the root Application has \`automated.prune = true\` + \`selfHeal = true\`.

Root Application sources from:
\`\`\`
repoURL:        https://github.com/<org>/aegis-core.git
targetRevision: main
path:           apps/staging
directory.recurse: true
\`\`\`

The \`<org>\` / \`aegis-core\` values come from \`config/landing-zone.yaml\` \`github.org\` / \`github.app_repo\` — no hardcoded URLs.

**Dex disabled.** External SSO wiring for ArgoCD is deferred to a future phase when operator patterns justify it. Initial admin login is via the standard \`argocd-initial-admin-secret\`; the kubectl command to fetch it is exposed as the output \`argocd_initial_admin_password_hint\`.

**Server Service type = ClusterIP.** The ArgoCD UI is not publicly exposed in PR 3. A follow-up PR can add an \`Ingress\` resource (with ACM cert + the LB Controller + DNS) once there's actual demand to reach the UI from outside the VPN / SSM-port-forward path.

## Cost delta vs PR #42

| Component | PR #42 (Karpenter) → PR #43 (LB + ArgoCD) |
|---|---|
| Karpenter-managed Spot EC2 | From "0 when idle" → "1 small instance when any workload runs" (~$0.01/hr) |
| ALB (on first Ingress provisioned) | $0 → $0.025/hr + LCU (only when Ingress resources exist) |
| ArgoCD + LB Controller pod resources | ~$0 marginal on Fargate, ~pennies on Karpenter EC2 |

Total platform running cost when idle remains ~$0.30/hr (EKS + Fargate + KMS + NAT). When workloads exist, add ~$0.025/hr (ALB) + $0.01/hr (Spot EC2).

## Apply sequence — full stack in one session

Merge all three (#39 + #42 + this PR 3) → then:

\`\`\`bash
gh workflow run terraform-apply-workload.yml -f env=staging
gh run watch   # approve workload-apply
\`\`\`

This single approval brings up: VPC + NAT + IPAM allocation → EKS 1.32 + 2 Fargate profiles + OIDC + Access Entries → Karpenter controller on Fargate + NodePool + EC2NodeClass → AWS LB Controller + ArgoCD + root Application.

Expected end-to-end runtime: ~25 minutes (EKS control plane creation is the dominant 12-minute step; everything else overlaps or is under 2 minutes each).

## Plan will fail as expected

Same pattern as PR #39 and PR #42 — staging/platform's cluster resources don't exist in AWS yet, so \`helm_release\`, \`kubernetes_manifest\`, and IAM resources that reference \`aws_eks_cluster.main.*\` or \`aws_iam_openid_connect_provider.cluster.*\` all fail to plan until the real cluster is up.

Review the diff, not the plan.

## Test plan (for the apply session after this merges)

- [ ] \`helm list -A\` shows karpenter (karpenter ns), aws-load-balancer-controller (kube-system), argocd (argocd)
- [ ] \`kubectl -n argocd get applications\` lists \`root\` with \`Sync: OK\` (or "OutOfSync" if aegis-core/apps/staging is empty — that is an aegis-core concern, not platform)
- [ ] \`kubectl -n kube-system get deployment aws-load-balancer-controller\` is Available
- [ ] Provisioning a test Ingress resource triggers ALB creation (smoke test, not in this PR)
- [ ] ArgoCD UI reachable via \`kubectl -n argocd port-forward svc/argocd-server 8080:80\` — login with the password from \`argocd_initial_admin_password_hint\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)