### PR TITLE
feat(ecr): deny push to aegis-core repo from any principal except OIDC role (closes #83)

### DIFF
--- a/terraform/environments/staging/bootstrap/ecr.tf
+++ b/terraform/environments/staging/bootstrap/ecr.tf
@@ -54,3 +54,54 @@ resource "aws_ecr_lifecycle_policy" "aegis_core" {
     ]
   })
 }
+
+# -----------------------------------------------------------------------------
+# Repository policy — Deny push from any principal except the OIDC role
+# -----------------------------------------------------------------------------
+# Server-side defense-in-depth for aegis-core's image push pipeline, paired
+# with the Bazel-side `target_compatible_with = ["@platforms//os:linux"]`
+# gate on `oci_push` rules. Asked for in cross-repo issue #83.
+#
+# Attack surfaces this closes:
+#   - A dev with AWS console / CLI access running `docker push` manually
+#     from a macOS box — previously would have uploaded a Mach-O-inside-
+#     Linux-image that confuses downstream consumers (ArgoCD, Cosign,
+#     Trivy). Now rejected by ECR with AccessDenied before any bytes land.
+#   - A future contributor with AWS access who skips reading CLAUDE.md
+#     and tries direct `docker push`. Same rejection.
+#
+# What this does NOT catch:
+#   - A compromised CI runner that has the OIDC token. At that point we
+#     have larger problems than a bad image in ECR.
+#
+# The OIDC role principal is the single exception. Cosign signing (future
+# Phase 4b) will use the same role; if a second push identity arrives, add
+# a second ArnEquals entry to the condition — do not weaken to a prefix
+# match.
+# -----------------------------------------------------------------------------
+
+resource "aws_ecr_repository_policy" "aegis_core_push_restriction" {
+  repository = aws_ecr_repository.aegis_core.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "DenyPushExceptFromOIDCRole"
+      Effect    = "Deny"
+      Principal = "*"
+      Action = [
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:BatchCheckLayerAvailability",
+      ]
+      Resource = "*"
+      Condition = {
+        StringNotEquals = {
+          "aws:PrincipalArn" = aws_iam_role.aegis_core_ecr.arn
+        }
+      }
+    }]
+  })
+}


### PR DESCRIPTION
## Summary

Closes #83 (non-blocking). Server-side defense-in-depth for aegis-core's ECR push pipeline, paired with the Bazel-side \`target_compatible_with = [\"@platforms//os:linux\"]\` gate that aegis-core already landed.

Adds an \`aws_ecr_repository_policy\` on the \`aegis-core\` repo that **denies all push actions unless the principal is the \`github-actions-aegis-core-ecr\` OIDC role**. Manual \`docker push\` from any other identity — dev box, console session, other IAM role — is rejected at the registry.

## Plan delta

\`\`\`
Plan: 1 to add, 0 to change, 0 to destroy.
\`\`\`

One new resource: \`aws_ecr_repository_policy.aegis_core_push_restriction\`.

## Coverage table

| Attack path | Bazel gate (aegis-core) | ECR policy (this PR) |
|---|---|---|
| \`bazel run :push_staging\` from macOS | ❌ blocked at analysis (\`incompatible target\`) | — (never reached) |
| Manual \`docker push\` after \`aws ecr get-login-password\` from dev box | ⚪ bypasses Bazel | ❌ blocked at registry (AccessDenied) |
| Compromised CI runner that has OIDC token | ⚪ | ⚪ — at this point we have bigger problems |
| Future contributor who skips CLAUDE.md | ⚪ depends on entrypoint | ❌ if they try direct push |

Both layers are cheap; neither alone is sufficient. Together they close the realistic non-catastrophic attack paths.

## What stays the same

- The OIDC role (\`github-actions-aegis-core-ecr\`) pushes normally — its trust scope is \`repo:BinHsu/aegis-core:ref:refs/heads/main\` (unchanged from PR #74).
- ECR read (\`ecr:BatchGetImage\`, \`ecr:GetDownloadUrlForLayer\`) is unchanged — downstream consumers (ArgoCD, Cosign, Trivy, Karpenter nodes) continue to pull.
- Lifecycle policy unchanged.

## Extension path

- When [ldz #79 Q1](https://github.com/BinHsu/aegis-aws-landing-zone/issues/79) (separate \`aegis-core-prod\` ECR repo) lands, apply the same policy shape to the prod repo with the prod-scoped OIDC role as the allowed principal.
- If a second legitimate push identity arrives (e.g. Cosign signing in Phase 4b that writes signatures as OCI artifacts), add a second \`ArnEquals\` to the condition. Do **not** weaken to a prefix/pattern match — each allowed identity should be an explicit ARN.

## Change-review checklist

1. **Blast radius** — one ECR repo's resource policy. Does not affect other repos in the account, does not touch IAM. The ONLY permitted push principal is the existing OIDC role — no change to who can push.
2. **Dependency assumptions** — \`aws_iam_role.aegis_core_ecr\` is defined in the same layer (\`staging/bootstrap/oidc-aegis-core.tf\`); policy resolves the ARN via reference (not hardcoded).
3. **Deprecation status** — \`aws_ecr_repository_policy\` is a stable resource in provider v6.40.
4. **Rollback plan** — remove the single resource block + \`terraform apply\`. No state impact beyond removing the policy. Push would then be permitted to any principal with appropriate IAM perms (i.e., revert to pre-PR posture).
5. **2 AM readability** — the inline comment explains what is blocked, what is not blocked, and how to extend (separate arnEquals, not regex). If a 2 AM operator is staring at an AccessDenied on push, the policy content tells them immediately whether the push identity is the correct OIDC role or not.

## Test plan

- [ ] Checkov green
- [ ] Plan matrix green
- [ ] Baseline apply on merge creates the repository policy (1 add, 0 change, 0 destroy)
- [ ] aegis-core's next main-branch push still succeeds (OIDC role is allowed)
- [ ] Manual verification (optional, after merge): \`aws ecr get-login-password\` + \`docker push\` from my SSO-\`PlatformAdmin\` session returns AccessDenied (expected, proves the policy works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)