### PR TITLE
fix(karpenter): Helm release requires create_namespace = true

### DIFF
--- a/terraform/environments/staging/platform/karpenter-helm.tf
+++ b/terraform/environments/staging/platform/karpenter-helm.tf
@@ -22,10 +22,14 @@ resource "helm_release" "karpenter" {
   chart      = "karpenter"
   version    = "1.0.8"
 
-  # Ensure the namespace and Fargate profile exist before installing.
-  # The Fargate profile won't match pods until after install because Helm
-  # creates the Deployment in the same transaction — Kubernetes schedules
-  # the pods onto Fargate once the profile's namespace selector matches.
+  # The Fargate profile (fargate.tf) matches pods by namespace selector but
+  # does NOT create the namespace itself — that is a Kubernetes concern, not
+  # an AWS concern. Helm creates `karpenter` (and populates it with the
+  # controller Deployment + ServiceAccount + RBAC + CRDs) in the same
+  # transaction; Fargate then schedules the resulting pods because the
+  # namespace selector matches. See Incident 13 in docs/incidents.md for
+  # the discovery story (first cold apply of Phase 3c PR #45 hit this).
+  create_namespace = true
 
   values = [
     yamlencode({


### PR DESCRIPTION
## Summary

First cold apply of Phase 3c platform hit:

\`\`\`
Error: create: failed to create: namespaces "karpenter" not found
  with helm_release.karpenter
\`\`\`

Helm does not auto-create the target namespace. Fargate profile selectors *match* namespaces but do not *create* them (profile = AWS; namespace = K8s).

## Fix

Add \`create_namespace = true\` to the Karpenter \`helm_release\`. Same pattern as \`argocd.tf\` already uses. \`lb-controller.tf\` targets \`kube-system\` (K8s built-in) and doesn't need the flag.

## Current state mid-apply

PR #45's apply succeeded for:
- EKS cluster endpoint update (CIDR \`/32\` → \`0.0.0.0/0\`, in-place)
- \`aws_eks_access_policy_association\` for CI role + operator SSO role (Access Policy ARN fix from Incident 11 works ✅)

Then errored on Karpenter helm_release as above. Remaining 6+ resources (LB Controller, ArgoCD, kubectl_manifest CRDs) were not attempted. Re-apply after this fix should complete everything.

## Test plan

- [ ] Plan: no state changes for the completed resources
- [ ] Apply: Karpenter Helm installs successfully; \`kubectl -n karpenter get all\` shows controller Deployment on Fargate
- [ ] Downstream resources (LB Controller, ArgoCD, CRD manifests) also complete

Incident 13 postmortem for the namespace gotcha will be filed separately in the next doc PR (bundled with the interview-notes + portfolio-routing doc work already in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)