### PR TITLE
feat(eks): K=2 slot-ceiling hard guard + schema maxItems + ADR-018 §3 enforcement section

### DIFF
--- a/config/schema.json
+++ b/config/schema.json
@@ -259,7 +259,8 @@
           "regions": {
             "type": "array",
             "minItems": 1,
-            "description": "EKS compute footprint per env — must be a subset of top-level regions[]. Length 1 = single-region; length 2+ = multi-region with primary + slave(s). See docs/decisions/018-multi-region-eks-design.md. Cross-field invariants (exactly-one-primary, subset, uniqueness) validated by scripts/validate-config.py and Terraform check blocks.",
+            "maxItems": 2,
+            "description": "EKS compute footprint per env — must be a subset of top-level regions[]. Length 1 = single-region; length 2 = multi-region with primary + one slave. The maxItems=2 ceiling matches the slot-pattern K=2 declared in docs/decisions/018-multi-region-eks-design.md §3 'Scaling boundary'. To go beyond 2: amend ADR-018 §3 (raise K), add a `slave_2` provider alias + module invocation in staging/{network,platform}/ (mirroring slave_1), then bump both this maxItems and the terraform_data.assert_k2_max precondition in the two config.tf files. Cross-field invariants (exactly-one-primary, subset, uniqueness) validated by scripts/validate-config.py and Terraform check blocks.",
             "items": {
               "type": "object",
               "required": ["region", "role", "mode"],

--- a/docs/decisions/018-multi-region-eks-design.md
+++ b/docs/decisions/018-multi-region-eks-design.md
@@ -109,6 +109,16 @@ module "cluster_slave_1" {
 - Growing to length 3 requires adding (a) one more `provider "aws"` block with alias `slave_2`, (b) one more `module "cluster_slave_2"` invocation, and (c) an ADR amendment raising K to 3. This is minutes of work.
 - Growing beyond K=3 (or wanting truly dynamic N) means breaking the slot pattern entirely. The documented escape hatch is to migrate to a **`scripts/configure-providers.sh` template**: `providers.tf` becomes gitignored, generated from config at plan time like `backend.tf` is today. This is a substantive architectural change — it costs reviewability (providers.tf is no longer in PR diffs) and adds a CI prerequisite step — and requires its own ADR superseding this section.
 
+**Enforcement — hard guard, not just convention**:
+
+The K=2 ceiling is enforced at three layers so a forker who edits `eks.<env>.regions` to length 3 without reading this ADR cannot accidentally produce broken Terraform:
+
+1. **JSON Schema** — `config/schema.json` declares `maxItems: 2` on `eks.<env>.regions`. `scripts/validate-config.py` catches violations pre-commit.
+2. **Terraform precondition** — `terraform_data "assert_k2_max"` resources in both `staging/network/config.tf` and `staging/platform/config.tf` use `lifecycle.precondition { condition = length(local.eks_regions) <= 2 }`. Unlike the `check` blocks for §2 invariants (warnings, plan continues), `lifecycle.precondition` is a hard error that halts plan. The error message inlines the full eight-step unlock procedure so an operator hitting it mid-session doesn't have to jump between the ADR and the .tf files.
+3. **This ADR's Scaling boundary section** (above) — human-readable version with rationale.
+
+The guard is intentionally temporary per slot bump: after amending this §3 and adding a `slave_2` slot + module invocation, the operator bumps both the schema `maxItems` and the precondition threshold to `<= 3` in the same PR. Removing the guard entirely is the migration signal for the escape-hatch generation-script approach.
+
 The pattern here is deliberately **pragmatic over clever**: K=2 is what the actual demo needs (primary + DR failover). We do not pre-invest in K=N flexibility that has zero near-term use.
 
 ### 4. State structure: single state per layer

--- a/terraform/environments/staging/network/config.tf
+++ b/terraform/environments/staging/network/config.tf
@@ -98,6 +98,76 @@ check "eks_region_names_unique" {
   }
 }
 
+# -----------------------------------------------------------------------------
+# K=2 slot ceiling — hard error, not a warning
+# -----------------------------------------------------------------------------
+# Unlike the check blocks above (which surface as warnings and let plan
+# continue), this terraform_data precondition HARD-ERRORS at plan time. The
+# slot pattern is K=2 by ADR-018 §3; going beyond requires the multi-step
+# unlock below, NOT just editing config. If you're reading this message
+# because your plan just failed, follow the numbered steps exactly.
+# -----------------------------------------------------------------------------
+resource "terraform_data" "assert_k2_max" {
+  lifecycle {
+    precondition {
+      condition     = length(local.eks_regions) <= 2
+      error_message = <<-EOT
+        eks.staging.regions[] has ${length(local.eks_regions)} entries, exceeding the slot-pattern K=2 ceiling declared in ADR-018 §3 "Scaling boundary".
+
+        This project's current slot commitment is TWO regions (primary + one slave). Adding a third region is intentionally made loud — it requires more than a YAML edit because the Terraform provider-alias layer does not support dynamic slot generation (see ADR-018 Alternatives D).
+
+        ## Unlock procedure for K=3 (in order)
+
+          1. Amend docs/decisions/018-multi-region-eks-design.md §3:
+             - Change "K=2" to "K=3" in the "Scaling boundary" paragraph
+             - Document the third slot in the Consequences section
+             - Update the "Amended YYYY-MM-DD" note at the top
+
+          2. In terraform/environments/staging/network/providers.tf:
+             - Add a `provider "aws" { alias = "slave_2" ... }` block
+               with region driven from `try(local.slave_regions[1].region, local.primary_region)`
+
+          3. In terraform/environments/staging/network/main.tf:
+             - Add a `module "vpc_slave_2"` invocation mirroring vpc_slave_1
+             - count = `length(local.slave_regions) >= 2 ? 1 : 0`
+             - providers = `{ aws.this = aws.slave_2 }`
+
+          4. Mirror steps 2-3 in terraform/environments/staging/platform/:
+             - Four provider aliases (aws.slave_2, kubernetes.slave_2, helm.slave_2, kubectl.slave_2)
+             - module "cluster_slave_2" invocation
+
+          5. In staging/network/outputs.tf and staging/platform/outputs.tf,
+             extend the `vpcs` / `clusters` maps with a `slave_2` entry
+             (wrapped in a length >= 2 conditional same as slave_1)
+
+          6. In config/schema.json: bump eks.<env>.regions maxItems from 2 to 3
+
+          7. Bump the `<=` threshold in THIS precondition (both network AND
+             platform config.tf) from 2 to 3
+
+          8. Commit the multi-file change as a single PR — reviewers should
+             see the whole ceiling bump atomically
+
+        ## Unlock procedure for K > 3 (truly dynamic N)
+
+        The slot pattern stops scaling cleanly around K=4+ (providers.tf
+        becomes unwieldy). Instead migrate to a generation-script approach
+        documented in ADR-018 §3 escape hatch: `scripts/configure-providers.sh`
+        reads config and writes providers.tf at plan time (same idea as the
+        existing `scripts/configure-backends.sh`). This is a substantive
+        architectural change requiring a new ADR (ADR-020+) because it
+        removes providers.tf from source control (generated artifact,
+        gitignored), which costs PR-diff reviewability.
+
+        See project memory `project_eks_cluster_module_provider_layout.md`
+        for the full rationale behind the slot-pattern choice and why
+        module-local providers (which would sidestep the slot cap) are
+        rejected by Terraform in the presence of `count`.
+      EOT
+    }
+  }
+}
+
 check "vpc_sizing_present_for_every_eks_region" {
   assert {
     condition = alltrue([

--- a/terraform/environments/staging/platform/config.tf
+++ b/terraform/environments/staging/platform/config.tf
@@ -77,6 +77,30 @@ check "eks_region_names_unique" {
   }
 }
 
+# -----------------------------------------------------------------------------
+# K=2 slot ceiling — hard error, not a warning
+# -----------------------------------------------------------------------------
+# Duplicated in staging/network/config.tf. The full unlock procedure lives
+# there (single source of truth). The guard must exist in BOTH layers
+# because either layer can be planned/applied independently; missing the
+# guard in one would leave half the infrastructure attempting K=3 while
+# the other refuses.
+# -----------------------------------------------------------------------------
+resource "terraform_data" "assert_k2_max" {
+  lifecycle {
+    precondition {
+      condition     = length(local.eks_regions) <= 2
+      error_message = <<-EOT
+        eks.staging.regions[] has ${length(local.eks_regions)} entries, exceeding the slot-pattern K=2 ceiling declared in ADR-018 §3 "Scaling boundary".
+
+        See the detailed unlock procedure in terraform/environments/staging/network/config.tf — it walks through the eight-step multi-file edit required to add a K=3 slot. Same error, same procedure; duplicating it here would let the two copies drift.
+
+        TL;DR: amend ADR-018 §3, add slave_2 provider alias + module invocation in BOTH staging/network/ and staging/platform/, extend outputs maps, bump schema.json maxItems, bump the `<=` threshold in both config.tf files.
+      EOT
+    }
+  }
+}
+
 check "config_eks_section_present" {
   assert {
     condition     = contains(keys(local.config), "eks") && contains(keys(local.config.eks), "staging")


### PR DESCRIPTION
## Summary

Per [ADR-018 §3 (amended)](https://github.com/BinHsu/aegis-aws-landing-zone/blob/main/docs/decisions/018-multi-region-eks-design.md#3-terraform-provider-pattern-slot-pattern-with-sub-module--configuration_aliases), the slot pattern is K=2 — primary + one slave. This PR makes a length-3+ \`eks.<env>.regions\` config **fail loudly with a self-documenting error** instead of silently producing broken Terraform.

## Three enforcement layers

| Layer | Where | Hard error? | Catches |
|---|---|---|---|
| 1. JSON Schema | \`config/schema.json\` \`maxItems: 2\` | Yes (pre-commit via \`validate-config.py\`) | Forker editing YAML |
| 2. Terraform precondition | \`terraform_data \"assert_k2_max\"\` in both \`staging/network/config.tf\` and \`staging/platform/config.tf\` | Yes (plan-time, exit 1) | Operator running \`terraform plan\` |
| 3. ADR §3 \"Enforcement\" subsection | \`docs/decisions/018-multi-region-eks-design.md\` | N/A (documentation) | Architect / reviewer |

Why all three: \`check\` blocks produce warnings only; \`lifecycle.precondition\` is the hard-error primitive. Schema + precondition + narrative covers the three different audiences (pre-commit / plan-time / ADR review).

## Verified locally

### Length-1 (current config) — passes cleanly
\`terraform plan\` against the current single-region config produces 22 new resources in network + 26 in platform, unchanged shape from before this PR.

### Length-3 (simulated) — fails with full unlock procedure
Patched \`config/landing-zone.yaml\` via python to add \`eu-north-1\` as a third slave, ran \`terraform plan\`:

\`\`\`
Error: Resource precondition failed
  on config.tf line 113, in resource \"terraform_data\" \"assert_k2_max\":
 113:       condition = length(local.eks_regions) <= 2
    │ local.eks_regions is tuple with 3 elements

eks.staging.regions[] has 3 entries, exceeding the slot-pattern K=2 ceiling
declared in ADR-018 §3 \"Scaling boundary\".

## Unlock procedure for K=3 (in order)
  1. Amend docs/decisions/018-multi-region-eks-design.md §3 ...
  2. In terraform/environments/staging/network/providers.tf, add slave_2 ...
  3. In terraform/environments/staging/network/main.tf, add module \"vpc_slave_2\" ...
  4. Mirror steps 2-3 in staging/platform/ ...
  5. Extend outputs maps with slave_2 entries ...
  6. Bump schema.json maxItems ...
  7. Bump <= threshold in BOTH config.tf files ...
  8. Commit as a single PR
\`\`\`

Full eight-step procedure inlined in the error message so an operator hitting it mid-session doesn't have to cross-reference the ADR. Config restored post-test.

## Duplication rationale

The \`terraform_data\` guard exists in BOTH \`staging/network/config.tf\` and \`staging/platform/config.tf\`. Reason: either layer can be planned/applied independently. If only network had the guard, an operator could still plan-and-apply platform with K=3 config and hit silent breakage downstream. Platform's copy is TL;DR + pointer to network's (which carries the full eight-step procedure) — keeps duplication low-drift.

## Why the guard is temporary per slot bump

After amending ADR-018 §3 and adding a \`slave_2\` slot + module invocation in both layers:

- Bump the schema.json \`maxItems\` from 2 → 3
- Bump the \`<= 2\` threshold in both \`terraform_data.assert_k2_max\` preconditions to \`<= 3\`

Both changes are part of the same PR as the slot addition. The guard itself stays — it's the right abstraction for \"this is the current ceiling\", not \"K is forever 2\". Removing the guard entirely is the signal for migrating to the ADR-018 §3 escape-hatch generation-script approach (K unlimited, different architectural tradeoff).

## Change-review checklist

1. **Blast radius** — pure constraint addition. Current config (length 1) plans identically pre- and post-PR. No resource change; only adds one \`terraform_data\` per layer (terraform_data has no underlying infra cost).
2. **Dependency assumptions** — \`terraform_data\` is a stable built-in since Terraform 1.4; we're on 1.14.8.
3. **Deprecation status** — N/A.
4. **Rollback plan** — revert the four-file change. Removes the guard but leaves ADR-018 §3 intact (existing \`check\` blocks for the other invariants still fire as warnings). Nothing breaks.
5. **2 AM readability** — error message includes the full unlock procedure. Operator hitting this in the middle of a demo does not need to read the ADR first.

## Test plan

- [ ] \`terraform fmt -check\` green
- [ ] Checkov green
- [ ] All plan-matrix jobs pass (current length-1 config — guard does not fire)
- [ ] \`scripts/validate-config.py\` rejects a length-3 config (schema maxItems) — manual verify post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)