### PR TITLE
feat: Phase 4a' docking station + 4b observability & flow logs

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -41,8 +41,7 @@ jobs:
             CKV_AWS_18,
             CKV_AWS_144,
             CKV2_AWS_62,
-            CKV_AWS_274,
-            CKV2_AWS_11
+            CKV_AWS_274
           # CKV_AWS_18  (S3 access logging) — deferred per ADR-003 Future Hardening.
           #   Enabling requires a separate log-destination bucket with ACL-based
           #   write permissions. Tracked for Phase 2 observability work.
@@ -54,9 +53,8 @@ jobs:
           # CKV_AWS_274 (AdministratorAccess policy) — intentional for lab per
           #   ADR-001 scope boundary and inline comments in oidc-github.tf.
           #   Production should scope down to per-environment minimum permissions.
-          # CKV2_AWS_11 (VPC Flow Logs) — deferred to Phase 4 per ADR-012
-          #   Consequences. Requires logarchive/bootstrap layer (not yet built)
-          #   to provision the central log destination bucket.
+          # CKV2_AWS_11 (VPC Flow Logs) — RESOLVED in Phase 4b. Flow Logs
+          #   enabled in staging/network/flow-logs.tf → S3 in staging account.
 
       - name: Upload SARIF to GitHub Security tab
         if: always()

--- a/docs/decisions/015-observability-tooling.md
+++ b/docs/decisions/015-observability-tooling.md
@@ -1,0 +1,79 @@
+# 015. Observability Tooling
+
+## Status
+Accepted
+
+## Context
+
+Phase 3c delivered a working EKS cluster, but with no metrics collection, no dashboards, and no alerting. The EKS control plane logs flow to CloudWatch (enabled at cluster creation), but there is no cluster-level or workload-level observability. An operator debugging at 2 AM has `kubectl` and guesswork.
+
+Phase 4b adds an observability stack. The decision is which stack.
+
+### Requirements
+
+1. **Cluster metrics**: node CPU/memory, pod status, Karpenter provisioning decisions, control plane health.
+2. **Workload metrics**: aegis-core gateway/engine request rates, latencies, error rates (when the workload arrives in 4a'').
+3. **Dashboards**: browser-accessible, no CLI gymnastics to view metrics.
+4. **Alerting foundation**: the ability to define alert rules (e.g., `apiserver_requested_deprecated_apis > 0` per the change-review-discipline doc §3.4). Alerting destinations (PagerDuty, Slack) are out of scope for the lab.
+5. **Cost discipline**: must tear down cleanly with the platform layer. Persistent costs when torn down should be < $2/month.
+6. **Portability**: the observability stack should transfer to any Kubernetes cluster, not just EKS. This is a portfolio project demonstrating general cloud-native skills, not AWS-specific integrations.
+
+### Bin's existing experience
+
+Bin has 3 years of Prometheus → Grafana operational experience: 12 alert rules deployed as Helm → ConfigMap → sidecar reload pipeline. This is not new territory — it is a consolidation of existing skills onto the EKS platform. The learning goal is integration with ArgoCD (GitOps-managed observability), not Prometheus itself.
+
+## Decision
+
+**`kube-prometheus-stack` Helm chart, deployed via ArgoCD app-of-apps.**
+
+`kube-prometheus-stack` is the community-maintained Helm chart that bundles:
+- **Prometheus Operator** — CRD-based Prometheus lifecycle management (`ServiceMonitor`, `PrometheusRule`, `Alertmanager`)
+- **Prometheus** — metrics scraping and storage
+- **Grafana** — dashboards, with 20+ pre-built Kubernetes dashboards included
+- **node-exporter** — host-level metrics (CPU, memory, disk, network per node)
+- **kube-state-metrics** — Kubernetes object state as metrics (pod phase, deployment replicas, etc.)
+- **Default alert rules** — KubeContainerWaiting, KubePodCrashLooping, NodeNotReady, etc.
+
+This chart is the de facto standard for single-cluster Kubernetes observability. It provides a complete stack in one Helm release, with sensible defaults and extensive customization via `values.yaml`.
+
+### Deployment model
+
+- **ArgoCD Application** in `apps/staging/` (aegis-core repo) pointing at the `kube-prometheus-stack` Helm chart from the `prometheus-community` repo.
+- **Namespace**: `monitoring` (created by ArgoCD's `CreateNamespace=true` — no Terraform-managed IRSA or NetworkPolicy dependency for the monitoring namespace, unlike the `aegis` workload namespace).
+- **Grafana Ingress**: AWS Load Balancer Controller provisions an ALB with ACM TLS (same pattern as future aegis-core ingress). Grafana is accessible via browser for the operator.
+- **Prometheus storage**: 20 GB `gp3` PersistentVolumeClaim. Acceptable to lose on teardown — lab metrics have no retention requirement. The PVC is created by Prometheus Operator; Karpenter schedules the pod on a node with EBS access.
+- **Retention**: 24 hours in-cluster (sufficient for a 4-hour session with margin). No long-term storage (Thanos/Mimir/Cortex are out of scope).
+
+### Cost
+
+| Component | Hourly (on Spot) | Per 4h session | Persistent when torn down |
+|---|---|---|---|
+| Prometheus + Grafana pods (~1 vCPU, 2 GB) | ~$0.03 | ~$0.12 | $0 (pods gone) |
+| node-exporter DaemonSet (minimal per-node) | ~$0.01 | ~$0.04 | $0 |
+| kube-state-metrics (tiny) | negligible | negligible | $0 |
+| Grafana ALB | ~$0.02 | ~$0.08 | $0 (ALB deleted with Ingress) |
+| EBS PVC (20 GB gp3) | $0.003 | $0.01 | $1.60/month if not deleted |
+
+**Total per session: ~$0.25.** Well within budget. The EBS PVC is the only persistent cost; destroying it on teardown (accepting metric loss) keeps monthly costs at zero.
+
+## Alternatives Considered
+
+**Amazon CloudWatch Container Insights.** Rejected. Container Insights costs $0.30 per node per hour for enhanced observability, which is $1.20/hour for a 4-node lab cluster — more than the entire Phase 3 baseline. Standard observability is cheaper but provides limited dashboards (no custom Grafana panels, no PromQL). Metrics are stored in CloudWatch Metrics at $0.30/metric/month for the first 10K — the combinatorial explosion of Kubernetes labels easily generates thousands of metrics. Additionally, Container Insights is AWS-only: the skills do not transfer to GKE, AKS, or bare-metal Kubernetes. For a portfolio project, vendor-neutral tooling is worth more than the convenience of a managed service.
+
+**Datadog.** Rejected. Datadog's free tier allows 5 hosts, which covers the lab, but the agent sends data to Datadog SaaS — introducing an external data dependency, requiring API key management, and demonstrating a vendor integration rather than an operational skill. The monthly cost for even one node on the Pro plan ($23/host/month) exceeds the entire project's monthly budget. A portfolio piece should demonstrate that the engineer can build observability, not purchase it.
+
+**Grafana Cloud free tier.** Considered. Grafana Cloud's free tier offers 10K metrics series and 50 GB logs — sufficient for the lab. However, it still sends data to a SaaS endpoint, requires a Grafana Cloud API key, and the scraping is done by Grafana Alloy (the agent), not Prometheus. The value proposition over self-hosted kube-prometheus-stack is managed Grafana — but for a single-cluster lab, self-hosting Grafana is trivial and demonstrates more skill than configuring a SaaS agent. Grafana Cloud would be the right choice for a team that wants to avoid Prometheus operations; this project intentionally opts in to Prometheus operations as a portfolio artifact.
+
+**Prometheus + Grafana without the Operator (raw Helm charts).** Considered. Installing `prometheus` and `grafana` Helm charts separately is simpler conceptually but loses the Operator's CRD-based lifecycle management (`ServiceMonitor`, `PrometheusRule`). Without the Operator, scrape targets are configured via Prometheus `scrape_configs` (static YAML), which does not integrate with ArgoCD's GitOps model as cleanly. The `kube-prometheus-stack` chart is larger but provides a coherent, tested bundle with all the CRDs pre-configured. The additional complexity is in the chart, not in the operator's mental model.
+
+## Consequences
+
+The `monitoring` namespace becomes a platform-provided namespace alongside `argocd` and `karpenter`. Unlike `aegis`, it is not Terraform-managed — ArgoCD creates it and owns its lifecycle.
+
+Workload teams (aegis-core) expose metrics by creating `ServiceMonitor` CRDs that target their pods. The Prometheus Operator discovers these monitors automatically. This is a clean contract: the platform provides Prometheus; the workload declares what to scrape.
+
+The `apiserver_requested_deprecated_apis` alert rule (from `docs/principles/change-review-discipline.md` §3.4) can now be implemented as a `PrometheusRule` CRD in the kube-prometheus-stack values. This closes the gap between "we should detect deprecated APIs" and "we actually do."
+
+Grafana dashboards are ephemeral — they are provisioned from the chart's built-in set and any ConfigMap-based custom dashboards. No persistent Grafana database. This is intentional: dashboards-as-code via Helm values is the GitOps-native pattern and avoids the "someone edited a dashboard in the UI and it was lost on restart" anti-pattern.
+
+The 24-hour in-cluster retention means metrics from previous sessions are not available. This is acceptable for a lab. If longer retention becomes useful (e.g., for week-over-week comparison), Thanos sidecar or remote-write to S3 can be added in a future phase without changing the core stack.

--- a/docs/decisions/017-workload-namespace-and-rbac-model.md
+++ b/docs/decisions/017-workload-namespace-and-rbac-model.md
@@ -1,0 +1,63 @@
+# 017. Workload Namespace and RBAC Model
+
+## Status
+Accepted
+
+## Context
+
+Phase 4a' delivers the "docking station" — the platform-side infrastructure that aegis-core workloads will deploy into. Before writing any Terraform, three questions need answers:
+
+1. **Namespace topology**: Should aegis-core's gateway and engine run in one shared namespace or separate namespaces?
+2. **Namespace lifecycle owner**: Should Terraform create the namespace, or should ArgoCD create it on first sync?
+3. **RBAC model**: What Kubernetes RBAC (beyond the existing cluster-admin for the operator) does the workload namespace need?
+
+The answers affect NetworkPolicy scope, IRSA trust policies, ArgoCD sync permissions, and the blast radius of a misconfigured workload.
+
+### Constraints
+
+- **Single operator, single application**: aegis-core is the only workload. There is no multi-tenancy requirement.
+- **ArgoCD auto-sync for staging**: CLAUDE.md mandates auto-sync for staging. The root Application in `argocd.tf` already sets `automated.prune = true` and `automated.selfHeal = true`.
+- **IRSA per-ServiceAccount scoping**: each IRSA role is bound to exactly one `namespace:serviceaccount` pair. Fewer namespaces means fewer IRSA roles to manage.
+- **NetworkPolicy is namespace-scoped**: a default-deny NetworkPolicy applies to the namespace it lives in. Per-component namespaces would require coordinating NetworkPolicies across namespace boundaries for gateway↔engine communication.
+- **Cost**: $0 — namespaces and RBAC objects are Kubernetes API resources with no AWS billing.
+
+## Decision
+
+### Single `aegis` namespace for all aegis-core workloads
+
+Gateway and engine pods share a single `aegis` namespace. This is appropriate because:
+
+- They are components of one application, not independent services. aegis-core's ADR-0017 describes the gateway as a gRPC client of the engine — they are co-designed and co-released.
+- A single namespace means gateway↔engine NetworkPolicy is an intra-namespace allow rule, not a cross-namespace rule. Simpler to write, easier to audit.
+- IRSA trust policies scope to `system:serviceaccount:aegis:<sa-name>`. Adding a second ServiceAccount in the same namespace is a one-line change; adding a second namespace requires a new IRSA role with a new trust policy.
+- ArgoCD's root Application already uses `CreateNamespace=true` as a sync option, but workload-specific resources target the `aegis` namespace via their manifests, not via ArgoCD creating it ad hoc.
+
+### Terraform creates the namespace; ArgoCD deploys into it
+
+The `aegis` namespace is created by Terraform in the `staging/workloads` layer, not by ArgoCD's `CreateNamespace=true` sync option. Reasons:
+
+- **Platform-side resources depend on the namespace existing**: IRSA skeleton roles reference the namespace in their trust policy subject (`system:serviceaccount:aegis:*`). The default-deny NetworkPolicy lives in the namespace. These are Terraform-managed resources that must exist before any workload syncs.
+- **Terraform owns the contract; ArgoCD owns the contents**: the namespace, IRSA roles, and NetworkPolicy base are part of the platform surface contract ([#54](https://github.com/BinHsu/aegis-aws-landing-zone/issues/54)). Workload Deployments, Services, and Ingresses are aegis-core's concern, synced by ArgoCD.
+- **Teardown ordering**: `terraform destroy` of the workloads layer can clean up the namespace and its dependent IAM roles in one pass. If ArgoCD owned the namespace, teardown would require sequencing ArgoCD app deletion before Terraform destroy — adding the kind of ordering dependency that caused Incidents 20 and 22.
+
+### No namespace-scoped RBAC for Phase 4
+
+The existing `aegis-cluster-admins` group (bound to `cluster-admin` ClusterRole via `cluster-role-binding.tf`) is sufficient for a single-operator lab. Adding namespace-scoped Roles and RoleBindings would be RBAC machinery with no consumer — the only human principal already has cluster-admin, and pod-level access is governed by IRSA, not RBAC.
+
+If multi-tenancy or a second operator arrives (not planned — see `docs/phase4.md` §What is NOT Phase 4), RBAC scoping becomes a real requirement and should get its own ADR at that point.
+
+## Alternatives Considered
+
+**Per-component namespaces (`aegis-gateway`, `aegis-engine`).** Rejected. Adds operational overhead without security benefit in a single-application, single-operator context. Cross-namespace communication requires explicit NetworkPolicy allow rules on both sides, doubles the IRSA role count, and splits ArgoCD sync targets. The Kubernetes best practice of "namespace per team" does not apply when there is one team.
+
+**ArgoCD creates the namespace via `CreateNamespace=true`.** Rejected. ArgoCD's `CreateNamespace=true` is a convenience for application namespaces that have no platform-side dependencies. The `aegis` namespace has Terraform-managed IRSA roles and NetworkPolicies that must exist before the first workload sync. Letting ArgoCD create the namespace would either (a) race with Terraform, or (b) require Terraform to import the ArgoCD-created namespace — both fragile.
+
+**Namespace-scoped RBAC with dedicated ServiceAccounts for CI and operator.** Deferred. Valid for production multi-tenancy but premature for this lab. The operator has cluster-admin; CI has cluster-admin via Access Entries. Adding namespace-scoped bindings would be defense-in-depth with no threat model to defend against — the only principals are the operator and CI, both already trusted at the cluster level.
+
+## Consequences
+
+The `staging/workloads` layer creates the `aegis` namespace and is the owner of its lifecycle. Any future workload layer changes (adding a second namespace, tightening RBAC) are Terraform changes in this layer, not ArgoCD manifest changes.
+
+The platform surface contract ([#54](https://github.com/BinHsu/aegis-aws-landing-zone/issues/54)) must be updated to document the `aegis` namespace as the deployment target for aegis-core workloads.
+
+ArgoCD's root Application (in `argocd.tf`) continues to point at `apps/staging/` in aegis-core. Aegis-core manifests must target `namespace: aegis` in their Deployment/Service/Ingress metadata. If they target a different namespace, ArgoCD will create it (due to `CreateNamespace=true`) — but that namespace will lack IRSA and NetworkPolicy. This is an intentional fail-safe: workloads landing outside `aegis` will not have AWS permissions, making the misconfiguration visible immediately rather than silently permissive.

--- a/docs/principles/change-review-discipline.md
+++ b/docs/principles/change-review-discipline.md
@@ -135,14 +135,15 @@ The living inventory of what's deployed and when it expires. Maintained in this 
 
 > **Update rule**: whenever a platform component version changes (Terraform apply merged to main, Helm chart bumped, EKS upgrade performed), update this table in the same PR. Out-of-date version tracking is worse than no tracking.
 
-| Component | Version (as of 2026-04-15) | Upstream EOL / deprecation | Our migration trigger | ADR |
+| Component | Version (as of 2026-04-16) | Upstream EOL / deprecation | Our migration trigger | ADR |
 |---|---|---|---|---|
 | Terraform CLI | 1.14.8 | — | — | [ADR-003](../decisions/003-terraform-backend-bootstrap.md) |
-| AWS provider | 6.40.0 | v5 EOL TBD | Dependabot PR when v7 releases | — |
+| AWS provider | 5.100.0 | v5 EOL TBD | Dependabot PR when v6 releases | — |
 | EKS Kubernetes | 1.32 | ~14 months from GA | Three releases before EOL | [ADR-013](../decisions/013-eks-architecture.md) |
 | Karpenter | v1.0.8 | v0.x deprecated; on v1 | Hold on v1.x until v2 stabilizes | [ADR-013](../decisions/013-eks-architecture.md) |
 | AWS Load Balancer Controller | v2.8.2 | — | Bump with EKS minor | [ADR-013](../decisions/013-eks-architecture.md) |
-| ArgoCD | (per Helm chart version in `k8s-manifests/argocd/`) | — | Quarterly review | [ADR-013](../decisions/013-eks-architecture.md) |
+| ArgoCD | 7.6.12 (chart) | — | Quarterly review | [ADR-013](../decisions/013-eks-architecture.md) |
+| kube-prometheus-stack | 72.6.2 (chart) | — | Dependabot or manual review | [ADR-015](../decisions/015-observability-tooling.md) |
 | cert-manager | Not deployed | — | Phase 5 (service mesh + per-pod TLS) | — |
 
 ---

--- a/terraform/environments/staging/network/flow-logs.tf
+++ b/terraform/environments/staging/network/flow-logs.tf
@@ -1,0 +1,89 @@
+# -----------------------------------------------------------------------------
+# VPC Flow Logs — Phase 4b
+# -----------------------------------------------------------------------------
+# Network audit trail: all accepted/rejected traffic logged to S3. Delivers
+# to a staging-local bucket for now; migration to a centralized logarchive
+# bucket (ADR-006: aegis-logarchive account) is a future improvement.
+#
+# Cost: negligible at lab traffic volume — Flow Logs publishing to S3 is
+# $0.25/GB for the first 10 TB (minimal in a lab). Storage: $0.023/GB/month
+# for S3 Standard, transitions to IA after 90 days ($0.0125/GB/month).
+# Expected total: < $0.50/month.
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "flow_logs" {
+  bucket = "aegis-staging-vpc-flow-logs-${local.account_id}"
+
+  tags = {
+    Name = "staging-vpc-flow-logs"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  rule {
+    id     = "transition-to-ia"
+    status = "Enabled"
+
+    transition {
+      days          = 90
+      storage_class = "STANDARD_IA"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "flow_logs" {
+  bucket = aws_s3_bucket.flow_logs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Flow Log — captures all traffic (ACCEPT + REJECT) in the default format.
+# max_aggregation_interval = 600 (10 min) balances cost vs. resolution.
+# -----------------------------------------------------------------------------
+
+resource "aws_flow_log" "main" {
+  vpc_id               = aws_vpc.main.id
+  traffic_type         = "ALL"
+  log_destination      = aws_s3_bucket.flow_logs.arn
+  log_destination_type = "s3"
+
+  max_aggregation_interval = 600
+
+  destination_options {
+    file_format        = "parquet"
+    per_hour_partition = true
+  }
+
+  tags = {
+    Name = "staging-vpc-flow-log"
+  }
+}

--- a/terraform/environments/staging/network/flow-logs.tf
+++ b/terraform/environments/staging/network/flow-logs.tf
@@ -35,6 +35,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
       days = 365
     }
   }
+
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "flow_logs" {

--- a/terraform/environments/staging/network/main.tf
+++ b/terraform/environments/staging/network/main.tf
@@ -8,8 +8,7 @@
 # CIDR allocated dynamically from the shared/ipam regional pool (RFC1918
 # 10.0.0.0/12 for eu-central-1). Specific CIDR is known-after-apply.
 #
-# VPC Flow Logs are deferred to Phase 4 when the logarchive layer is
-# available. See ADR-012 "Consequences" for the deferral note.
+# VPC Flow Logs: see flow-logs.tf (added in Phase 4b).
 # -----------------------------------------------------------------------------
 
 # -----------------------------------------------------------------------------

--- a/terraform/environments/staging/workloads/backend.tf
+++ b/terraform/environments/staging/workloads/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "staging/workloads/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/staging/workloads/config.tf
+++ b/terraform/environments/staging/workloads/config.tf
@@ -1,0 +1,51 @@
+# -----------------------------------------------------------------------------
+# Configuration Contract — ADR-004
+# -----------------------------------------------------------------------------
+
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.staging.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+
+  cluster_name = "${local.config.organization.name}-staging"
+
+  # From platform remote state — cluster connection details for the
+  # kubernetes provider and IRSA trust policy references.
+  cluster_endpoint  = data.terraform_remote_state.staging_platform.outputs.cluster_endpoint
+  cluster_ca        = data.terraform_remote_state.staging_platform.outputs.cluster_certificate_authority_data
+  oidc_provider_arn = data.terraform_remote_state.staging_platform.outputs.oidc_provider_arn
+  oidc_provider_url = data.terraform_remote_state.staging_platform.outputs.oidc_provider_url
+
+  tags = merge(local.config.tags, {
+    Environment = "staging"
+    Component   = "workloads"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Cross-layer state reads
+# -----------------------------------------------------------------------------
+# The workloads layer depends on the platform layer (EKS cluster, OIDC
+# provider) being applied first. Apply order is enforced by the
+# terraform-apply-workload.yml workflow (network → platform → workloads).
+# -----------------------------------------------------------------------------
+
+data "terraform_remote_state" "staging_platform" {
+  backend = "s3"
+  config = {
+    bucket = "aegis-terraform-state-345895787808"
+    key    = "staging/platform/terraform.tfstate"
+    region = "eu-central-1"
+  }
+}
+
+check "platform_layer_applied" {
+  assert {
+    condition = (
+      data.terraform_remote_state.staging_platform.outputs != null &&
+      try(data.terraform_remote_state.staging_platform.outputs.cluster_endpoint, "") != ""
+    )
+    error_message = "staging/platform has not been applied — cluster_endpoint is empty. Apply staging/platform before staging/workloads (gh workflow run terraform-apply-workload.yml -f env=staging)."
+  }
+}

--- a/terraform/environments/staging/workloads/irsa.tf
+++ b/terraform/environments/staging/workloads/irsa.tf
@@ -1,0 +1,40 @@
+# -----------------------------------------------------------------------------
+# IRSA skeleton — engine ServiceAccount
+# -----------------------------------------------------------------------------
+# Trust policy is ready; no permission policy attached yet. The actual
+# permissions depend on what aegis-core's engine needs (S3 for audio,
+# SQS for job queue, etc.) — those will be added in Phase 4a'' when the
+# workload requirements are concrete.
+#
+# The gateway does not need AWS permissions — it is a gRPC proxy between
+# the ALB and the engine pool. If that changes, add a second IRSA role
+# following this same pattern.
+#
+# Per ADR-013, IRSA is the chosen mechanism for all pod → AWS API access.
+# The trust policy scopes to exactly one namespace:serviceaccount pair.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "aegis_engine" {
+  name = "${local.cluster_name}-aegis-engine"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = local.oidc_provider_arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.oidc_provider_url}:aud" = "sts.amazonaws.com"
+          "${local.oidc_provider_url}:sub" = "system:serviceaccount:aegis:aegis-engine"
+        }
+      }
+    }]
+  })
+
+  tags = {
+    Name = "${local.cluster_name}-aegis-engine"
+  }
+}

--- a/terraform/environments/staging/workloads/namespace.tf
+++ b/terraform/environments/staging/workloads/namespace.tf
@@ -1,0 +1,18 @@
+# -----------------------------------------------------------------------------
+# Workload namespace — ADR-017
+# -----------------------------------------------------------------------------
+# Terraform creates the namespace; ArgoCD deploys workload contents into it.
+# Platform-side resources (IRSA roles, NetworkPolicies) depend on the
+# namespace existing before any workload syncs.
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_namespace_v1" "aegis" {
+  metadata {
+    name = "aegis"
+
+    labels = {
+      "app.kubernetes.io/part-of"    = "aegis"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}

--- a/terraform/environments/staging/workloads/network-policy.tf
+++ b/terraform/environments/staging/workloads/network-policy.tf
@@ -1,0 +1,70 @@
+# -----------------------------------------------------------------------------
+# Default-deny NetworkPolicy — ADR-017
+# -----------------------------------------------------------------------------
+# Denies all ingress and egress in the aegis namespace by default. Workload
+# manifests (in aegis-core) must create explicit allow rules for:
+#   - gateway ← ALB ingress
+#   - engine  ← gateway (gRPC)
+#   - egress  → DNS (kube-dns), AWS APIs (HTTPS)
+#
+# This is a security posture decision: deny-by-default means a
+# misconfigured workload cannot communicate until explicitly allowed.
+# The NetworkPolicy only takes effect when a CNI that supports
+# NetworkPolicy is installed (VPC CNI with network policy support,
+# enabled by default on EKS 1.25+).
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_network_policy_v1" "default_deny" {
+  metadata {
+    name      = "default-deny-all"
+    namespace = kubernetes_namespace_v1.aegis.metadata[0].name
+  }
+
+  spec {
+    pod_selector {}
+
+    policy_types = ["Ingress", "Egress"]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Allow DNS egress — without this, pods cannot resolve service names.
+# Scoped to kube-dns on port 53 (TCP + UDP).
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_network_policy_v1" "allow_dns" {
+  metadata {
+    name      = "allow-dns-egress"
+    namespace = kubernetes_namespace_v1.aegis.metadata[0].name
+  }
+
+  spec {
+    pod_selector {}
+
+    policy_types = ["Egress"]
+
+    egress {
+      ports {
+        port     = "53"
+        protocol = "UDP"
+      }
+      ports {
+        port     = "53"
+        protocol = "TCP"
+      }
+
+      to {
+        namespace_selector {
+          match_labels = {
+            "kubernetes.io/metadata.name" = "kube-system"
+          }
+        }
+        pod_selector {
+          match_labels = {
+            "k8s-app" = "kube-dns"
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/environments/staging/workloads/observability.tf
+++ b/terraform/environments/staging/workloads/observability.tf
@@ -1,0 +1,139 @@
+# -----------------------------------------------------------------------------
+# Observability stack — ADR-015
+# -----------------------------------------------------------------------------
+# kube-prometheus-stack deployed as an ArgoCD Application. ArgoCD manages the
+# Helm release lifecycle (install, upgrade, rollback); Terraform manages the
+# Application CRD. This is the same pattern as the root Application in
+# staging/platform/argocd.tf.
+#
+# The Application targets the prometheus-community Helm chart directly —
+# ArgoCD supports Helm chart repos as source type. Helm values are inline
+# in the Application spec, making them visible in the ArgoCD UI and
+# auditable via git diff on this file.
+#
+# Access: Grafana is ClusterIP — use `kubectl port-forward` for browser
+# access (same pattern as ArgoCD UI today). ALB + ACM ingress is a
+# follow-up when a Route 53 domain is wired up.
+#
+# Chart version: pinned to a known-good release. Update via PR when
+# Dependabot or manual review identifies a newer version. ArgoCD will
+# not auto-upgrade — targetRevision is an exact pin.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "kube_prometheus_stack" {
+  yaml_body = yamlencode({
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "Application"
+    metadata = {
+      name      = "kube-prometheus-stack"
+      namespace = "argocd"
+      finalizers = [
+        "resources-finalizer.argocd.argoproj.io",
+      ]
+    }
+    spec = {
+      project = "default"
+
+      source = {
+        repoURL        = "https://prometheus-community.github.io/helm-charts"
+        targetRevision = "72.6.2"
+        chart          = "kube-prometheus-stack"
+
+        helm = {
+          releaseName = "kube-prometheus-stack"
+          values = yamlencode({
+            # -----------------------------------------------------------------
+            # Prometheus
+            # -----------------------------------------------------------------
+            prometheus = {
+              prometheusSpec = {
+                retention = "24h"
+                resources = {
+                  requests = { cpu = "200m", memory = "512Mi" }
+                  limits   = { memory = "1Gi" }
+                }
+                storageSpec = {
+                  volumeClaimTemplate = {
+                    spec = {
+                      storageClassName = "gp2"
+                      accessModes      = ["ReadWriteOnce"]
+                      resources = {
+                        requests = { storage = "20Gi" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            # -----------------------------------------------------------------
+            # Grafana — lab-sized, ClusterIP access via port-forward
+            # -----------------------------------------------------------------
+            grafana = {
+              resources = {
+                requests = { cpu = "50m", memory = "128Mi" }
+                limits   = { memory = "256Mi" }
+              }
+              adminPassword = "aegis-lab-grafana"
+            }
+
+            # -----------------------------------------------------------------
+            # Alertmanager — disabled. No alerting targets (PagerDuty, Slack)
+            # in the lab. Alert rules are still evaluated by Prometheus and
+            # visible in the Prometheus UI; they just don't route anywhere.
+            # -----------------------------------------------------------------
+            alertmanager = {
+              enabled = false
+            }
+
+            # -----------------------------------------------------------------
+            # Custom alert rules — deprecated API detection
+            # -----------------------------------------------------------------
+            # Per docs/principles/change-review-discipline.md §3.4, alert on
+            # any non-zero value of apiserver_requested_deprecated_apis. This
+            # metric is emitted by the API server when a client uses a
+            # deprecated API version.
+            # -----------------------------------------------------------------
+            additionalPrometheusRulesMap = {
+              deprecated-apis = {
+                groups = [{
+                  name = "deprecated-api-detection"
+                  rules = [{
+                    alert = "KubernetesDeprecatedAPIUsed"
+                    expr  = "apiserver_requested_deprecated_apis > 0"
+                    for   = "5m"
+                    labels = {
+                      severity = "warning"
+                    }
+                    annotations = {
+                      summary     = "Deprecated Kubernetes API in use"
+                      description = "The API {{ $labels.resource }}.{{ $labels.group }}/{{ $labels.version }} is deprecated. Migrate before the removal version."
+                    }
+                  }]
+                }]
+              }
+            }
+          })
+        }
+      }
+
+      destination = {
+        server    = "https://kubernetes.default.svc"
+        namespace = "monitoring"
+      }
+
+      syncPolicy = {
+        automated = {
+          prune    = true
+          selfHeal = true
+        }
+        syncOptions = [
+          "CreateNamespace=true",
+          "ServerSideApply=true",
+        ]
+      }
+    }
+  })
+
+  depends_on = [kubernetes_namespace_v1.aegis]
+}

--- a/terraform/environments/staging/workloads/outputs.tf
+++ b/terraform/environments/staging/workloads/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  description = "Workload namespace name"
+  value       = kubernetes_namespace_v1.aegis.metadata[0].name
+}
+
+output "engine_irsa_role_arn" {
+  description = "IRSA role ARN for the aegis-engine ServiceAccount"
+  value       = aws_iam_role.aegis_engine.arn
+}

--- a/terraform/environments/staging/workloads/providers.tf
+++ b/terraform/environments/staging/workloads/providers.tf
@@ -1,0 +1,44 @@
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}
+
+# -----------------------------------------------------------------------------
+# Kubernetes provider — authenticates to the EKS cluster via the platform
+# layer's remote state outputs. Used for namespace, NetworkPolicy, and any
+# future K8s resources in the workloads layer.
+#
+# Auth model matches staging/platform/providers.tf: exec-based token
+# acquisition via `aws eks get-token`. The calling principal (CI role or
+# operator SSO) must be mapped to an EKS Access Entry — see
+# staging/platform/access-entries.tf.
+# -----------------------------------------------------------------------------
+provider "kubernetes" {
+  host                   = local.cluster_endpoint
+  cluster_ca_certificate = base64decode(local.cluster_ca)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--region", local.primary_region]
+  }
+}
+
+# kubectl provider — used for ArgoCD Application CRDs. Auth matches the
+# kubernetes provider above. See staging/platform/providers.tf for rationale.
+provider "kubectl" {
+  host                   = local.cluster_endpoint
+  cluster_ca_certificate = base64decode(local.cluster_ca)
+  load_config_file       = false
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", local.cluster_name, "--region", local.primary_region]
+  }
+}

--- a/terraform/environments/staging/workloads/versions.tf
+++ b/terraform/environments/staging/workloads/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+    # kubectl provider for ArgoCD Application CRDs — deferred plan-time
+    # schema validation avoids the bootstrap trap where kubernetes_manifest
+    # requires the CRD to be reachable at plan time. See
+    # staging/platform/karpenter-nodepool.tf and Incident 10.
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.19"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **ADR-017**: workload namespace model — single `aegis` namespace, Terraform-owned lifecycle, no extra RBAC for single-operator lab
- **ADR-015**: observability tooling — kube-prometheus-stack chosen over Container Insights / Datadog / Grafana Cloud (cost, portability, skills transfer)
- **4a' docking station** (`staging/workloads`): namespace `aegis` + default-deny NetworkPolicy + DNS egress allow + IRSA skeleton for engine SA + ArgoCD Application for kube-prometheus-stack
- **4b flow logs** (`staging/network`): VPC Flow Logs → S3 (Parquet, 90d→IA, 365d expiry); Checkov CKV2_AWS_11 skip removed
- **Version table**: corrected AWS provider version (5.100.0), added kube-prometheus-stack 72.6.2

## Change review checklist (per `docs/principles/change-review-discipline.md`)

### 2.1 Blast radius
- **staging/workloads**: new layer — no existing resources affected. Creates K8s namespace + NetworkPolicy + IAM role + ArgoCD Application. Failure = workloads layer doesn't apply; platform unaffected.
- **staging/network flow-logs.tf**: additive only — VPC Flow Log + S3 bucket. No modification to existing VPC/subnet/route resources.
- **checkov.yml**: removes one skip entry. Failure = Checkov may flag new findings (intended).

### 2.2 Dependency assumptions
- Workloads layer assumes `staging/platform` is applied (cluster endpoint, OIDC provider from remote state). Enforced by `check "platform_layer_applied"` block.
- kube-prometheus-stack ArgoCD Application assumes ArgoCD is running (installed by platform layer). Apply order enforced by CI workflow (network → platform → workloads).
- Flow Logs S3 bucket is staging-local (not centralized logarchive). Migration to `aegis-logarchive` is a future improvement.

### 2.3 Deprecation status
- AWS provider 5.100.0: all resources used are GA, no deprecation warnings.
- Kubernetes provider 2.35: `kubernetes_namespace_v1` and `kubernetes_network_policy_v1` are stable v1 resources.
- kube-prometheus-stack 72.6.2: chart version pinned. Will need verification at apply time.

### 2.4 Rollback plan
- `git revert` + re-apply. New layer with no existing state — revert removes the directory, CI skips it gracefully.
- Flow Logs: `terraform destroy -target=aws_flow_log.main -target=aws_s3_bucket.flow_logs` if needed.

### 2.5 2 AM readability
- Each file in `staging/workloads/` has a single responsibility with header comments citing the relevant ADR.
- NetworkPolicy has explicit allow-DNS rule (not buried in a default-deny comment).

## Cost impact
- 4a': $0 (K8s API objects + IAM role)
- 4b observability: ~$0.25/session on Spot; $1.60/month if Prometheus PVC survives teardown
- 4b Flow Logs: < $0.50/month at lab traffic

## Not in this PR
- Grafana ALB Ingress (no Route 53 domain wired up — use `kubectl port-forward`)
- pluto CI step (no static YAML manifests to scan)
- ADR-014 (ALB session affinity) — Phase 4a'', gates on aegis-core
- ADR-016 (Kyverno vs Gatekeeper) — Phase 4c

## Test plan
- [ ] `terraform fmt -check -recursive terraform/environments/staging/workloads/` passes
- [ ] `terraform fmt -check terraform/environments/staging/network/flow-logs.tf` passes
- [ ] Checkov CI passes (CKV2_AWS_11 skip removed, Flow Logs now present)
- [ ] Terraform Plan CI passes for `staging/network` (new flow-logs.tf)
- [ ] After platform is up: `terraform init && terraform plan` in `staging/workloads/` shows expected creates
- [ ] After apply: `kubectl get ns aegis`, `kubectl get networkpolicy -n aegis`, ArgoCD Application syncs kube-prometheus-stack
- [ ] Grafana reachable via `kubectl port-forward svc/kube-prometheus-stack-grafana -n monitoring 3000:80`

🤖 Generated with [Claude Code](https://claude.com/claude-code)