### PR TITLE
fix(platform): use kubectl_manifest to escape bootstrap trap

### DIFF
--- a/terraform/environments/staging/platform/.terraform.lock.hcl
+++ b/terraform/environments/staging/platform/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.19.0"
+  constraints = "~> 1.19"
+  hashes = [
+    "h1:quymfa/OKEfWI5JXFEwGbUY2aAy0vet3rA9JWJam+3k=",
+    "zh:1dec8766336ac5b00b3d8f62e3fff6390f5f60699c9299920fc9861a76f00c71",
+    "zh:43f101b56b58d7fead6a511728b4e09f7c41dc2e3963f59cf1c146c4767c6cb7",
+    "zh:4c4fbaa44f60e722f25cc05ee11dfaec282893c5c0ffa27bc88c382dbfbaa35c",
+    "zh:51dd23238b7b677b8a1abbfcc7deec53ffa5ec79e58e3b54d6be334d3d01bc0e",
+    "zh:5afc2ebc75b9d708730dbabdc8f94dd559d7f2fc5a31c5101358bd8d016916ba",
+    "zh:6be6e72d4663776390a82a37e34f7359f726d0120df622f4a2b46619338a168e",
+    "zh:72642d5fcf1e3febb6e5d4ae7b592bb9ff3cb220af041dbda893588e4bf30c0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1da03e3239867b35812ee031a1060fed6e8d8e458e2eaca48b5dd51b35f56f7",
+    "zh:b98b6a6728fe277fcd133bdfa7237bd733eae233f09653523f14460f608f8ba2",
+    "zh:bb8b071d0437f4767695c6158a3cb70df9f52e377c67019971d888b99147511f",
+    "zh:dc89ce4b63bfef708ec29c17e85ad0232a1794336dc54dd88c3ba0b77e764f71",
+    "zh:dd7dd18f1f8218c6cd19592288fde32dccc743cde05b9feeb2883f37c2ff4b4e",
+    "zh:ec4bd5ab3872dedb39fe528319b4bba609306e12ee90971495f109e142d66310",
+    "zh:f610ead42f724c82f5463e0e71fa735a11ffb6101880665d93f48b4a67b9ad82",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/terraform/environments/staging/platform/argocd.tf
+++ b/terraform/environments/staging/platform/argocd.tf
@@ -101,8 +101,11 @@ resource "helm_release" "argocd" {
 # sync for prod"). `selfHeal = true` re-applies drift; `prune = true`
 # deletes child resources removed from the repo.
 # -----------------------------------------------------------------------------
-resource "kubernetes_manifest" "argocd_root_app" {
-  manifest = {
+# kubectl_manifest (not kubernetes_manifest) — deferred plan-time schema
+# validation. See the bootstrap-trap note in karpenter-nodepool.tf +
+# Incident 10.
+resource "kubectl_manifest" "argocd_root_app" {
+  yaml_body = yamlencode({
     apiVersion = "argoproj.io/v1alpha1"
     kind       = "Application"
     metadata = {
@@ -144,7 +147,7 @@ resource "kubernetes_manifest" "argocd_root_app" {
         ]
       }
     }
-  }
+  })
 
   depends_on = [helm_release.argocd]
 }

--- a/terraform/environments/staging/platform/karpenter-nodepool.tf
+++ b/terraform/environments/staging/platform/karpenter-nodepool.tf
@@ -21,13 +21,19 @@
 #     `kubernetes.io/role/internal-elb = 1` — we reuse that tag here.
 #   - 30-minute node lifecycle — nodes are recycled at least every 30
 #     minutes to pick up AMI patches and security updates.
+#
+# Implementation note: these are CRD instances installed by the Karpenter
+# Helm chart. We use `kubectl_manifest` (gavinbunney/kubectl) rather than
+# hashicorp/kubernetes's `kubernetes_manifest` because the latter requires
+# the CRD schema to be reachable at PLAN time. On a cold apply the cluster
+# does not exist yet, so plan errors with "Failed to construct REST client:
+# no client config". The kubectl provider defers validation to apply time
+# (just runs `kubectl apply` with the raw YAML), which is what we need for
+# a single-pass bootstrap apply. See Incident 10 in docs/incidents.md.
 # -----------------------------------------------------------------------------
 
-# Server-side apply is required for Karpenter v1 manifests because the
-# API ships OpenAPI schema validation that `kubernetes_manifest` uses at
-# plan time. Requires a running cluster to plan.
-resource "kubernetes_manifest" "karpenter_default_ec2nodeclass" {
-  manifest = {
+resource "kubectl_manifest" "karpenter_default_ec2nodeclass" {
+  yaml_body = yamlencode({
     apiVersion = "karpenter.k8s.aws/v1"
     kind       = "EC2NodeClass"
     metadata = {
@@ -63,13 +69,13 @@ resource "kubernetes_manifest" "karpenter_default_ec2nodeclass" {
         "topology.kubernetes.io/region"                      = local.primary_region
       })
     }
-  }
+  })
 
   depends_on = [helm_release.karpenter]
 }
 
-resource "kubernetes_manifest" "karpenter_default_nodepool" {
-  manifest = {
+resource "kubectl_manifest" "karpenter_default_nodepool" {
+  yaml_body = yamlencode({
     apiVersion = "karpenter.sh/v1"
     kind       = "NodePool"
     metadata = {
@@ -147,9 +153,9 @@ resource "kubernetes_manifest" "karpenter_default_nodepool" {
         memory = "16Gi"
       }
     }
-  }
+  })
 
   depends_on = [
-    kubernetes_manifest.karpenter_default_ec2nodeclass,
+    kubectl_manifest.karpenter_default_ec2nodeclass,
   ]
 }

--- a/terraform/environments/staging/platform/providers.tf
+++ b/terraform/environments/staging/platform/providers.tf
@@ -44,3 +44,19 @@ provider "helm" {
     }
   }
 }
+
+# kubectl provider — used for CRD instances. Auth matches the kubernetes
+# provider above. `load_config_file = false` disables the local kubeconfig
+# fallback, which is important in CI where /github/home/.kube/config does
+# not exist and would otherwise trigger a misleading error.
+provider "kubectl" {
+  host                   = aws_eks_cluster.main.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.main.certificate_authority[0].data)
+  load_config_file       = false
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.main.name, "--region", local.primary_region]
+  }
+}

--- a/terraform/environments/staging/platform/versions.tf
+++ b/terraform/environments/staging/platform/versions.tf
@@ -18,5 +18,15 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.35"
     }
+    # gavinbunney/kubectl used for CRD instances (NodePool, EC2NodeClass,
+    # ArgoCD root Application). Unlike hashicorp/kubernetes's
+    # `kubernetes_manifest`, this provider does NOT require the cluster to
+    # be reachable at plan time (it applies raw YAML via `kubectl apply`
+    # at apply time). Necessary to avoid the "first apply plan fails
+    # because cluster does not exist yet" bootstrap trap.
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.19"
+    }
   }
 }


### PR DESCRIPTION
## Summary

First apply of PR #43 failed with \`Failed to construct REST client: no client config\` because \`kubernetes_manifest\` fetches CRD schemas at PLAN time and the cluster doesn't exist yet on a cold apply. Swap the 3 affected resources to \`kubectl_manifest\` (gavinbunney/kubectl) which defers validation to apply time.

## Affected resources

- \`kubernetes_manifest.karpenter_default_ec2nodeclass\` → \`kubectl_manifest\`
- \`kubernetes_manifest.karpenter_default_nodepool\` → \`kubectl_manifest\`
- \`kubernetes_manifest.argocd_root_app\` → \`kubectl_manifest\`

Plus \`versions.tf\` + \`providers.tf\` add \`gavinbunney/kubectl ~> 1.19\` with the same exec-plugin auth as the other cluster-bound providers.

## Why this matters

\`hashicorp/kubernetes/kubernetes_manifest\` does a plan-time schema fetch against the cluster. This is correct behavior for day-2 ops (catches typos without applying), but breaks day-0 bootstrap. Pretty much every Terraform-managed Karpenter / ArgoCD / cert-manager setup hits this — the canonical fixes are:

1. Split into two Terraform passes (cluster, then cluster resources). Ugly for our single-apply workflow.
2. Use \`kubectl_manifest\` from gavinbunney/kubectl. Defers schema validation. We use this.
3. Use \`helm_release\` for everything (wrap the manifests in a tiny Helm chart). Overkill for 3 resources.

Postmortem is Incident 10 (follow-up PR).

## Current live state (for context)

- \`staging/network\` applied successfully before the platform plan failed — **VPC + NAT are running** (~\$0.045/hr for NAT)
- \`staging/platform\` state is empty (plan never reached apply, no resources created)
- Cost clock is ticking on NAT only (~\$0.045/hr ≈ \$1/day)

After this PR merges:

\`\`\`bash
gh workflow run terraform-apply-workload.yml -f env=staging
# Approve → network apply is a no-op → platform apply plans cleanly → full stack up ~20 min
\`\`\`

## Test plan

- [ ] Code review: \`kubectl_manifest\` resources preserve the previous YAML content exactly
- [ ] Validate: provider added to lock file, no fmt issues
- [ ] After merge + re-dispatch workload apply: EKS cluster ACTIVE, Karpenter controller pod Running, default NodePool + EC2NodeClass present (\`kubectl get nodepool,ec2nodeclass\`), ArgoCD root Application present

🤖 Generated with [Claude Code](https://claude.com/claude-code)