### PR TITLE
fix(iam): grant github-actions-aegis-core-ecr read-after-write on aegis-core repo (closes #80)

### DIFF
--- a/terraform/environments/staging/bootstrap/oidc-aegis-core.tf
+++ b/terraform/environments/staging/bootstrap/oidc-aegis-core.tf
@@ -71,6 +71,22 @@ resource "aws_iam_role_policy" "aegis_core_ecr" {
         ]
         Resource = aws_ecr_repository.aegis_core.arn
       },
+      {
+        # Read-after-write — required for rules_oci `oci_push` which fetches
+        # the manifest post-push to verify the upload succeeded, and for any
+        # downstream automation (Cosign signing, Trivy scanning, ArgoCD tag
+        # watching) that needs to resolve the image it just pushed. Scoped
+        # to the same single repo as the push permissions; the role still
+        # cannot list, read, or modify any other repo in the account.
+        # Requested by cross-repo aegis-core Phase 4a Slice 3 (see ldz #80).
+        Sid    = "VerifyPushedManifest"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+        ]
+        Resource = aws_ecr_repository.aegis_core.arn
+      },
     ]
   })
 }


### PR DESCRIPTION
## Summary

Closes #80 (cross-repo/blocking).

Adds \`ecr:BatchGetImage\` + \`ecr:GetDownloadUrlForLayer\` to the inline policy on the \`github-actions-aegis-core-ecr\` role, scoped to the same single \`aegis-core\` ECR repository the existing push actions target.

## Why

aegis-core Phase 4a Slice 3 just shipped an ECR push workflow using \`rules_oci\`'s \`oci_push\` rule. The push itself succeeds — image lands, manifest is written. But \`oci_push\` does a **post-push manifest fetch** to verify the upload, and the role currently lacks read permission. The workflow exits non-zero even though the artifact is good. See #80 for the exact error + workflow run link.

## Blast radius

Both new actions are \`Resource = aws_ecr_repository.aegis_core.arn\`. The role still has:

- ❌ Zero access to any other ECR repo in the account (no wildcards on Resource)
- ❌ Zero \`ecr:List*\` — cannot enumerate repos
- ❌ Zero \`ecr:Delete*\` — cannot remove images or repos
- ❌ Zero \`ecr:Put*RepositoryPolicy\` — cannot modify repo policy
- ✅ Push to \`aegis-core\` repo (unchanged)
- ✅ Read manifest + download layer URL for \`aegis-core\` repo (new)

This is the minimum required for \`oci_push\` to succeed end-to-end, plus the same primitives that downstream automation (Cosign keyless signing in Phase 4b, Trivy scanning, ArgoCD tag-watching) will need on the same artifact.

## Verification

\`terraform plan\` on \`staging/bootstrap\` against live state:

\`\`\`
Plan: 0 to add, 1 to change, 0 to destroy.
\`\`\`

The single change is the role's inline policy — one new Statement appended, nothing else in the file moves.

aegis-core will verify end-to-end once merged by re-running their push workflow (either on a fresh commit or re-running the previously failed run).

## Change-review checklist

1. **Blast radius** — one IAM role policy, in-place update. Already-issued OIDC sessions unaffected (they re-evaluate policy on next API call). No resource creation or destruction.
2. **Dependency assumptions** — aegis-core \`oci_push\` behavior is the upstream; the fetch-after-push verification is a rules_oci-published design, not an in-house assumption. Also confirmed against the failed workflow log in #80.
3. **Deprecation status** — N/A. \`ecr:BatchGetImage\` + \`ecr:GetDownloadUrlForLayer\` are stable IAM actions; no deprecation notice.
4. **Rollback plan** — revert the single file; \`terraform apply\` reverts the policy. No state impact.
5. **2 AM readability** — one new Statement block, with an inline comment explaining why the read is needed + who asked for it (#80).

## Test plan

- [ ] Checkov green
- [ ] Plan matrix all green
- [ ] Baseline apply on merge applies the in-place update (one role policy modified)
- [ ] aegis-core re-runs their workflow on a fresh push-to-main, confirms 0 exit and closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)