### PR TITLE
fix: add aegis-core OIDC trust for ECR push access

### DIFF
--- a/terraform/environments/staging/bootstrap/oidc-github.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github.tf
@@ -11,6 +11,8 @@ locals {
   github_infra_repo = local.config.github.infra_repo
   github_oidc_url   = "https://token.actions.githubusercontent.com"
 
+  github_app_repo = local.config.github.app_repo
+
   # Subject claims the role trust policy accepts. Each trigger type in GitHub
   # Actions produces a different `sub` claim in the OIDC token:
   #   - push to main                      → ref:refs/heads/main
@@ -18,11 +20,15 @@ locals {
   #   - workflow_dispatch + environment:X → environment:X
   # Baseline apply uses main; plan uses pull_request; workload apply + teardown
   # use environment-scoped claims (ADR-009 workflow split).
+  #
+  # aegis-core (app repo) is granted main-branch push access so its CI can
+  # push container images to ECR in this account. See #54 platform contract.
   github_oidc_subjects = [
     "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main",
     "repo:${local.github_org}/${local.github_infra_repo}:pull_request",
     "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-apply",
     "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-teardown",
+    "repo:${local.github_org}/${local.github_app_repo}:ref:refs/heads/main",
   ]
 }
 


### PR DESCRIPTION
## Summary

- Add `repo:BinHsu/aegis-core:ref:refs/heads/main` to the `github-actions-terraform` trust policy in staging/bootstrap
- aegis-core CI can now assume the role to push images to ECR
- #54 platform contract corrected (previously claimed the trust was already in place — it was not)

## Change review checklist

### 2.1 Blast radius
IAM trust policy change — adds one OIDC subject. Existing subjects unchanged. The role has AdministratorAccess (lab scope per CKV_AWS_274 skip).

### 2.2 Dependency assumptions
`config.github.app_repo` exists in landing-zone.yaml (same field used by argocd.tf for the root Application).

### 2.3 Deprecation status
No version changes.

### 2.4 Rollback plan
`git revert` — removes the aegis-core subject from the trust policy.

### 2.5 2 AM readability
Comment explains why the app repo needs access (ECR push).

## Test plan
- [ ] CI passes
- [ ] After apply: aegis-core CI can `aws sts assume-role-with-web-identity` in staging account
- [ ] `aws ecr get-login-password` + `docker push` from aegis-core CI succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)