### PR TITLE
chore(docs): pre-Phase-4 housekeeping — counts + principles doc + CLAUDE.md refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,14 @@ Some Terraservices layers have their own operational contracts — pre-flight ch
 
 - **Rule: When adding a new layer whose operations require their own diagnostic order (e.g., observability, service mesh), add a runbook under `docs/runbooks/` rather than extending this file.** Keeping CLAUDE.md small preserves its discoverability; layer-specific details belong with the layer.
 
+### Operational principles (as distinct from per-layer runbooks)
+
+Some rules are *cross-cutting* — they apply to reviewing any platform change, not just one layer. These live in `docs/principles/<topic>.md`.
+
+- **Rule: Before opening a PR that touches cluster components, Terraform provider versions, GitHub Actions workflows, IAM surfaces, or SCPs, AI must read `docs/principles/change-review-discipline.md` and answer the 5-step checklist in the PR description.** The checklist (blast radius / dependency assumptions / deprecation status / rollback plan / 2 AM readability) is short by design — if answering takes more than a paragraph per step, the PR is probably too big. Deprecation status specifically must reference the upstream upgrade guide (Terraform provider, Kubernetes API, GitHub Action) so future-me or a forker can trace how "deprecated" was determined at PR time, not after.
+
+- **Rule: When a new cross-cutting discipline emerges that applies to multiple layers (e.g., observability, security posture, release engineering), add a principles doc under `docs/principles/` rather than another CLAUDE.md section.** Same motivation as runbooks: this file stays small, subject-matter details live where the subject lives.
+
 ### Cross-repo coordination (landing-zone ↔ aegis-core)
 
 This repository shares a lifecycle boundary with [aegis-core](https://github.com/BinHsu/aegis-core) — the app-side repository that ArgoCD syncs from. The two repos are maintained by independent agents and must coordinate through durable artifacts, not direct IPC.
@@ -138,43 +146,42 @@ This repository shares a lifecycle boundary with [aegis-core](https://github.com
 
 ```
 aws-landing-zone-lab/
-├── README.md
-├── CLAUDE.md
+├── README.md                  # Public entry point (spirit + reading guide + architecture)
+├── CLAUDE.md                  # This file — operational rules for AI agents
 ├── terraform/
-│   ├── modules/
-│   │   ├── organizations/     # AWS Organizations, OUs, accounts
-│   │   ├── scp/               # Service Control Policies
-│   │   ├── sso/               # AWS Identity Center
-│   │   ├── oidc-github/       # GitHub OIDC provider
-│   │   ├── terraform-backend/ # S3 bucket + state config
-│   │   ├── vpc/               # VPC per account
-│   │   ├── eks/               # EKS cluster
-│   │   └── argocd/            # ArgoCD Helm deployment
-│   ├── environments/
-│   │   ├── management/        # Management account resources
-│   │   ├── security/          # Security account resources
-│   │   ├── staging/           # Staging account resources
-│   │   └── prod/              # Production account resources
-│   └── backend.tf             # Bootstrap backend config
-├── k8s-manifests/
-│   ├── argocd/                # ArgoCD app-of-apps
-│   ├── monitoring/            # Prometheus + Grafana
-│   └── apps/                  # Sample application
+│   └── environments/          # Terraservice layers (one state file per directory)
+│       ├── management/{bootstrap,scps}/
+│       ├── shared/{bootstrap,ipam}/   # shared/aft/ committed but not applied (ADR-011)
+│       ├── staging/{bootstrap,network,platform}/   # platform = EKS + Karpenter + ArgoCD
+│       └── prod/bootstrap/    # prod workloads not yet provisioned
+├── k8s-manifests/             # App-of-apps root (details live in aegis-core repo)
+├── config/
+│   ├── landing-zone.example.yaml   # Template for forkers
+│   ├── landing-zone.yaml           # Gitignored — actual deployment config
+│   └── schema.json                 # JSON Schema for validation
+├── scripts/
+│   ├── configure-backends.sh       # Sync backend.tf from config
+│   ├── configure-github.sh         # Set GitHub Actions + Dependabot secrets
+│   ├── validate-config.py          # JSON-Schema-validate config/landing-zone.yaml
+│   ├── teardown/                   # Soft / hard / emergency teardown scripts
+│   └── emergency/                  # nuke-workload-account.sh (triple-confirm)
 ├── .github/
-│   └── workflows/
-│       ├── terraform-plan.yml
-│       └── terraform-apply.yml
-├── docs/
-│   ├── architecture.md
-│   ├── phase1.md              # Phase 1 spec + design considerations
-│   ├── phase2.md              # Phase 2 spec
-│   ├── phase3.md              # Phase 3 spec
-│   ├── phase4.md              # Phase 4 spec
-│   └── decisions/             # ADRs (Architecture Decision Records)
-│       ├── 001-management-account-scope.md
-│       ├── 002-shared-services-account.md
-│       └── 003-multi-region-strategy.md
-└── README.md
+│   ├── workflows/
+│   │   ├── terraform-plan.yml
+│   │   ├── terraform-apply-baseline.yml
+│   │   ├── terraform-apply-workload.yml
+│   │   ├── terraform-teardown-workload.yml
+│   │   └── checkov.yml
+│   └── dependabot.yml
+└── docs/
+    ├── architecture.md             # Mermaid diagrams (account topology, CI/CD, IPAM, etc.)
+    ├── design-narrative.md         # 2-minute pitch + key decisions + war stories
+    ├── interview-notes.md          # Reader's guide for recruiters / architect peers
+    ├── incidents.md                # Append-only postmortems (24 as of 2026-04-15)
+    ├── decisions/                  # 13 ADRs (NNN-<topic>.md)
+    ├── runbooks/                   # 3 per-layer operational runbooks
+    ├── principles/                 # Cross-cutting discipline docs (e.g. change-review)
+    └── personal/                   # Gitignored — private portfolio brief
 ```
 
 ## Cost Guardrails

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Built solo by a **hands-on architect** — designs AND implements. Every file in
 
 Stance: ship the cross-cutting scope (multi-account governance, CI/CD, platform bootstrap, security posture, cost discipline) using current-but-stable tools, written line-by-line. Specialist depth in any single area (IAM policy minimization, Karpenter internals, Kubernetes controller-manager internals) is out of scope here and tagged with clear hand-off notes — not because I can't learn it, but because breadth + execution is where my value sits, and a specialist's depth is better invested when they arrive. Explicit scope in [`docs/interview-notes.md §4`](docs/interview-notes.md).
 
-The project value is execution *and* discipline, layered together: 13 ADRs (several with "Design iteration" sections documenting reversed decisions honestly), 20+ incident postmortems (written after the fact, never softened retroactively), 3 runbooks (AWS bootstrap / EKS operator access / platform first-time verification), and a 4-workflow CI/CD split shaped by cost profile rather than template copy-paste. None of it could be produced by someone who only draws architecture diagrams.
+The project value is execution *and* discipline, layered together: 13 ADRs (several with "Design iteration" sections documenting reversed decisions honestly), 24 incident postmortems (written after the fact, never softened retroactively), 3 runbooks (AWS bootstrap / EKS operator access / platform first-time verification), and a 4-workflow CI/CD split shaped by cost profile rather than template copy-paste. None of it could be produced by someone who only draws architecture diagrams.
 
 ## Reading guide
 
@@ -36,7 +36,7 @@ Different readers have different goals. Start here:
 | If you are… | Start here |
 |---|---|
 | You are a recruiter / hunter / HR | [`docs/interview-notes.md`](docs/interview-notes.md) — competency inventory, hands-on-architect stance, conservative-by-design trade-offs, and the explicit scope-of-claims |
-| You are a technical leader / architect peer | [`docs/decisions/`](docs/decisions/) (13 ADRs, with "Design iteration" sections) + [`docs/incidents.md`](docs/incidents.md) (12 postmortems of real failures) |
+| You are a technical leader / architect peer | [`docs/decisions/`](docs/decisions/) (13 ADRs, with "Design iteration" sections) + [`docs/incidents.md`](docs/incidents.md) (24 postmortems of real failures) |
 | You want the story behind the project | [`docs/design-narrative.md`](docs/design-narrative.md) — 2-minute pitch, key decisions, war stories |
 | You want the architecture diagrams | [`docs/architecture.md`](docs/architecture.md) — 5 Mermaid diagrams |
 | You want to reproduce this from zero | [`docs/runbooks/001-bootstrap-aws-account.md`](docs/runbooks/001-bootstrap-aws-account.md) |

--- a/docs/interview-notes.md
+++ b/docs/interview-notes.md
@@ -4,7 +4,7 @@ A reader's guide for recruiters, hiring managers, and technical leadership revie
 
 **Time budget**:
 - Recruiter / HR / hunter: read all of this doc (~10 min).
-- Technical leader / architect peer: skim section 1 (stance), then jump to [`docs/decisions/`](decisions/) for the 13 ADRs and [`docs/incidents.md`](incidents.md) for the 20 postmortems.
+- Technical leader / architect peer: skim section 1 (stance), then jump to [`docs/decisions/`](decisions/) for the 13 ADRs and [`docs/incidents.md`](incidents.md) for the 24 postmortems.
 
 ---
 
@@ -93,16 +93,16 @@ Each entry: what was built → where to look in the repo → the kind of questio
 
 **Built**: three layers of operational writing with explicit rules in [`CLAUDE.md`](../CLAUDE.md):
 - **ADRs** — 13 in [`docs/decisions/`](decisions/), supersede-in-place style ("Design iteration" sections note evolution)
-- **Incidents** — 20 in [`docs/incidents.md`](incidents.md), append-only, standard format
+- **Incidents** — 24 in [`docs/incidents.md`](incidents.md), append-only, standard format
 - **Runbooks** — 3 in [`docs/runbooks/`](runbooks/); CLAUDE.md rule requires AI agents to read the layer's runbook before operating on it
 
 **Where to look**:
 - [`CLAUDE.md`](../CLAUDE.md) — 6 explicit "Rule: AI must..." clauses
 - [`docs/decisions/`](decisions/) — 13 ADRs
-- [`docs/incidents.md`](incidents.md) — 20 postmortems
+- [`docs/incidents.md`](incidents.md) — 24 postmortems
 - [`docs/runbooks/`](runbooks/) — 3 runbooks
 
-**Likely questions**: show me a real incident (pick from the 20 in `docs/incidents.md` — Incidents 6, 7, 12, 18, 20 are the most informative for different angles: CMK recovery, cross-account IAM subtlety, design reversal, asymmetric policy, AWS-side orphan cleanup); what does the ADR format give you that code comments don't (ADRs preserve *why* even when *what* is obvious from code); how do you keep this discipline consistent (CLAUDE.md rules + pre-commit hooks + AI reminders — not willpower).
+**Likely questions**: show me a real incident (pick from the 24 in `docs/incidents.md` — Incidents 6, 7, 12, 18, 22, 24 cover the widest angle: CMK recovery, hidden cross-account prerequisites, honest design reversal, asymmetric IAM policy, belt-and-suspenders teardown architecture, and Terraform concurrency edge cases); what does the ADR format give you that code comments don't (ADRs preserve *why* even when *what* is obvious from code); how do you keep this discipline consistent (CLAUDE.md rules + pre-commit hooks + AI reminders — not willpower).
 
 ### 2.7 Cost governance
 
@@ -145,7 +145,7 @@ Positive statements of what this project demonstrates, paired with explicit stat
 ### What is claimed
 
 - **Cross-cutting architectural design**: composing 10+ AWS services into a working multi-account landing zone with explicit decisions (ADRs) and documented trade-offs.
-- **Operational discipline**: 13 ADRs + 20 incident postmortems + 3 runbooks, each written to a consistent format, never softened retroactively.
+- **Operational discipline**: 13 ADRs + 24 incident postmortems + 3 runbooks, each written to a consistent format, never softened retroactively.
 - **Production-shaped patterns** — not production-*hardened* (the lab is single-operator, single-region-primary, no DR-tested, no SOC 2 audit trail). The patterns are transferable to production; the lab itself isn't production.
 - **Reproducibility**: a single `config/landing-zone.yaml` + two shell scripts land the whole foundation in a fresh AWS organization. Fork-and-deploy is not a slogan here; it's tested.
 
@@ -178,7 +178,10 @@ IAM Identity Center, SSO user, permission set, cross-account IAM; Terraform stat
 GitHub OIDC, four GitHub Actions workflows split by cost profile, Checkov + pre-commit. PRs #9-#38 span this phase. Incidents 3, 6 (CMK destroyed by CI), 8 (OIDC subject claims) landed here.
 
 ### Phase 3 — EKS + Karpenter + ArgoCD (done)
-Three incremental PRs for core features (#39 EKS core, #42 Karpenter, #43 LB Controller + ArgoCD) plus a run of cold-apply hardening PRs (#44–#46, #48, #51, #53, #56, #57) that codified every first-apply discovery into infra-as-code so a forker's next cold apply is clean. Incidents 10–20 landed here, covering bootstrap traps, AWS-side auto-resource orphans, admission webhook races, IAM policy asymmetry, and teardown ordering with external-controller-managed resources.
+Three incremental PRs for core features (#39 EKS core, #42 Karpenter, #43 LB Controller + ArgoCD) plus a run of cold-apply hardening PRs (#44–#46, #48, #51, #53, #56, #57, #59, #62) that codified every first-apply discovery into infra-as-code so a forker's next cold apply is clean. Incidents 10–22 landed here, covering bootstrap traps, AWS-side auto-resource orphans, admission webhook races, IAM policy asymmetry, and the Karpenter-quiesce belt-and-suspenders teardown architecture (Incidents 19–22, all four layered on top of each other).
+
+### Post-Phase-3c — ongoing ops hygiene (done 2026-04-15)
+Two incidents caught during a Dependabot maintenance sweep after the Phase 3c rollout, both fixed via PRs #63 and #64: **Incident 23** — Dependabot PRs run in a separate secret namespace from Actions, so `scripts/configure-github.sh` now populates both; **Incident 24** — S3 native state locking is strictly FCFS with no queue, default `-lock-timeout=0` stampedes under bulk rebase, `terraform-plan.yml` now specifies `-lock-timeout=10m`. Same session also enabled GitHub Secret Scanning + push protection + Dependabot vulnerability alerts (free on public repos; directly validate the "zero static credentials by design" stance) and bumped the AWS Terraform provider v5.100 → v6.40 across all six Terraservices with baseline apply success on every leg.
 
 ### Phase 4 — Observability + security-at-cluster (not started)
 Prometheus + Grafana, VPC Flow Logs, GuardDuty, Security Hub, AWS Config conformance packs.
@@ -195,7 +198,7 @@ This doc is frame-level. For the actual substance:
 | Interest | Open |
 |---|---|
 | "Walk me through the architectural decisions" | [`docs/decisions/`](decisions/) — 13 ADRs |
-| "Show me real failures and what you learned" | [`docs/incidents.md`](incidents.md) — 20 postmortems |
+| "Show me real failures and what you learned" | [`docs/incidents.md`](incidents.md) — 24 postmortems |
 | "How do I reproduce this?" | [`docs/runbooks/001-bootstrap-aws-account.md`](runbooks/001-bootstrap-aws-account.md) |
 | "How would an AI agent work on this?" | [`CLAUDE.md`](../CLAUDE.md) |
 | "What does the config contract look like?" | [`config/landing-zone.example.yaml`](../config/landing-zone.example.yaml) + [`config/schema.json`](../config/schema.json) + [ADR-004](decisions/004-deployment-configuration-contract.md) |
@@ -203,4 +206,4 @@ This doc is frame-level. For the actual substance:
 
 ---
 
-*Last updated: 2026-04-14 — end of Phase 3c initial rollout.*
+*Last updated: 2026-04-15 — Post-Phase-3c ops hygiene sweep (provider v6 + Incidents 23/24 + GitHub security posture).*

--- a/docs/principles/change-review-discipline.md
+++ b/docs/principles/change-review-discipline.md
@@ -1,0 +1,168 @@
+# Change Review Discipline
+
+> **Scope**: platform-level change review — cluster components, EKS version upgrades, CNI/CSI, ingress controller, IAM surfaces, GitHub Actions workflow edits, Terraform provider / module bumps, SCP changes.
+>
+> **Not in scope**: application-manifest changes (Deployment/Service/HPA version bumps, Helm chart updates of app charts, app rollback procedures). Those belong to [`aegis-core`](https://github.com/BinHsu/aegis-core), not here. The ownership split mirrors the repository split documented in [ADR-007](../decisions/007-infra-app-repository-split.md).
+
+This document is an **operational discipline doc**, not an ADR. It captures *how* platform changes are reviewed on this repo — the mental checklist before a PR opens and the automated guardrails before it merges. ADRs record *what* was decided; this doc records *how to decide well*.
+
+---
+
+## 1. Why this matters more than usual for a platform repo
+
+A platform-level change has two qualities most application changes don't:
+
+1. **Blast radius is shared.** A broken ingress-controller-policy change takes down every service in the cluster; a broken Kubernetes API version assumption takes down every controller that depends on that API. The surface that *looks* like one file change is often the entry point to every workload on the cluster.
+2. **Deprecations arrive with long fuses.** Kubernetes deprecates APIs v+3 releases out; AWS deprecates resource attributes across provider major bumps; GitHub Actions deprecates syntax silently via Node version changes. The time between "noticed" and "broken" is long enough that the fix stops feeling urgent — which is exactly when it becomes a production surprise.
+
+Specific deprecations already on the horizon as of 2026:
+
+- **Ingress NGINX** retired 2026-03-24 (upstream EOL). Our platform avoids this by using AWS Load Balancer Controller instead — see [ADR-013 §Alternatives Considered](../decisions/013-eks-architecture.md). This is a concrete "conservative-by-design" decision that paid off without special effort.
+- **`discovery.k8s.io/v1.Endpoints`** deprecated in Kubernetes v1.33 (use `EndpointSlices`).
+- **`externalIPs` in `Service` type** deprecated v1.36.
+- **AWS provider v5 → v6** (major bump) — handled 2026-04-15; baseline apply succeeded across all six Terraservices. See Incident 24 aftermath for the Dependabot rebase sequencing.
+
+If any of the above surprised a team, it's because their discipline wasn't continuous. The cost of the discipline is lower than the cost of the surprise.
+
+---
+
+## 2. The 5-step checklist (applies to every platform PR)
+
+Before merging a platform change — whether a Terraform diff, a workflow edit, or a Helm value bump — the author (and reviewer) must answer all five. If any answer is "I don't know," the PR is not ready.
+
+### 2.1 Blast radius
+*If this change misbehaves, what is the smallest set of systems affected? The largest?*
+
+- "Only this one NodePool" — low blast.
+- "Every pod on the cluster" — high blast (e.g., CNI, kube-proxy replacement, admission webhook).
+- "Every workload account using the shared VPC" — highest blast.
+
+**Rule**: changes with cluster-wide or org-wide blast must include a rollback plan in the PR description, not just in the reviewer's head.
+
+### 2.2 Dependency assumptions
+*What is this change assuming about the state of other components?*
+
+- "Karpenter NodePool assumes Karpenter controller is running" — trivially true but worth naming.
+- "This IAM policy assumes the IRSA OIDC provider was already registered" — subtle; forgetting it caused Incident 11's family of delays.
+- "This Terraform data source assumes the remote state file is reachable from this principal" — caused Incident 5 (cross-account `kms:Decrypt` on `aws/s3`).
+
+**Rule**: list the non-obvious dependencies explicitly. "Obvious to me now" becomes "invisible in six months."
+
+### 2.3 Deprecation status of what's being touched
+*Is the API / resource / action version you're using still supported? For how long?*
+
+- **Terraform provider attributes**: check the provider's upgrade guide (e.g., [AWS provider v6 upgrade guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade)).
+- **Kubernetes APIs**: run `kubent` (see §3.1) against the cluster before the change; run `pluto` on the PR's Helm values and rendered YAML.
+- **GitHub Actions**: the `node20` → `node24` deprecation is an ongoing treadmill. Check the action's repo for "uses Node.js 20" warnings in its README or latest release notes.
+- **AWS service APIs**: check the service's deprecation notices (AWS generally deprecates with long fuses).
+
+**Rule**: if the thing you're touching is deprecated, the PR must either (a) migrate to the replacement, or (b) explicitly justify staying on the deprecated path with an end-of-life date.
+
+### 2.4 Rollback plan
+*If this change breaks something we didn't catch in review, how do we revert? How long does revert take?*
+
+- **Fastest**: `git revert` + CI apply. Viable when the change is a single commit and the state file is consistent with the code (most baseline changes).
+- **Medium**: revert the commit, then run a narrower apply (e.g., `terraform apply -target=...`). Needed when partial application has left state + AWS diverged.
+- **Slowest**: destroy + recreate the affected layer. Needed for stuck state locks or orphan resources (see Incidents 20, 22).
+
+**Rule**: "we'll figure it out" is not a rollback plan. Put the command line in the PR description.
+
+### 2.5 2 AM readability
+*If the on-call (including future-me) is debugging this at 2 AM, will the code make sense?*
+
+- Variable names descriptive enough to re-parse in a coffee-deprived brain?
+- Comments where the *why* is non-obvious and not captured elsewhere?
+- Resource names that collide with AWS's auto-generated ones? (Incident 20: EKS's auto-created cluster SG looks like a Terraform-managed one until it's orphaning your VPC.)
+- ADR reference in the PR description for the decision this change embodies?
+
+**Rule**: the code you ship is the code someone else will read under stress. Optimize for that reader.
+
+---
+
+## 3. Automated deprecation detection
+
+Human checklists degrade. Automate the detections that cost nothing to run.
+
+### 3.1 `kubent` — Kube-No-Trouble
+
+Scans a running cluster for resources using deprecated API versions. Runs against live state, so it catches what's *actually* there, not what the manifests *claim*.
+
+**CI integration** (recommended, not yet implemented):
+
+```yaml
+- name: kubent
+  run: |
+    kubectl apply -f - <<< "$(curl -sL https://raw.githubusercontent.com/doitintl/kube-no-trouble/master/installation/install.sh | sh)"
+    kubent --context $CLUSTER --exit-error-on-issue
+```
+
+**Local use** (today):
+
+```bash
+# After aws eks update-kubeconfig, per runbook 002
+kubent
+```
+
+### 3.2 `pluto` — static scanner
+
+Scans Helm charts, `kustomize` output, or raw YAML for deprecated API versions. Catches before apply; complementary to `kubent` (which catches after).
+
+**CI integration** (recommended):
+
+```yaml
+- name: pluto
+  run: |
+    pluto detect-files -d k8s-manifests/ --target-versions k8s=v1.32.0
+```
+
+### 3.3 Terraform provider upgrade diffing
+
+When a Dependabot PR bumps a provider across a major version boundary (v5 → v6), the `Terraform Plan` PR comment is the artifact. Expected signals:
+
+- **No resource changes** in plan output → clean major bump (AWS provider v6 on 2026-04-15 had this shape for all six Terraservices).
+- **Resource changes** in plan output → read each change carefully against the provider's upgrade guide. Likely renames / default changes, not bugs.
+- **Plan errors** → the provider's stricter validation in the new major version caught an existing misconfiguration. Fix the config, don't pin to old provider.
+
+### 3.4 Kubernetes API server deprecated-api metrics
+
+The API server emits `apiserver_requested_deprecated_apis` when a client uses a deprecated API. In a Phase 4+ observability stack, alert on any non-zero value. Today this metric is collected (EKS control plane logs go to CloudWatch) but not alerted on — tracked as a Phase 4 observability task.
+
+---
+
+## 4. Platform-level version tracking
+
+The living inventory of what's deployed and when it expires. Maintained in this document as a lightweight alternative to a CMDB until the cluster count justifies something heavier.
+
+> **Update rule**: whenever a platform component version changes (Terraform apply merged to main, Helm chart bumped, EKS upgrade performed), update this table in the same PR. Out-of-date version tracking is worse than no tracking.
+
+| Component | Version (as of 2026-04-15) | Upstream EOL / deprecation | Our migration trigger | ADR |
+|---|---|---|---|---|
+| Terraform CLI | 1.14.8 | — | — | [ADR-003](../decisions/003-terraform-backend-bootstrap.md) |
+| AWS provider | 6.40.0 | v5 EOL TBD | Dependabot PR when v7 releases | — |
+| EKS Kubernetes | 1.32 | ~14 months from GA | Three releases before EOL | [ADR-013](../decisions/013-eks-architecture.md) |
+| Karpenter | v1.0.8 | v0.x deprecated; on v1 | Hold on v1.x until v2 stabilizes | [ADR-013](../decisions/013-eks-architecture.md) |
+| AWS Load Balancer Controller | v2.8.2 | — | Bump with EKS minor | [ADR-013](../decisions/013-eks-architecture.md) |
+| ArgoCD | (per Helm chart version in `k8s-manifests/argocd/`) | — | Quarterly review | [ADR-013](../decisions/013-eks-architecture.md) |
+| cert-manager | Not deployed | — | Phase 5 (service mesh + per-pod TLS) | — |
+
+---
+
+## 5. How this connects to existing discipline
+
+- [**ADR-005 — ISO 27001 Annex A.8 Change Management**](../decisions/005-compliance-framework-iso-27001.md): the formal framework this doc is the *executable form* of. ADR-005 says "we do change management." This doc says "here is the checklist, here are the tools."
+- [**ADR-008 — Control Tower hybrid**](../decisions/008-landing-zone-tooling-control-tower-hybrid.md): tooling choices that pre-emptively reduce deprecation risk by staying on managed surfaces (Control Tower instead of hand-rolled Organizations wiring) where the cost-benefit favors them.
+- **Future Kyverno / admission-control ADR** (not yet written): admission webhooks are the *runtime* enforcement of the checks this doc runs at *review time*. Once Phase 4 observability is in place, admission-time deprecation blocks are the natural next layer.
+- [**CLAUDE.md**](../../CLAUDE.md): the operational rules that live at the project root. This doc defers to CLAUDE.md on anything it restates.
+
+---
+
+## 6. Boundary: what this document does NOT cover
+
+- **Application code changes**: see [`aegis-core`'s change discipline](https://github.com/BinHsu/aegis-core) when that repo documents its own (platform ≠ app).
+- **Hot-fixing production directly**: this repo has no production yet. When production is live, a "break-glass change" path will need its own runbook — not this doc.
+- **Dependency pinning strategy**: covered by Dependabot config (`.github/dependabot.yml`). This doc is about reviewing what Dependabot proposes, not about whether Dependabot should propose it.
+- **Incident response**: see [`docs/incidents.md`](../incidents.md) and the per-incident postmortems. This doc is preventive; incidents are post-hoc.
+
+---
+
+*Last updated: 2026-04-15 — initial doc, triggered by the backlog item flagged during Phase 3c rollout. Incident 24 (Terraform state-lock stampede under Dependabot bulk rebase) is the first case study that exercises step 2.4 (rollback plan) and 3.3 (provider upgrade diffing) from this checklist retroactively.*


### PR DESCRIPTION
## Summary

Docs-only sweep to bring every external-facing surface into sync with the actual repo state before Phase 4 begins.

- **interview-notes.md + README.md**: bump incident count 20 → 24 across all surfaces. Extend Phase 3 narrative through Incident 22. Add new "Post-Phase-3c — ongoing ops hygiene" section documenting Incidents 23/24, provider v5→v6 sweep, and the GitHub security posture enabled 2026-04-15.
- **docs/principles/change-review-discipline.md** (new): cross-cutting discipline doc — the platform-level counterpart to per-layer runbooks. 5-step checklist, automated deprecation detection recommendations, platform version tracking table, scope boundary. Backlog item flagged since Phase 3 kickoff; actionable now that the cluster is real.
- **CLAUDE.md**:
  - New "Operational principles" section with two rules (read principles doc before platform PR; future cross-cutting disciplines go under `docs/principles/` rather than back into CLAUDE.md).
  - Directory Structure refreshed from pre-Phase-0 aspirational layout to actual repo shape. No more phantom phase1-4.md files or `terraform/modules/` that never existed.

## Why now

Pre-Phase 4 cleanup: when a reader opens README, interview-notes, and CLAUDE.md in adjacent tabs, every count and every path should agree. Counts were honestly 4 behind (Incidents 21-24 added during Phase 3c rollout + hygiene sweep). CLAUDE.md's directory structure had never been refreshed since the project opened.

## Scope discipline — what is NOT in this PR

- No new ADRs. The change-review-discipline doc is explicitly *not* an ADR (no decision being made here — it's operational discipline documentation of the *how*, not the *what*).
- No workflow changes. Principles doc recommends `kubent`/`pluto` CI integration but does not add them — that's a Phase 4+ work item when observability tooling is in scope.
- No AWS changes. Zero Terraform diffs in this PR.

## Test plan

- [ ] All 4 required status checks green (3× Plan + Checkov). Plans should all report "No changes" since this is docs-only.
- [ ] Cross-repo audit clean: no `cross-repo/blocking` label on either side's open issues (verified during planning — aegis-core #11 standing, landing-zone #54 standing, #61 FYI only).
- [ ] Spot-check the new principles doc renders correctly in GitHub's markdown view (tables, links to ADRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)