### PR TITLE
fix(karpenter): EC2NodeClass.spec.tags — remove Karpenter-reserved prefixes

### DIFF
--- a/terraform/environments/staging/platform/karpenter-nodepool.tf
+++ b/terraform/environments/staging/platform/karpenter-nodepool.tf
@@ -63,11 +63,20 @@ resource "kubectl_manifest" "karpenter_default_ec2nodeclass" {
 
       role = aws_iam_role.karpenter_node.name
 
-      tags = merge(local.tags, {
-        "karpenter.sh/discovery"                             = aws_eks_cluster.main.name
-        "kubernetes.io/cluster/${aws_eks_cluster.main.name}" = "owned"
-        "topology.kubernetes.io/region"                      = local.primary_region
-      })
+      # User-level tags only. Karpenter's admission webhook REJECTS tag
+      # prefixes it reserves for internal use:
+      #   - `kubernetes.io/cluster/*`    (Karpenter auto-applies `=owned`
+      #                                   to every EC2 it launches)
+      #   - `karpenter.sh/*`             (Karpenter internal bookkeeping)
+      #   - `karpenter.k8s.aws/*`        (Karpenter internal)
+      #
+      # Note also: `karpenter.sh/discovery` is the tag that should go on
+      # the *subnets* and *security groups* (consumed by
+      # subnetSelectorTerms / securityGroupSelectorTerms above), NOT on
+      # EC2NodeClass.spec.tags. The network layer handles subnet tagging.
+      #
+      # See docs/incidents.md Incident 14 for the webhook-rejection story.
+      tags = local.tags
     }
   })
 


### PR DESCRIPTION
## Summary

Phase 3c apply (run 24387984584) failed at Karpenter's admission webhook:

\`\`\`
EC2NodeClass ... is invalid: spec.***
  Invalid value: "object": tag contains a restricted tag matching
  kubernetes.io/cluster/
\`\`\`

Karpenter v1 reserves three tag prefixes for its internal bookkeeping on the EC2 instances it launches: \`kubernetes.io/cluster/*\`, \`karpenter.sh/*\`, and \`karpenter.k8s.aws/*\`. My \`karpenter-nodepool.tf\` set all three on \`EC2NodeClass.spec.tags\` — webhook rejected.

## Cascade failure

This single rejection caused three visible errors in the apply log:

1. \`kubectl_manifest.karpenter_default_ec2nodeclass\`: webhook rejection (root cause)
2. \`helm_release.argocd\`: pre-install hook timeout (no EC2 capacity because NodePool never created)
3. \`helm_release.aws_lb_controller\`: context deadline exceeded (same — no EC2 capacity)

Karpenter's controller itself runs on Fargate (PR #39), so it installed fine. But the two Helm releases that need EC2-schedulable nodes (LB Controller in \`kube-system\`, ArgoCD in its own namespace) couldn't schedule because EC2NodeClass was broken → NodePool absent → Karpenter couldn't provision.

## Fix

\`EC2NodeClass.spec.tags = local.tags\` (project-level user tags only). Inline comment documents the three Karpenter-reserved prefixes and the \`karpenter.sh/discovery\` concept correction (that tag belongs on subnets/SGs, not on the EC2NodeClass).

## Test plan

After merge + re-dispatch workload apply:

- [ ] \`kubectl get ec2nodeclass default\` → Ready
- [ ] \`kubectl get nodepool default\` → Ready
- [ ] \`kubectl get nodes\` shows Karpenter-provisioned Spot EC2 (appears after ~30-60s when LB Controller + ArgoCD pods schedule)
- [ ] \`helm list -A\` shows all 3 releases deployed (karpenter, aws-load-balancer-controller, argocd)
- [ ] \`kubectl -n argocd get app root\` → exists

Incident 14 postmortem will be filed in a follow-up doc PR alongside the pending Incident 13 (Karpenter namespace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)