### PR TITLE
fix(argocd): depends_on aws_lb_controller to avoid webhook race

### DIFF
--- a/terraform/environments/staging/platform/argocd.tf
+++ b/terraform/environments/staging/platform/argocd.tf
@@ -86,6 +86,15 @@ resource "helm_release" "argocd" {
 
   depends_on = [
     helm_release.karpenter, # ArgoCD needs EC2 capacity to schedule on
+    # AWS LB Controller installs a MutatingWebhookConfiguration that
+    # intercepts every Service creation. If Karpenter creates the Services
+    # in the same apply pass as the LB Controller (parallel helm installs),
+    # the webhook may have no backing endpoints yet — ArgoCD's Services
+    # then fail admission with:
+    #   "no endpoints available for service aws-load-balancer-webhook-service"
+    # Serialize the install so LB Controller's webhook is reachable before
+    # ArgoCD's Services hit admission. See Incident 17 in docs/incidents.md.
+    helm_release.aws_lb_controller,
   ]
 }
 


### PR DESCRIPTION
## Summary

Second re-apply of Phase 3c platform failed on the AWS LB Controller webhook race:

\`\`\`
Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws":
no endpoints available for service "aws-load-balancer-webhook-service"
\`\`\`

\`helm_release.argocd\` and \`helm_release.aws_lb_controller\` were running in parallel; ArgoCD's Services hit the LB Controller's mutating webhook before the controller's endpoints were populated.

## Fix

Add \`helm_release.aws_lb_controller\` to \`helm_release.argocd\`'s \`depends_on\`. LB Controller now fully deploys (webhook endpoints populated) before ArgoCD starts. ~30-60s slower total apply; worth it for reliability.

## Test plan

- [ ] Plan: the two helm_releases reorder; no other changes
- [ ] After merge + re-dispatch (with \`helm uninstall argocd\` to clean failed state first): ArgoCD pods all Running, root Application exists

Incident 17 postmortem in a follow-up doc PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)