### PR TITLE
fix(platform): Access Policy ARN + relax public_access_cidrs + 3 incidents

### DIFF
--- a/config/landing-zone.example.yaml
+++ b/config/landing-zone.example.yaml
@@ -115,9 +115,16 @@ eks:
   staging:
     version: "1.32"
     public_access_cidrs:
-      # Operator's current public IP, /32. Update when the ISP reassigns —
-      # see runbook 002 for the check + update procedure.
-      - "203.0.113.1/32"
+      # Default: 0.0.0.0/0 — open endpoint, AWS IAM SigV4 + Access Entries +
+      # SSO session expiry are the primary auth layers. This matches EKS
+      # Blueprints and the majority of CI-managed EKS reference architectures.
+      #
+      # Tighter options (documented in ADR-013 "Design iteration"):
+      #   - Option Z (corporate): include GitHub Actions published IP
+      #     ranges from https://api.github.com/meta -> .actions (~50 CIDRs)
+      #   - Option Y (strict):    self-hosted GH Actions runners inside
+      #     the VPC, then restrict to operator /32 + runner subnet CIDR
+      - "0.0.0.0/0"
   # prod:
   #   version: "1.32"
   #   public_access_cidrs:

--- a/docs/decisions/013-eks-architecture.md
+++ b/docs/decisions/013-eks-architecture.md
@@ -22,7 +22,7 @@ Karpenter itself is a pod and needs to run somewhere. Running it on the nodes it
 
 **Control plane endpoint — public + private.**
 
-The EKS API server is accessible via both public (for `kubectl` from the operator's laptop) and private (for in-cluster components) endpoints. Fully private endpoints would require either a bastion host, a VPN, or SSM port forwarding for operator access — all of which add complexity without security benefit in a single-operator lab. Access to the public endpoint is restricted to the operator's IP range via `public_access_cidrs`, which is read from config at deployment time.
+The EKS API server is accessible via both public (for `kubectl` from the operator's laptop) and private (for in-cluster components) endpoints. Fully private endpoints would require either a bastion host, a VPN, or SSM port forwarding for operator access — all of which add complexity without security benefit in a single-operator lab. Access to the public endpoint is restricted to the operator's IP range via `public_access_cidrs`, which is read from config at deployment time. (**Superseded by "Design iteration" below**: the lab runs with `public_access_cidrs = ["0.0.0.0/0"]` because CI-managed Helm/kubectl needs Kubernetes API reachability from GitHub-hosted runners.)
 
 **Workload IAM — IAM Roles for Service Accounts (IRSA).**
 
@@ -87,3 +87,25 @@ The Fargate-hosted Karpenter pod is a small but continuous cost (~$30/month if l
 ECR repositories are created in `aegis-staging` by the `staging/platform/` Terraform layer. When the platform layer is destroyed, ECR repositories are preserved (`prevent_destroy = true` on the repository resource) so that image history survives cluster teardown. Only the cluster itself is ephemeral; artifacts persist.
 
 The public EKS endpoint restricted to the operator's IP means the IP must be kept current in config. A mobile operator (different cafe, different VPN exit) either updates the config and re-applies the platform layer (~2 minutes) or falls back to SSM session manager through a bootstrap EC2 instance. Documented as a known operational trade-off of avoiding the bastion.
+
+## Design iteration — public_access_cidrs relaxed to `0.0.0.0/0`
+
+**Date**: 2026-04-14 (Phase 3c first cold apply)
+**Driver**: Incident 12 in `docs/incidents.md`
+
+The original design (above) scoped `public_access_cidrs` to the operator's `/32` as a defense-in-depth layer on top of IAM SigV4 auth and Kubernetes RBAC. That scope was correct for operator-only access but **incompatible with CI-managed Helm / kubectl / kubectl_manifest**: GitHub-hosted Actions runners use ephemeral IPs from AWS-wide egress ranges, so the runner cannot complete a TLS handshake to the Kubernetes API server. AWS API calls (STS, EKS, IAM) flow through public AWS endpoints that are not CIDR-gated and continued to work; only the Kubernetes API was blocked.
+
+Two paths were considered to resolve the conflict:
+
+1. **Open the endpoint** — `public_access_cidrs = ["0.0.0.0/0"]`. Rely on AWS IAM SigV4 + Access Entries + Kubernetes RBAC + 8-hour SSO session expiry as the primary auth stack. This matches the AWS EKS Blueprints reference architecture and is the documented pattern used by essentially every CI-managed EKS setup in public examples.
+
+2. **Narrow the Terraform scope** — remove `helm_release` / `kubectl_manifest` resources from the Terraform platform layer; apply them from the operator's laptop after each `terraform apply` via a `scripts/bootstrap-cluster.sh`. Preserves the `/32` lockdown but breaks the "Terraform owns the whole platform" single-apply model and adds a hands-on step to every session.
+
+**Chosen: (1).** The `public_access_cidrs` field is set to `["0.0.0.0/0"]` in `config/landing-zone.yaml`. The threat model is IAM-primary: any caller reaching the public endpoint must present a valid SigV4 signature from a principal that has an Access Entry mapped to a Kubernetes RBAC role, or they get `401 Unauthorized` at the API handler. The attack surface without a CIDR gate is essentially equivalent to the STS public endpoint — broad reachability does not translate to exploit capability without a credential.
+
+**Corporate / enterprise deployments that cannot open the endpoint** have two narrower options in order of operational cost:
+
+- **Option Z — include published GitHub Actions IP ranges.** Fetch `https://api.github.com/meta` and read the `.actions` field, which lists the CIDR blocks GitHub-hosted runners egress from. Roughly 50 CIDRs, published-and-stable but refreshed periodically. Automate the refresh via a small Lambda or CI job that diff-commits to the config.
+- **Option Y — self-hosted runners inside the VPC.** Add an EKS-backed or EC2-backed runner fleet in the cluster's VPC, restrict `public_access_cidrs` to the operator `/32` + the VPC NAT egress CIDR. Higher setup cost; closest to a production enterprise posture.
+
+The lab opts for simplicity and IAM-primary auth. Corporate forks should take Option Z or Y.

--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -526,6 +526,176 @@ The `sso-assignments.tf` file in this repo now documents this class of hazard in
 
 ---
 
+## Incident 10 — `kubernetes_manifest` plan-time schema fetch breaks cold bootstrap
+
+**Date**: 2026-04-14 (Phase 3c, first cold apply of staging/platform; PR #43 → fix in PR #44)
+**Severity**: S3 (blocked first cluster apply; no AWS resources created)
+**Duration**: ~5 min to diagnose + patch
+
+### Symptom
+
+The first `terraform-apply-workload.yml` run with the `staging/platform` layer enabled failed at PLAN phase, before creating any cluster resources:
+
+```
+Error: Failed to construct REST client
+  cannot create REST client: no client config
+  with kubernetes_manifest.karpenter_default_ec2nodeclass
+  with kubernetes_manifest.karpenter_default_nodepool
+  with kubernetes_manifest.argocd_root_app
+```
+
+Network layer applied fine. Platform layer's EKS cluster resource would have been created successfully if plan had reached apply — but plan itself errored on three `kubernetes_manifest` resources.
+
+### Root cause
+
+`hashicorp/kubernetes`'s `kubernetes_manifest` resource fetches the target CRD's OpenAPI schema from the Kubernetes API server **at plan time** to validate the manifest shape. This is correct for day-2 operations (catches manifest typos without attempting to apply). It is fatal for day-0 bootstrap: on the first cold apply, the cluster does not exist yet, so there is no Kubernetes API server to query, so no schema, so no plan.
+
+The three `kubernetes_manifest` resources in question were the Karpenter `NodePool`, the Karpenter `EC2NodeClass`, and the ArgoCD root `Application` — all CRD instances whose CRDs are installed by upstream Helm charts elsewhere in the same Terraform configuration. Terraform's dependency graph correctly ordered `helm_release.karpenter` → `kubernetes_manifest.karpenter_default_nodepool`, but the provider's plan-time behavior ignored the graph — it tried to reach the cluster unconditionally.
+
+### Detection
+
+The error message was direct and pointed at the exact resources. Diagnosis was 30 seconds of reading. The broader pattern ("how do I bootstrap an EKS cluster + CRD instances in one Terraform apply?") is a well-known issue in the Terraform + Kubernetes community; searching for the error string leads immediately to the usual solutions.
+
+### Resolution
+
+Swap the three `kubernetes_manifest` resources for `kubectl_manifest` from the `gavinbunney/kubectl` provider. That resource applies raw YAML via `kubectl apply -f -` at apply time and does not do plan-time schema validation. Plan succeeds without a live cluster; apply waits for the cluster + CRD install + runs the manifest apply.
+
+Changes in PR #44:
+
+- `versions.tf`: add `gavinbunney/kubectl ~> 1.19`
+- `providers.tf`: configure `kubectl` provider with the same `aws eks get-token` exec-plugin auth as the `kubernetes` and `helm` providers
+- `karpenter-nodepool.tf`, `argocd.tf`: replace three `kubernetes_manifest` resources with `kubectl_manifest` using `yaml_body = yamlencode({...})`
+
+### Prevention
+
+**Use `kubectl_manifest` (gavinbunney) for CRD instances that are bootstrapped in the same Terraform apply that installs the CRDs.** Reserve `kubernetes_manifest` (hashicorp) for manifests targeting CRDs that are guaranteed to exist before plan — typically day-2 configuration changes to a steady-state cluster.
+
+The two providers are otherwise functionally similar; the plan-time behavior is the only meaningful difference. The choice is not about quality; it is about *when the cluster exists relative to when plan runs*.
+
+### Lessons
+
+- **"Apply-time validation" vs "plan-time validation" is a real axis for Kubernetes-touching Terraform resources.** Every provider in this space has a stance on it. `helm_release` validates at apply; `kubernetes_manifest` at plan; `kubectl_manifest` at apply. Pick per the lifecycle stage the resource is bootstrapping.
+- **Dependency graphs describe apply-time ordering, not plan-time ordering.** A `depends_on` that says "apply this after the Helm release" does not tell the resource to postpone its plan-time schema fetch. This is a subtlety worth noting because it's counter-intuitive.
+- **Search the error string before inventing a workaround.** "Failed to construct REST client: no client config" is a well-indexed community failure mode. The solution pattern (kubectl_manifest) is not novel.
+
+---
+
+## Incident 11 — EKS Access Policy ARN namespace is not IAM
+
+**Date**: 2026-04-14 (Phase 3c, first cold apply of staging/platform, same run as Incident 12)
+**Severity**: S3 (blocked Access Entry creation; cluster came up but no principals were mapped to cluster-admin)
+**Duration**: ~2 min to diagnose
+
+### Symptom
+
+Platform layer apply partially succeeded — EKS cluster + Fargate profiles + OIDC provider + Access Entries all created. Then two `aws_eks_access_policy_association` resources errored:
+
+```
+Error: creating EKS Access Policy Association
+  (aegis-staging#<principal>#arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy):
+  InvalidParameterException: The policyArn parameter format is not valid
+```
+
+### Root cause
+
+EKS Access Policies live in their **own ARN namespace**, distinct from IAM Managed Policies. The correct format is:
+
+```
+arn:aws:eks::aws:cluster-access-policy/<PolicyName>
+```
+
+The Terraform code used the IAM form, `arn:aws:iam::aws:policy/<PolicyName>`. The names look parallel (`AmazonEKSClusterAdminPolicy` exists in both namespaces as conceptually the same cluster-admin role), but the ARN prefix is different and the `aws_eks_access_policy_association` API strictly validates the namespace.
+
+This is the kind of mistake that happens precisely because the two namespaces look similar — `AmazonEKSClusterAdminPolicy` feels like an IAM managed policy name, so it gets the IAM ARN prefix by reflex.
+
+### Detection
+
+The error message was unambiguous (`policyArn parameter format is not valid`), and the offending ARN was right in the error text. AWS documentation for [EKS Access Policies](https://docs.aws.amazon.com/eks/latest/userguide/access-policies.html) confirms the `arn:aws:eks::aws:cluster-access-policy/...` format.
+
+### Resolution
+
+Single-character namespace fix in `access-entries.tf`:
+
+```diff
+- policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy"
++ policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+```
+
+Applied in both the CI-role and operator-SSO-role associations. Inline comment added above the resources explaining the namespace distinction so the next reader (or AI agent) doesn't re-make the mistake.
+
+### Prevention
+
+**When a new AWS service introduces its own ARN namespace for policies, read the ARN format from that service's docs, not by pattern-matching on IAM.** Services that have their own policy namespaces (non-exhaustive, as of 2026): EKS (`arn:aws:eks::aws:cluster-access-policy/...`), SES (`arn:aws:ses:<region>:<account>:email-identity-policy/...`), Organizations SCPs (`arn:aws:organizations::<account>:policy/o-.../service_control_policy/...`). Always reach for the service's own docs first.
+
+The inline comment in `access-entries.tf` points at this incident for future reference.
+
+### Lessons
+
+- **AWS resource naming looks parallel, but the ARN prefix is canonical.** A policy name alone does not tell you which service namespace it belongs to. Always carry the full ARN.
+- **"Looks like it should work" is not a validity check for AWS ARNs.** There is no way to test-before-apply other than reading the docs or trying the API. The AWS Terraform provider could offer nicer error messages for this case (flag when the wrong namespace is used for a resource type) but does not.
+- **The AI agent making this mistake is a symptom of training-data pattern-matching.** IAM policy ARNs are much more common in public code than EKS Access Policy ARNs. The safest habit when wiring a new AWS service in Terraform is to read the resource documentation and copy-paste the ARN example, not to compose the ARN from memory.
+
+---
+
+## Incident 12 — Public `public_access_cidrs` lockdown incompatible with CI-managed Helm
+
+**Date**: 2026-04-14 (Phase 3c, first cold apply of staging/platform, same run as Incident 11)
+**Severity**: S2 (full platform bootstrap blocked; cluster existed but could not be configured)
+**Duration**: ~10 min to diagnose; ~30 min to fix-and-document (this incident + ADR-013 design iteration + runbook 002 rewrite)
+
+### Symptom
+
+After the cluster created successfully, the Helm release for Karpenter failed:
+
+```
+Error: Kubernetes cluster unreachable:
+  Get "https://E2BD20D584DF52A0937C50D9FB60108D.gr7.eu-central-1.eks.amazonaws.com/version":
+  dial tcp 63.182.209.11:443: i/o timeout
+
+  with helm_release.karpenter
+```
+
+The error's `63.182.209.11` was the GitHub Actions runner's egress IP. The EKS endpoint is at `...eks.amazonaws.com`. The runner could not complete a TCP connection to that endpoint.
+
+### Root cause
+
+The cluster was provisioned with `public_access_cidrs = ["5.28.82.226/32"]` — the operator's home IP. GitHub-hosted Actions runners egress from AWS-wide IP ranges that rotate per job; there is no way to pre-whitelist a specific runner IP, and the published ranges (`https://api.github.com/meta` → `.actions`) are roughly 50 CIDRs that change periodically.
+
+The `/32` lockdown was chosen originally (ADR-013 "Control plane endpoint") as defense-in-depth on top of IAM auth. That intent was correct for operator-driven `kubectl`, but **incompatible with CI-managed Helm/kubectl**. The CI runner's AWS SDK calls (to STS, EKS, IAM) continued to work because those hit public AWS API endpoints that are not CIDR-gated; the **Kubernetes API** (a different endpoint class, gated by `public_access_cidrs`) rejected the runner's connection.
+
+The design blind spot was conflating "who can reach Kubernetes" with "who is the operator." In a single-operator lab with fully manual `kubectl`, `/32` lockdown works. In a lab where Terraform itself is the primary client of the Kubernetes API (via `helm_release` and `kubectl_manifest`), the client is the CI runner and its IP surface is wide and ephemeral.
+
+### Detection
+
+The error message was direct and pointed at the runner's public IP vs the cluster's DNS. A `whois 63.182.209.11` or a quick search confirmed the IP belongs to GitHub Actions' egress ranges. The conflict with the configured `public_access_cidrs` was immediate.
+
+### Resolution
+
+Relax `public_access_cidrs` to `["0.0.0.0/0"]` for the lab. The four auth layers (TLS, AWS IAM SigV4, EKS Access Entries, Kubernetes RBAC) remain the real gate; the CIDR lockdown was defense-in-depth above them, and the lab accepts losing that particular layer in exchange for CI-managed platform-as-code.
+
+Documented fully in:
+
+- `docs/decisions/013-eks-architecture.md` → new "Design iteration — public_access_cidrs relaxed to 0.0.0.0/0" section, which supersedes the original Decision paragraph and lays out the two corporate-fork alternatives (Option Z: GitHub Actions IP ranges; Option Y: self-hosted VPC runners).
+- `docs/runbooks/002-eks-access.md` → rewritten around the four-layer auth model; the IP drift diagnostic order is downgraded to step 5 (from step 1) because the CIDR is no longer the likely failure site.
+- `config/landing-zone.example.yaml` → the default value is now `0.0.0.0/0` with inline comments documenting Options Y and Z.
+- `config/landing-zone.yaml` (operator's local) → `0.0.0.0/0`; GitHub secret `LANDING_ZONE_CONFIG` refreshed in the same session.
+
+### Prevention
+
+**Before choosing a CIDR lockdown for any public AWS endpoint, enumerate the clients that will use it, including CI/CD.** If any client's IP is not pre-knowable, either (a) open to `0.0.0.0/0` and rely on IAM, (b) whitelist the CI provider's published ranges, or (c) move that client into the network (self-hosted runners, private endpoint + VPN). There is no fourth option.
+
+**"Defense in depth at the network layer" is an aesthetic, not a capability, when IAM already gates authentication.** This is not a universal statement — an Ingress Controller with no authentication in front of it absolutely needs a network-layer gate — but for authenticated AWS API endpoints (EKS, STS, IAM), the network gate is redundant with IAM and costs more in operational friction than it buys in reduced blast radius.
+
+The corporate-fork options (Y, Z) in ADR-013 document the path to re-add a network gate if the deployment context requires it (e.g., SOC 2, FedRAMP, or an internal audit checklist that flags `0.0.0.0/0`).
+
+### Lessons
+
+- **Design decisions that work in isolation can conflict when composed.** The ADR-013 decisions "public endpoint with CIDR lockdown" and "CI applies cluster resources via Helm/kubectl" were each sound; their composition was not. A design-review check for "does this decision imply a client, and is that client's network reachable?" would have caught it at ADR time.
+- **CI runner IPs are not whitelistable at lab budget.** A lab that depends on CI-managed cluster-API calls cannot also hold a narrow `public_access_cidrs`. Picking one of the two is a real architectural choice; forking a production-grade version that keeps both (via self-hosted runners) is a meaningful upgrade path.
+- **The IAM / RBAC auth stack is the real primary gate for any IAM-authenticated AWS service.** Network-layer gates are optional hardening. This reframes how to evaluate security-in-depth trade-offs for any AWS API: enumerate the gates, identify the primary, and only add secondary gates when they don't break a functional requirement.
+
+---
+
 ## Adding a new incident
 
 Append new sections at the bottom, before this footer, using the format:

--- a/docs/runbooks/002-eks-access.md
+++ b/docs/runbooks/002-eks-access.md
@@ -1,24 +1,25 @@
 # Runbook 002 — EKS operator access
 
-Scope: operational procedures for reaching the `aegis-staging` EKS cluster from the operator's laptop. Covers pre-flight checks, connectivity failure diagnosis, and the procedure for updating the allow-listed public IP when the operator's ISP reassigns it.
+Scope: operational procedures for reaching the `aegis-staging` EKS cluster from the operator's laptop. Covers the authentication model, the diagnostic order for `kubectl` connectivity failures, and the per-account IAM / Access Entry wiring.
 
-This runbook is the authoritative source for the operational contract behind the `eks.<env>.public_access_cidrs` field in `config/landing-zone.yaml`. See ADR-013 for the design rationale behind a public-endpoint-restricted-by-CIDR access model.
+This runbook pairs with ADR-013 ("EKS Architecture" + "Design iteration"). If the design iteration section of that ADR is unfamiliar, read it first — the iteration history explains why the endpoint is currently at `0.0.0.0/0` + IAM-primary rather than the originally-planned operator-`/32` lockdown.
 
 ---
 
-## 1. Pre-flight check — run this at the start of every EKS-touching session
+## 1. Current auth model — IAM-primary, four layers
 
-Before the first `kubectl`, `aws eks describe-*`, or `terraform apply` against `staging/platform`, verify that the operator's current public IP still matches the allow-list in the config.
+The EKS public endpoint is open at the network layer (`public_access_cidrs = ["0.0.0.0/0"]`). **This is not the same as "unauthenticated" or "insecure".** Four auth layers gate any call to the Kubernetes API:
 
-```bash
-curl -s https://checkip.amazonaws.com
-```
+| # | Layer | What it enforces |
+|---|---|---|
+| 1 | **TLS** | API server is HTTPS-only, cluster CA is rotated by AWS. `curl http://...` is not a thing. |
+| 2 | **AWS IAM (SigV4)** | Every Kubernetes API call must be signed by an AWS principal. Anonymous or expired tokens get `401 Unauthorized` before any Kubernetes RBAC is consulted. |
+| 3 | **EKS Access Entries** | The signed principal must have an Access Entry in the cluster mapping it to one or more Kubernetes RBAC roles. No Access Entry = no access, regardless of IAM permissions. |
+| 4 | **Kubernetes RBAC** | The mapped role must permit the specific API operation against the specific resource. `kubectl` verbs are further filtered here. |
 
-Compare the returned address with the value in `config/landing-zone.yaml` under `eks.staging.public_access_cidrs`. If they match → proceed normally. If they do not match → stop and go to section 3 before any cluster operation.
+**Attack surface is equivalent to the STS public endpoint.** Broad reachability does not translate to exploit capability without a valid credential + Access Entry + RBAC permission. Defense-in-depth at the network layer was considered but would require either self-hosted runners in the VPC (corporate Option Y in ADR-013) or whitelisting ~50 GitHub Actions published CIDRs (Option Z). For this single-operator lab, IAM-primary is the chosen model; corporate forks should adopt Option Y or Z.
 
-**Why this check matters.** Home ISPs (the operator is on a residential connection in Germany) reassign public IPs silently on router reboot, lease expiry, or provider-side renumbering. A mismatch does not break immediately — the allow-list is enforced by AWS on each connection, so existing kube-apiserver calls fail with a TLS handshake timeout rather than a clean 403. Diagnosing the failure downstream costs 10–20 minutes; `curl` costs 1 second. See section 4 for the `why-IP-first` diagnostic rule.
-
-**Responsibility.** Any AI agent working on this repository MUST run the check and warn the operator if mismatched, per the rule in `CLAUDE.md`. This is not optional.
+**Operator session expiry is a real defense layer.** SSO sessions are capped at 8 hours. A compromised laptop loses cluster access automatically within that window.
 
 ---
 
@@ -28,7 +29,7 @@ Prerequisites:
 
 - An active SSO session: `aws sso login --sso-session aegis`
 - The `aegis-staging-admin` profile selected: `export AWS_PROFILE=aegis-staging-admin`
-- The operator's public IP is in `eks.staging.public_access_cidrs` and the current `staging/platform` Terraform apply has landed.
+- `staging/platform` Terraform has applied (cluster exists and your SSO reserved role has an Access Entry)
 
 Fetch the kubeconfig entry (idempotent — safe to re-run):
 
@@ -39,29 +40,64 @@ aws eks update-kubeconfig --name aegis-staging --region eu-central-1
 Verify cluster reachability:
 
 ```bash
-kubectl get nodes            # should list Karpenter-managed EC2 + Fargate
-kubectl get pods -A          # baseline: CoreDNS, Karpenter controller
+kubectl get nodes            # Fargate + Karpenter-provisioned EC2
+kubectl get pods -A          # baseline: CoreDNS (Fargate), Karpenter (Fargate), LB Controller + ArgoCD (EC2)
 ```
 
-The `kubectl` token is derived from the SSO session and expires when the session expires (8 hours). Re-running `aws sso login --sso-session aegis` refreshes it; no kubeconfig re-generation is needed.
+The `kubectl` token is derived from the SSO session and expires when the session expires. Re-running `aws sso login --sso-session aegis` refreshes it; no kubeconfig regeneration is needed.
 
 ---
 
 ## 3. Connectivity failure — diagnostic order
 
-When `kubectl`, `aws eks describe-cluster`, or a platform-layer `terraform apply` hits a network error, follow this order. The ordering is deliberate: cheapest check first, most likely cause first. Do NOT skip ahead.
+When `kubectl`, `aws eks describe-cluster`, or a platform-layer `terraform apply` hits an auth or connection error, follow this order. The ordering reflects the **IAM-primary** model — the network layer is last, not first.
 
-### Step 1 — check your public IP
+### Step 1 — verify the SSO session is valid
 
 ```bash
-curl -s https://checkip.amazonaws.com
+aws sts get-caller-identity
 ```
 
-Compare with `config/landing-zone.yaml` → `eks.staging.public_access_cidrs`. If different, the IP drifted. Go to section 5 (update procedure).
+Expected: a non-expired principal ARN pointing at `AWSReservedSSO_PlatformAdmin_*` for staging.
 
-**This accounts for the overwhelming majority of connectivity breakages in this project.** Only move to step 2 if the IP matches.
+If this returns `ExpiredToken` or similar: `aws sso login --sso-session aegis`. SSO session expiry is the most common failure on a laptop that hasn't been touched for 8+ hours.
 
-### Step 2 — verify the cluster endpoint resolves and is reachable at the TLS layer
+### Step 2 — verify kubectl is using the current session
+
+```bash
+aws eks update-kubeconfig --name aegis-staging --region eu-central-1
+kubectl config current-context
+```
+
+Expected: context references `arn:aws:eks:eu-central-1:<account>:cluster/aegis-staging`.
+
+### Step 3 — verify you authenticate as the expected principal
+
+```bash
+kubectl auth whoami
+```
+
+Expected: the SSO role ARN for `PlatformAdmin` in staging, e.g. `arn:aws:iam::251774439261:role/aws-reserved/sso.amazonaws.com/eu-central-1/AWSReservedSSO_PlatformAdmin_*`.
+
+If the output differs: `kubectl config use-context <expected>`.
+
+### Step 4 — verify the Access Entry + policy association exist
+
+```bash
+aws eks list-access-entries --cluster-name aegis-staging
+
+aws eks list-associated-access-policies \
+  --cluster-name aegis-staging \
+  --principal-arn <your-sso-role-arn>
+```
+
+Expected: an entry for your role, associated with `arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy` at scope `cluster`.
+
+If absent: either `staging/platform` never applied, or the `aws_eks_access_entry` / `aws_eks_access_policy_association` for your principal failed. Check Terraform state and re-apply.
+
+### Step 5 — network layer (last)
+
+With `public_access_cidrs = ["0.0.0.0/0"]`, the network layer is rarely the cause. But verify the endpoint resolves and accepts TLS:
 
 ```bash
 ENDPOINT=$(aws eks describe-cluster --name aegis-staging \
@@ -69,116 +105,40 @@ ENDPOINT=$(aws eks describe-cluster --name aegis-staging \
 curl -sI --max-time 10 "${ENDPOINT}/healthz"
 ```
 
-- `Could not resolve host` → DNS issue, likely local network misconfiguration, not the cluster.
-- `TLS handshake timeout` → the CIDR allow-list is likely still rejecting you despite step 1 matching (possible IPv6 vs IPv4 split, VPN exit, corporate proxy). Try `curl -4 -s https://checkip.amazonaws.com` to confirm IPv4 egress IP.
-- `HTTP/2 401` → network layer is fine, you just lack valid credentials (section 4).
+Expected: `HTTP/2 401` (the handler responded; no valid creds was passed). If `Connection refused`, `TLS handshake timeout`, or `Could not resolve host`, the issue is your local network, a corporate proxy, or (rarely) an EKS endpoint outage.
 
-### Step 3 — verify the SSO session is valid
-
-```bash
-aws sts get-caller-identity
-```
-
-If this returns a 401 / `ExpiredToken`, the SSO session has expired. Refresh:
-
-```bash
-aws sso login --sso-session aegis
-```
-
-### Step 4 — verify kubectl is using the current session
-
-```bash
-aws eks update-kubeconfig --name aegis-staging --region eu-central-1
-kubectl config current-context   # should reference aegis-staging
-```
-
-### Step 5 — IAM / Access Entry diagnostics
-
-Only reach this step after all of the above pass. A `403 forbidden from server` or `Unauthorized` response from `kubectl` at this point indicates an Access Entry or RBAC misconfiguration, not a network layer problem.
-
-```bash
-# Confirm you are authenticating as the expected principal
-kubectl auth whoami
-
-# Confirm the Access Entry exists for your SSO role
-aws eks list-access-entries --cluster-name aegis-staging
-
-# Confirm the Access Entry has cluster-admin policy attached
-aws eks list-associated-access-policies \
-  --cluster-name aegis-staging \
-  --principal-arn <your-sso-role-arn>
-```
-
-Access Entry mismatches are rare and require Terraform changes to fix (see `terraform/environments/staging/platform/access-entries.tf`). This is deliberately the last step because it is the least likely cause and the most expensive to remediate.
+**If the project later narrows `public_access_cidrs` (moving to Option Y or Z in ADR-013),** this step moves higher in the diagnostic order and `curl https://checkip.amazonaws.com` becomes the quick pre-flight check again.
 
 ---
 
-## 4. Why IP-drift is the first suspect
+## 4. Updating `public_access_cidrs`
 
-The EKS public endpoint has four defensive layers: TLS, AWS IAM SigV4 auth, Kubernetes RBAC, and the CIDR allow-list. Three of those layers (TLS, IAM, RBAC) are stable — once configured, they do not change between sessions. The CIDR allow-list is the only layer whose correctness depends on a value (the operator's public IP) that drifts outside the operator's control.
+The CIDR list lives in `config/landing-zone.yaml` under `eks.staging.public_access_cidrs`. Editing it triggers an EKS cluster update (in-place, not a recreate) on the next `staging/platform` apply. Typical reasons to edit:
 
-Empirically: the operator's IP changes roughly every few weeks on a residential ISP. All other layers change only when this repository's Terraform changes. Therefore, on a cold-start "it doesn't work" symptom, the IP is the most likely drift site by a wide margin. Debugging IAM, kubeconfig, or RBAC first is a common time sink and explicitly discouraged — both by this runbook and by `CLAUDE.md`.
+- **Corporate fork adopting Option Z** — replace `0.0.0.0/0` with the GitHub Actions published CIDRs. Recommended to maintain a small script that fetches `https://api.github.com/meta | jq '.actions'` and commits the list; the field will grow / shrink over time.
+- **Corporate fork adopting Option Y** — self-hosted runners in the VPC means the cluster can be reached from inside; narrow to the operator `/32` + the runners' egress CIDR.
+- **Temporary lockdown during incident response** — narrow to operator `/32` to cut off automation during investigation, then widen again once safe.
 
----
-
-## 5. Update procedure when the IP has drifted
-
-### Preferred path — PR-driven
+Edit sequence (PR-driven, auditable):
 
 ```bash
-# 1. Capture the current IP
-curl -s https://checkip.amazonaws.com
+# 1. Edit config/landing-zone.yaml
+# 2. Refresh the GitHub secret that CI reads
+gh secret set LANDING_ZONE_CONFIG < config/landing-zone.yaml
 
-# 2. Edit config/landing-zone.yaml (gitignored — local only)
-#    Update eks.staging.public_access_cidrs to ["<new-ip>/32"]
-
-# 3. Edit config/landing-zone.example.yaml too if the placeholder is stale
-
-# 4. Commit + push + PR
-git checkout -b ops/update-operator-ip
-# (edit config files)
-git commit -sS -m "ops: rotate operator public IP allow-list"
-git push -u origin ops/update-operator-ip
-gh pr create --fill
-
-# 5. After merge — the staging/platform layer does not apply automatically
-#    (it's a cost-incurring workload layer). Trigger manually:
+# 3. PR + merge
+# 4. Workload apply picks it up
 gh workflow run terraform-apply-workload.yml -f env=staging
-gh run watch   # approve in UI
 ```
 
-End-to-end time: ~5 minutes (PR merge + one workload apply cycle).
-
-### Emergency path — local apply, then land the code immediately
-
-If the PR-driven path is blocked (CI outage, urgent need to reach the cluster):
-
-```bash
-export AWS_PROFILE=aegis-staging-admin
-aws sso login --sso-session aegis
-
-# Edit config/landing-zone.yaml locally
-cd terraform/environments/staging/platform
-terraform apply
-
-# IMMEDIATELY commit the config change to main
-#   — per Incident 6, code that lives only on a branch gets "corrected"
-#   by the next CI apply. The local change must land on main before the
-#   next baseline or workload apply.
-```
-
-Do not leave locally-applied state un-landed overnight. A merge to main between the local apply and the code landing will reconcile Terraform state against the (stale) main branch and destroy your change.
-
-### Why there is no auto-update script (yet)
-
-An obvious convenience would be a `scripts/update-operator-ip.sh` that reads `checkip.amazonaws.com`, rewrites the config, commits, and opens a PR. This is tracked as a future improvement. For now, the manual edit is deliberate — it forces the operator to see the new CIDR before applying it, which has prevented at least one incident of committing the wrong IP (corporate VPN exit vs. home IP) during this project's early Phase 3 work.
+Emergency local apply is possible but must be followed by a PR landing the change on main immediately (per Incident 6 — never leave local-apply state un-landed).
 
 ---
 
-## 6. Related references
+## 5. Related references
 
-- ADR-013 (`docs/decisions/013-eks-architecture.md`) — why the endpoint is public-with-CIDR-restriction
-- `CLAUDE.md` — the `before-EKS-operation` rule requiring the section 1 check
-- `config/schema.json` — the schema entry that enforces the CIDR format
+- ADR-013 (`docs/decisions/013-eks-architecture.md`) — endpoint design + Design iteration section covering the 0.0.0.0/0 decision
+- `CLAUDE.md` — the generic meta-rule pointing here before any `staging/platform` operation
 - `terraform/environments/staging/platform/access-entries.tf` — IAM → RBAC mapping
-- Incident 6 in `docs/incidents.md` — the "local apply drift" incident that motivates the "land it on main immediately" rule in section 5
+- `docs/incidents.md` Incident 12 — the first-cold-apply discovery that the `/32` lockdown was incompatible with CI-managed Helm
+- `docs/incidents.md` Incident 11 — Access Policy ARN namespace gotcha (EKS ≠ IAM)

--- a/terraform/environments/staging/platform/access-entries.tf
+++ b/terraform/environments/staging/platform/access-entries.tf
@@ -5,6 +5,16 @@
 # per ADR-013 "Operator access". Access Entries map AWS IAM principals
 # directly to Kubernetes RBAC via AWS-managed cluster policies.
 #
+# IMPORTANT: Access Policy ARNs have their OWN namespace, separate from
+# IAM Managed Policy ARNs. The correct format is:
+#
+#   arn:aws:eks::aws:cluster-access-policy/<PolicyName>
+#
+# NOT `arn:aws:iam::aws:policy/<PolicyName>`. Passing an IAM ARN to
+# aws_eks_access_policy_association fails at apply with
+# `InvalidParameterException: The policyArn parameter format is not valid`.
+# See Incident 11 in docs/incidents.md for the discovery story.
+#
 # Two principals need cluster-admin in staging:
 #
 #   1. The GitHub Actions CI role — so that the Helm and Kubernetes
@@ -42,7 +52,7 @@ resource "aws_eks_access_entry" "ci" {
 resource "aws_eks_access_policy_association" "ci_cluster_admin" {
   cluster_name  = aws_eks_cluster.main.name
   principal_arn = local.ci_role_arn
-  policy_arn    = "arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy"
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
 
   access_scope {
     type = "cluster"
@@ -95,7 +105,7 @@ resource "aws_eks_access_policy_association" "operator_cluster_admin" {
 
   cluster_name  = aws_eks_cluster.main.name
   principal_arn = local.platform_admin_role_arn
-  policy_arn    = "arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy"
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
 
   access_scope {
     type = "cluster"


### PR DESCRIPTION
## Summary

First cold apply of \`staging/platform\` (from workflow run #24382575682) failed on two distinct issues. Both are fixed here alongside three postmortems covering the full diagnostic arc of the Phase 3c bootstrap.

## Code fixes

### Incident 11 — EKS Access Policy ARN namespace

\`access-entries.tf\` was using the IAM managed-policy ARN form. EKS Access Policies live in their own namespace:

\`\`\`diff
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterAdminPolicy"
+  policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
\`\`\`

Two associations fixed (CI role + operator SSO role). Inline header comment added pointing at Incident 11 so the next reader / AI agent doesn't re-make the mistake.

### Incident 12 — \`public_access_cidrs\` relaxed to \`0.0.0.0/0\`

The \`/32\` operator-only lockdown blocked GitHub-hosted Actions runners from reaching the Kubernetes API. AWS API calls (STS, EKS, IAM) continued to work because those hit different public endpoints that are not CIDR-gated. Only the Kubernetes API (which IS CIDR-gated) rejected the runner.

Opened to \`0.0.0.0/0\` with AWS IAM SigV4 + EKS Access Entries + Kubernetes RBAC + 8h SSO session as the four primary auth layers. Corporate alternatives documented in ADR-013's new "Design iteration" section:

- **Option Z**: whitelist GitHub Actions published IP ranges (\`api.github.com/meta → .actions\`, ~50 CIDRs)
- **Option Y**: self-hosted runners inside the VPC, narrow to operator \`/32\` + runner egress CIDR

User guidance: lab takes \`0.0.0.0/0\`; corporate / enterprise forks should adopt Y or Z.

## Doc updates

- \`docs/decisions/013-eks-architecture.md\` — "Design iteration" section supersedes original endpoint paragraph; inline back-reference from the original text
- \`docs/runbooks/002-eks-access.md\` — complete rewrite around the four-layer auth model; IP drift dropped from diagnostic step 1 to step 5
- \`docs/incidents.md\` — three new postmortems:
  - **Incident 10** (retroactive): \`kubernetes_manifest\` plan-time schema bootstrap trap (fixed in PR #44)
  - **Incident 11**: EKS Access Policy ARN namespace
  - **Incident 12**: \`/32\` vs CI runners + "design decisions that work in isolation can conflict when composed" lesson
- \`config/landing-zone.example.yaml\` — default \`0.0.0.0/0\` + inline Option Y/Z comments

## Current live state

- VPC + NAT (~\$0.045/hr) — will stay up through the fix-apply cycle
- EKS cluster (~\$0.10/hr) — will remain; public_access_cidrs update is in-place, not recreate
- Fargate profiles, OIDC provider, Access Entries — already created
- Access Policy Associations — not created (errored); will be created by this PR's re-apply with the fixed ARN
- Helm releases (Karpenter, LB Controller, ArgoCD) — not created; will be created on re-apply with \`0.0.0.0/0\` allowing runner reachability

Total burn so far ~\$0.30. Not significant, but this is why fix-and-reapply fast.

## Post-merge sequence

\`\`\`bash
# 1. Merge PR (admin bypass — branch behind main due to PR #44)
gh pr merge <this> --merge --admin --delete-branch

# 2. Refresh GitHub secret (operator local config now has public_access_cidrs = 0.0.0.0/0)
gh secret set LANDING_ZONE_CONFIG < config/landing-zone.yaml

# 3. Re-dispatch workload apply
gh workflow run terraform-apply-workload.yml -f env=staging
gh run watch   # approve, network job no-op, platform job updates endpoint + creates failed resources
\`\`\`

## Test plan

- [ ] Plan management/bootstrap on this PR: no changes
- [ ] Plan staging/network on this PR: no changes
- [ ] Plan staging/platform (not in matrix, will not run on PR — expected)
- [ ] After merge + re-dispatch: EKS cluster update succeeds (endpoint CIDR change is in-place), Access Policy Associations create, Karpenter/LB Controller/ArgoCD Helm releases install, root Application applied
- [ ] \`kubectl get applications -n argocd\` shows \`root\` (may be OutOfSync if aegis-core empty — that's an aegis-core concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)