### PR TITLE
feat(edge): staging/edge Terraservice — S3 + CloudFront + OIDC role (closes #91) + ADR-019 + runbook 004

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Some Terraservices layers have their own operational contracts — pre-flight ch
   - `docs/runbooks/001-bootstrap-aws-account.md` — initial AWS / Control Tower bootstrap
   - `docs/runbooks/002-eks-access.md` — EKS operator access (MUST read before any `kubectl`, `aws eks`, or `staging/platform` apply in a session)
   - `docs/runbooks/003-platform-first-verification.md` — end-to-end checklist after `staging/platform` applies; links to Incidents 10–17 for cold-apply gotchas (MUST follow for any fresh apply of the platform layer)
+  - `docs/runbooks/004-dns-delegation-cloudflare-to-route53.md` — Cloudflare-side subdomain NS delegation to a Route53 hosted zone; one-time setup + rollback + troubleshooting (MUST read when provisioning `staging/edge/` or any future env's edge Terraservice)
 
 - **Rule: When adding a new layer whose operations require their own diagnostic order (e.g., observability, service mesh), add a runbook under `docs/runbooks/` rather than extending this file.** Keeping CLAUDE.md small preserves its discoverability; layer-specific details belong with the layer.
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Complete improvement index and reliability map: [`docs/improvements/README.md`](
 | [016](docs/decisions/016-admission-control.md) | Admission control — Kyverno |
 | [017](docs/decisions/017-workload-namespace-and-rbac-model.md) | Workload namespace and RBAC model |
 | [018](docs/decisions/018-multi-region-eks-design.md) | Multi-region EKS design (list-driven, pilot light default) |
+| [019](docs/decisions/019-frontend-serving-strategy.md) | Frontend serving strategy — S3 + CloudFront, split subdomain |
 
 ## Runbooks
 

--- a/docs/decisions/019-frontend-serving-strategy.md
+++ b/docs/decisions/019-frontend-serving-strategy.md
@@ -1,0 +1,199 @@
+# 019. Frontend serving strategy — S3 + CloudFront
+
+## Status
+Accepted
+
+## Context
+
+aegis-core's Phase 4a-5 ships a static SPA bundle (React + Vite, output at `frontend_web/dist/`). It is not a server — it is HTML / JS / CSS / fonts that need to be served from somewhere. The question is where.
+
+Three candidates, each with a different split of responsibility between ldz (platform) and aegis-core (workload):
+
+| Option | aegis-core side | ldz side | Cost (persistent) |
+|---|---|---|---|
+| A. Bundle into gateway image | Add a static-file handler to the Go gateway | Nothing extra — gateway Deployment already serves | $0 |
+| B. Separate frontend container (nginx/caddy) | New OCI image baked with the SPA + nginx | New Deployment + Service + Ingress routing | ALB overhead |
+| C. S3 + CloudFront | CI step syncs `dist/` to S3, invalidates CDN | S3 bucket + CloudFront + ACM + Route53 + OIDC role | ~$0.50/month |
+
+Context from the cross-repo thread (ldz #90 → aegis-core #91):
+
+- aegis-core is deployed on EKS via ArgoCD; backend (gateway + engine) needs a load balancer ALB for WebSocket + gRPC. That ALB is required regardless.
+- `binhsu.org` is the lab's domain (on Cloudflare DNS). A subdomain delegation to Route53 is acceptable for the `staging.` namespace (runbook 004 covers it).
+- The lab is EU-operator + EU-user; CloudFront's PriceClass_100 (North America + Europe edges) is sufficient.
+- Portfolio angle matters — this repo is public and is meant to demonstrate senior-level infrastructure choices.
+
+## Decision
+
+**Option C — S3 + CloudFront, with OAC (Origin Access Control), split subdomains.**
+
+Implementation lives in `terraform/environments/staging/edge/` as a dedicated Terraservice. Key shape:
+
+- **S3 bucket** (`aegis-staging-frontend-<account-id>`): OAC-locked, public access fully blocked, SSE-S3 encryption, versioning enabled with 30-day non-current-version expiration.
+- **CloudFront distribution**: PriceClass_100, default root object `/index.html`, SPA 404/403 rewrite to `/index.html` with status 200, `redirect-to-https`, Managed-CachingOptimized cache policy, IPv6 enabled.
+- **ACM certificate** in `us-east-1` (CloudFront service constraint), DNS-validated via Route53 in the primary region. Single SAN = `aegis-app.staging.binhsu.org` today; adds `aegis-app.prod.binhsu.org` when prod cut lands.
+- **Route53 hosted zone** for `staging.binhsu.org` (subdomain-delegated from Cloudflare-hosted `binhsu.org`), with A + AAAA alias records for `aegis-app.staging.binhsu.org` → CloudFront.
+- **OIDC role** `github-actions-aegis-core-frontend` — assumed by aegis-core's `release-staging-frontend.yml` workflow. Trust scope: `sub = repo:BinHsu/aegis-core:ref:refs/heads/main` + `job_workflow_ref` pinned to that specific workflow file path + ref. Inline policy: `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` on the frontend bucket + `cloudfront:CreateInvalidation` on the specific distribution.
+- **S3 bucket policy** — two statements: `AllowCloudFrontRead` (scoped to this specific distribution ARN via OAC) and `DenyPutExceptFromOIDCRole` (mirrors the ECR #83/#89 pattern — a dev running `aws s3 sync` from their laptop gets AccessDenied).
+
+### Domain naming
+
+- `aegis-app.staging.binhsu.org` → frontend (CloudFront)
+- `aegis-api.staging.binhsu.org` → gateway (ALB, Phase 4c, provisioned when workloads layer migrates)
+
+Hyphenated project-prefix form, **not** `app.staging.binhsu.org`:
+
+- `binhsu.org` is a personal umbrella domain; generic `app.` could collide with future non-aegis projects
+- Matches the `aegis-<env>-<purpose>` pattern already used in AWS account names (`aegis-staging`, `aegis-management`) and S3 bucket names (`aegis-staging-frontend-...`)
+- `aegis-app` / `aegis-api` is clearer-at-a-glance than `aegisapp` / `aegisapi` (run-together form)
+
+### Why split subdomains (not path-based routing at the CDN)
+
+CloudFront can front both the frontend S3 and the backend ALB via origin groups + path-pattern behaviors. We rejected this because:
+
+- **WebSocket path (`/ws/*`)** for the gateway is session-affinity-sensitive (ADR-014). Routing through CloudFront would add a non-transparent hop; CloudFront's WebSocket semantics are not as battle-tested as ALB's.
+- **gRPC over HTTP/2** for the gateway's public gRPC-Web surface — CloudFront does support HTTP/2 but has a 30-second per-request timeout ceiling that WebSocket-like long-lived streams can violate. ALB has configurable idle timeout up to 4000 seconds.
+- Path-pattern behaviors require one distribution to straddle two very different workloads (static assets + live bidirectional traffic). The abstraction cost isn't worth avoiding two subdomains.
+- Split subdomains mean CORS is explicit in both directions (`aegis-app` → `aegis-api` is cross-origin; the gateway's `AEGIS_ALLOWED_ORIGINS` env permits exactly the frontend hostname). Explicit is maintainable.
+
+### Why OAC, not legacy OAI
+
+CloudFront has two mechanisms for restricting S3 origin access:
+
+- **OAI (Origin Access Identity)** — legacy, uses a signed-URL-like scheme, doesn't support KMS-encrypted buckets, AWS has declared it as "still available" but pushes new installations to OAC
+- **OAC (Origin Access Control)** — current, uses SigV4, supports everything OAI does plus KMS-encrypted S3, is the recommended choice for new distributions as of 2022+
+
+We picked OAC despite using SSE-S3 (not SSE-KMS) because: zero downside today, and if we ever upgrade to SSE-KMS (e.g., compliance requirement), we don't have to re-architect.
+
+### Why PriceClass_100
+
+CloudFront pricing has three tiers:
+- **PriceClass_All** — global edge coverage, highest request fees
+- **PriceClass_200** — North America + Europe + Asia (excludes South America, South Africa, Middle East)
+- **PriceClass_100** — North America + Europe only
+
+At lab scale, request volume is noise-level. The operator is EU-based (Germany). Users for demo purposes are likely EU/NA. PriceClass_100 is the cheapest tier that covers the demo scenario. Can be bumped without re-architecture if traffic patterns demand it.
+
+## Alternatives Considered
+
+### A. Bundle frontend into gateway image
+
+Rejected. Gateway is a Go HTTP/gRPC server, not a static file server. Serving 1MB of JS from the Go pod would:
+
+- Force every frontend change to rebuild + repush the gateway image (tightly coupled deploy cadence)
+- Waste gateway CPU serving static content (Karpenter scales gateway by request-rate; static requests inflate the metric without actually needing backend resources)
+- Miss out on edge caching (every user fetch hits origin EU, not their nearest POP)
+- Make TLS termination entangled (gateway's ALB already has ACM, but if we later add a WAF at CloudFront for the static side, we'd be doubling up the TLS story)
+
+Cheapest to implement, lowest operational maturity. Rejected on portfolio grounds alone (a platform engineer shouldn't serve JS from Go).
+
+### B. Separate frontend container (nginx / caddy)
+
+Rejected. All of the operational cost of a second Deployment (K8s manifests, resource requests/limits, Pod autoscaling, health checks, log pipeline) for zero of CloudFront's edge-cache benefit. In-cluster static serving is the worst of both worlds.
+
+Only makes sense in environments where CloudFront is unavailable (e.g., private on-prem deploys) — not relevant here.
+
+### C.1 CloudFront + S3 with path-based routing to ALB
+
+Considered briefly. Reasons to reject covered above under "Why split subdomains".
+
+### D. Cloudflare Pages / Workers
+
+Cloudflare already hosts the root domain DNS. Cloudflare Pages would serve the SPA with comparable edge caching at comparable cost. Rejected because:
+
+- The aegis-core CI needs to push to the asset store. Cloudflare Pages' Git integration wants its own repo connection; we'd be adding a second CI credential surface (Cloudflare API token alongside the GitHub OIDC → AWS pattern).
+- Portfolio angle: the rest of the infrastructure is AWS-native. Adding a Cloudflare Pages layer would be inconsistent without a reason the demo needs.
+- Harder to audit: CloudFront invalidations + access logs ship to CloudWatch Logs / S3; Cloudflare Pages has its own observability surface.
+
+Cloudflare stays as the registrar-level DNS for `binhsu.org` apex; all compute lives on AWS.
+
+### E. Terraform the Cloudflare side (full move to Route53 + ACM)
+
+Considered. Rejected because:
+
+- The runbook 004 subdomain-delegation pattern keeps the rest of the domain (`binhsu.org`, `www.binhsu.org`, any future non-aegis service) on Cloudflare where the operator already manages it.
+- Moving the apex would require updating registrar NS records (one-time manual step), plus re-creating any existing Cloudflare-managed records in Route53 (email auth TXT records, any unrelated subdomains).
+- Subdomain delegation is the lower-blast-radius choice — if we ever want to move the apex, we still can, without it being the first step.
+
+## Consequences
+
+### Easier
+
+- Frontend deploys are a CI-owned `aws s3 sync` + `aws cloudfront create-invalidation`. Takes ~30 seconds; no cluster involvement.
+- Edge cache hits mean typical user latency is < 100ms globally even though origin is eu-central-1.
+- The aegis-core side owns what to deploy; ldz owns where it goes. Clean split, per ADR-007.
+- Changes to aegis-core don't trigger re-applies of K8s cluster resources. Frontend-only change ships without touching Karpenter / ArgoCD / any workload pod.
+- The ALB stays scoped to backend APIs (WebSocket + gRPC). Clean responsibilities.
+
+### Harder
+
+- One more Terraservice to maintain (`staging/edge/`). Cold-apply takes ~5 minutes (CloudFront distribution provisioning is slow).
+- Cross-region provider alias for ACM (`aws.cloudfront_cert` pointing at us-east-1). One extra provider block per edge Terraservice.
+- DNS delegation is a one-time manual step on the parent DNS provider (Cloudflare) — documented in runbook 004. Not hard but not pure-Terraform.
+- Prod environment will need its own edge Terraservice (or this one parameterized by env) when ldz #79 Q1 lands. Additional cert SAN + ACM propagation delay.
+
+### Cross-repo impact
+
+aegis-core owns:
+
+- `.github/workflows/release-staging-frontend.yml` — OIDC role assumption, s3 sync, CloudFront invalidation
+- `frontend_web/dist/` Vite build output
+- Gateway CORS allowlist (`AEGIS_ALLOWED_ORIGINS` env var permits `https://aegis-app.staging.binhsu.org`)
+- No container image for the frontend (intentional — Option A was rejected)
+
+ldz owns:
+
+- Everything in `terraform/environments/staging/edge/`
+- The three values aegis-core consumes as GitHub Actions secrets / env hardcodes: bucket name, distribution ID, OIDC role ARN (posted on issue #91)
+
+Coordination: if aegis-core renames `release-staging-frontend.yml`, the `job_workflow_ref` trust condition on the OIDC role needs an ldz-side edit (a one-line PR). Flagged as a cross-repo coupling point.
+
+### Cost
+
+At lab scale:
+
+| Item | Monthly (persistent) |
+|---|---|
+| S3 storage (2 GB ceiling, versioned) | < $0.05 |
+| CloudFront requests (PriceClass_100, ~10K/month demo) | ~$0.15 |
+| CloudFront data transfer (1 GB/month demo) | ~$0.08 |
+| Route53 hosted zone (1) | $0.50 |
+| ACM certificate | $0 |
+| IAM role | $0 |
+| **Total** | **~$0.80** |
+
+Negligible. If the demo goes viral or we cut a prod, traffic is the variable — but even 10× growth keeps this below $10/month.
+
+### Reversibility
+
+Fully reversible. `terraform destroy` on `staging/edge/` removes:
+
+- CloudFront distribution (~15 min AWS-side deletion)
+- ACM certificate (immediate; validation records + cert together)
+- S3 bucket (must be empty; apply `force_destroy = true` at destroy time if it has objects)
+- Route53 zone (removes the 4 NS records at Cloudflare become pointing at a non-existent zone — operator cleans those manually per runbook 004 rollback)
+- IAM role + policy
+
+Recovery path if bucket gets nuked by accident: state versioning keeps the previous S3 assets for 30 days; the last successful aegis-core deploy is also recoverable by re-running the workflow.
+
+### Portfolio implication
+
+1. **Edge-first static serving** is the cloud-native canonical pattern for SPAs; demonstrates the engineer can build production-grade delivery, not just compute.
+2. **OAC + deny-by-default bucket policy** is the current best-practice S3 + CloudFront lockdown; demonstrates defense-in-depth thinking.
+3. **Subdomain delegation** (keep parent domain on existing provider, Terraform the subdomain only) is lower-blast-radius than "move everything" — demonstrates pragmatic migration posture.
+4. **`job_workflow_ref` OIDC condition** pinning the CI workflow file path is one layer tighter than `sub`-only; demonstrates GitHub-OIDC threat-model familiarity beyond the 80%-common trust policy shape.
+5. **Split subdomains over path-based CDN routing** is the right-for-the-job choice when backend traffic is WebSocket-heavy; demonstrates understanding of CDN limits vs ALB semantics, not just "use CloudFront because it's there".
+
+## Compliance / residency
+
+- S3 bucket lives in `eu-central-1` (EU operator + EU user demo).
+- CloudFront is a global service but honors data-at-rest for the S3 origin.
+- ACM cert lives in `us-east-1` (CloudFront constraint, unavoidable).
+- The frontend contains no PII or session data — it's public HTML/JS. Compliance surface is minimal.
+
+## References
+
+- Cross-repo coordination: [ldz #91](https://github.com/BinHsu/aegis-aws-landing-zone/issues/91), [ldz #90](https://github.com/BinHsu/aegis-aws-landing-zone/issues/90)
+- ADR-014 (ALB session affinity) — why WebSocket path stays on ALB, not CDN
+- ADR-018 §3 amended — role-based provider aliases (this Terraservice uses the `cloudfront_cert` alias for the us-east-1 ACM provider)
+- Runbook 004 — DNS delegation Cloudflare → Route53
+- ECR defense-in-depth pattern (PRs #86 / #89) — the S3 DenyPut bucket policy follows the same shape

--- a/docs/runbooks/004-dns-delegation-cloudflare-to-route53.md
+++ b/docs/runbooks/004-dns-delegation-cloudflare-to-route53.md
@@ -1,0 +1,150 @@
+<!-- session-close-review: Cloudflare UI screenshots / terminology still match the current Cloudflare dashboard; dig verification commands still produce the shape shown; the 4 NS values in the example reflect the live Route53 zone -->
+# 004 — DNS delegation: Cloudflare → Route53 subdomain
+
+**Scope**: one-time setup to delegate the `staging.binhsu.org` subdomain from Cloudflare-hosted `binhsu.org` to an AWS Route53 hosted zone. Same shape applies to any future subdomain delegation (e.g. `prod.binhsu.org` when ldz #79 Q1 lands).
+
+**Audience**: repo operator with Cloudflare dashboard access for `binhsu.org`.
+
+**Precondition**: Route53 hosted zone exists. `terraform apply` on `staging/edge/` (or `terraform apply -target=aws_route53_zone.staging` for the two-phase apply) creates it and outputs the 4 authoritative nameservers via `terraform output -json delegated_zone_nameservers`.
+
+## Flow at a glance
+
+```
+┌──────────────────────┐      ┌─────────────────────┐      ┌─────────────────────┐
+│ Resolver (user/dig)  │─────►│ Cloudflare          │─────►│ Route53 hosted zone │
+│                      │      │ (binhsu.org apex)   │      │ (staging.binhsu.org)│
+└──────────────────────┘      └─────────────────────┘      └─────────────────────┘
+                                 "for staging.binhsu.org:
+                                  go ask the 4 AWS NS"
+```
+
+The parent zone (`binhsu.org` on Cloudflare) carries 4 `NS` records at name `staging` pointing at the AWS nameservers. Any query for `*.staging.binhsu.org` gets routed to Route53; everything else stays on Cloudflare.
+
+## Step 1 — get the nameservers from Terraform
+
+```bash
+cd terraform/environments/staging/edge
+AWS_PROFILE=aegis-staging-admin terraform output -json delegated_zone_nameservers
+```
+
+Output shape:
+
+```json
+[
+  "ns-1414.awsdns-48.org",
+  "ns-1594.awsdns-07.co.uk",
+  "ns-30.awsdns-03.com",
+  "ns-705.awsdns-24.net"
+]
+```
+
+The four values are the only ones you need; they are stable for the lifetime of the Route53 hosted zone (they do NOT change on apply, restart, etc.). If `terraform destroy` removes the zone and a later apply recreates it, the 4 values WILL change — plan your teardown accordingly.
+
+## Step 2 — add the 4 NS records in Cloudflare
+
+1. Log in to https://dash.cloudflare.com.
+2. Select the `binhsu.org` zone from the domain list.
+3. Top navigation → **DNS** → **Records**.
+4. Click **Add record**.
+5. Fill each field exactly:
+
+   | Field | Value |
+   |---|---|
+   | Type | `NS` |
+   | Name | `staging` (no dot, no `binhsu.org` suffix — Cloudflare auto-appends) |
+   | Nameserver | (one of the 4 values, no trailing dot) |
+   | Proxy status | **DNS only** (🔘 grey cloud) — critical, see gotcha below |
+   | TTL | `Auto` (or 300s — anything works) |
+
+6. **Save**.
+7. Repeat steps 4–6 **three more times**, one record per remaining nameserver. You should end up with 4 separate `NS` rows at `staging.binhsu.org`.
+
+### Gotcha — Proxy status must be DNS only
+
+Cloudflare's orange-cloud proxy intercepts and re-serves traffic through their CDN. That mode is fine for `A` / `CNAME` records serving a single origin, but `NS` records are metadata pointing at OTHER resolvers — they must resolve to the bare AWS nameserver hostnames, not Cloudflare's proxy. If left as orange cloud, the delegation silently fails: `dig +short NS staging.binhsu.org` returns nothing, or returns Cloudflare IPs instead of the AWS values.
+
+If you accidentally toggled orange cloud: click the cloud icon on the record row, switch to DNS only (grey), save. Propagation is near-instant.
+
+## Step 3 — verify delegation is live
+
+Run from any machine with `dig`:
+
+```bash
+# Ask Cloudflare's public resolver
+dig +short NS staging.binhsu.org @1.1.1.1
+
+# Ask Google's public resolver (cross-check)
+dig +short NS staging.binhsu.org @8.8.8.8
+
+# Ask whatever your machine's default resolver is
+dig +short NS staging.binhsu.org
+```
+
+All three should return the 4 AWS nameservers (order may differ — DNS rotates them):
+
+```
+ns-1594.awsdns-07.co.uk.
+ns-1414.awsdns-48.org.
+ns-705.awsdns-24.net.
+ns-30.awsdns-03.com.
+```
+
+If any resolver returns empty or returns non-AWS values, something is off — see troubleshooting below.
+
+**Typical propagation time**: Cloudflare's DNS-only records are ~instant (< 60 seconds). If your `dig` still shows empty after 5 minutes, the Cloudflare record is misconfigured (probably `Name` field or proxy status).
+
+## Step 4 — apply the rest of staging/edge
+
+Once delegation is verified:
+
+```bash
+cd terraform/environments/staging/edge
+AWS_PROFILE=aegis-staging-admin terraform apply
+```
+
+ACM will validate the cert via DNS in Route53 (typically < 5 min). CloudFront distribution provisioning is the slow step (2–15 minutes depending on AWS-side propagation). Total cold apply is ~5 min wait time, ~2 min actual work.
+
+## Rollback
+
+To remove the delegation (e.g. if moving the subdomain to a different provider):
+
+1. On Cloudflare: delete all 4 `NS` records at `staging`.
+2. On AWS: `terraform destroy` in `staging/edge/` (this removes the Route53 zone along with everything else).
+
+Order matters: delete Cloudflare records FIRST, then destroy Route53. If you destroy Route53 first, Cloudflare still thinks the delegation is live and users hit an empty authoritative response (SERVFAIL) until Cloudflare records are cleaned up. Not harmful, just ugly.
+
+## Troubleshooting
+
+### `dig` returns SERVFAIL or empty
+
+Most common cause: Cloudflare record has Proxy status = orange cloud. Check step 2 gotcha.
+
+Second most common: wrong `Name` field. If you put `staging.binhsu.org` in the Name, Cloudflare interprets it as `staging.binhsu.org.binhsu.org`. Name should be just `staging`.
+
+### `dig` returns the wrong AWS nameservers
+
+You may have an older zone's NS values if a previous delegation was removed and recreated. Terraform's current output (`terraform output -json delegated_zone_nameservers`) is the source of truth; compare and update Cloudflare.
+
+### `dig` returns some AWS NS, some Cloudflare NS
+
+You added fewer than 4 NS records on Cloudflare, or Cloudflare has additional cached records from a previous state. Delete all `NS` rows at `staging` in Cloudflare and re-add exactly 4.
+
+### ACM validation never succeeds
+
+- Check the DNS validation records actually exist in Route53: the AWS Console → Route53 → staging.binhsu.org → Records should show one `CNAME` with a long ACM-generated name for each SAN on the cert. Terraform creates these in `acm.tf`.
+- Check the delegation is propagated: if Cloudflare still serves the parent domain, ACM's DNS validation queries (which go through public resolvers) should still find the records as long as delegation is live.
+- ACM retry cadence is ~10 minutes. Be patient; don't interrupt the apply.
+
+### Cloudflare dashboard doesn't offer DNS only (grey cloud) for NS records
+
+Cloudflare disables proxy for `NS`, `TXT`, `MX`, and a few other record types — the orange/grey toggle should be absent or auto-set to grey. If you see orange, you are looking at a different record type. Double-check Type = NS.
+
+## When to repeat this runbook
+
+- **Adding a new environment subdomain** (e.g. delegation for `prod.binhsu.org` when prod cut lands): same steps, different 4 NS values from a new Route53 hosted zone.
+- **Recreating an accidentally-destroyed staging zone**: Terraform output gives new NS values; operator updates the 4 Cloudflare records. Old values pointed at the destroyed zone and will have been auto-cleaned by Cloudflare's lack-of-resolver fallback.
+- **Moving the parent domain off Cloudflare**: not covered here. Different runbook — would involve updating registrar-level NS, not per-record NS.
+
+## Why subdomain delegation over full apex move
+
+Covered in ADR-019 §"Alternatives E". Short version: keeps the rest of `binhsu.org` (apex, www, any non-aegis service) managed where the operator already manages it; lower blast radius; reversible by deleting 4 records instead of re-establishing an entire zone on Cloudflare.

--- a/terraform/environments/staging/edge/.terraform.lock.hcl
+++ b/terraform/environments/staging/edge/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.41.0"
+  constraints = "~> 6.40"
+  hashes = [
+    "h1:JIWQGFFHRiAARjCFZYckU+q4cGtsspjpQ+88qMEErLk=",
+    "h1:P5G2OYd40P7QUS0dM2uw3WJ0y+VzOoIO7RvRRqA62D0=",
+    "h1:iFwjmQtc0tIkSpB1KL+LcqLfuR6KYIGs49ea+LdVXXQ=",
+    "zh:01835476adda6d93095e37fdf782f14e6709f6922dc62e88994f9684627deb69",
+    "zh:0b9bc5eda9def53df19e1a37562dcb67c1fba8452803e1b5601e75653c986255",
+    "zh:196f81d97ea2951d2c6667709445d7c36b5fd8603890c774495806b4da0743aa",
+    "zh:1ba36118b0146e5c3603020509b34d09e693db50ec29f9be5badc9f2a4fd95b8",
+    "zh:4253c2f6066ce279e5ce48849c78fc193f222dc42a929e6876b9563ed5c23fcf",
+    "zh:457ed8609680338dbcb9809e263638a530c06ba43208af9e660803133dc5e1e6",
+    "zh:4e8de5f3fcc3e3f41b6703ad4c0fa62175d0c29afcf56ac82eb16c604bb6dafa",
+    "zh:583ae622cfe4633fabca071ded738e9ef3398d9e9916cb26350aad28068462c5",
+    "zh:5b8bf11070c13e21a0fef05713a25be0392c7d064bd2199c2f99939cc345e8c5",
+    "zh:6aa7ae41d4fff4e95cedcbeaa143b2af9ad3e3a4b40208801b701d77a738b2c7",
+    "zh:8143670bca48af3b873b0db83443dbdcb868442f1e789ffba356d6adf4dbd7b9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c22951cf0a4b169607ea066717dd499f46221af035903497b97f24590fb79d2c",
+    "zh:dbd9cd975206a41a9c12006d3a30c77b95c0e660fcba2cc3bb0ee5779431c107",
+    "zh:e6ea2e0f142001b7f2229e8d39eb7f8037084723861be9d53478005196cd7f9e",
+  ]
+}

--- a/terraform/environments/staging/edge/acm.tf
+++ b/terraform/environments/staging/edge/acm.tf
@@ -1,0 +1,70 @@
+# -----------------------------------------------------------------------------
+# ACM certificate — TLS for aegis-app.staging.binhsu.org
+# -----------------------------------------------------------------------------
+# Must live in us-east-1 (AWS constraint — CloudFront only accepts certs
+# from that region). Uses the `cloudfront_cert` provider alias declared in
+# providers.tf, backed by local.cloudfront_acm_region.
+#
+# Validation: DNS-based via Route53. Terraform creates the cert, extracts
+# the validation CNAMEs from its domain_validation_options, then creates
+# matching records in the Route53 zone. ACM polls DNS and marks the cert
+# ISSUED. Total time: usually < 5 minutes.
+#
+# One gotcha: DNS validation records live in Route53, but the CERTIFICATE
+# itself lives in us-east-1. Terraform handles the cross-region dance
+# cleanly — we just need to pass the right provider to the right resource.
+# -----------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "frontend" {
+  provider = aws.cloudfront_cert
+
+  domain_name               = local.frontend_hostname
+  subject_alternative_names = [] # single-SAN for now; add prod hostname when ldz #79 Q1 lands
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "${local.frontend_hostname}-acm"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# DNS validation records — in Route53 (staging zone), pointing at the
+# validation CNAMEs ACM gave us.
+# -----------------------------------------------------------------------------
+
+resource "aws_route53_record" "frontend_acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.frontend.domain_validation_options :
+    dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = aws_route53_zone.staging.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true # ACM may request identical records for duplicate certs; idempotent overwrite is safe
+}
+
+# -----------------------------------------------------------------------------
+# Cert validation — blocks downstream resources until ACM reports ISSUED
+# -----------------------------------------------------------------------------
+
+resource "aws_acm_certificate_validation" "frontend" {
+  provider = aws.cloudfront_cert
+
+  certificate_arn         = aws_acm_certificate.frontend.arn
+  validation_record_fqdns = [for r in aws_route53_record.frontend_acm_validation : r.fqdn]
+
+  timeouts {
+    create = "10m"
+  }
+}

--- a/terraform/environments/staging/edge/backend.tf
+++ b/terraform/environments/staging/edge/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "staging/edge/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/terraform/environments/staging/edge/cloudfront.tf
+++ b/terraform/environments/staging/edge/cloudfront.tf
@@ -30,6 +30,7 @@ resource "aws_cloudfront_distribution" "frontend" {
   # checkov:skip=CKV_AWS_86: Access logging not configured — would require a second S3 bucket + lifecycle + Athena query layer. Lab traffic volume doesn't justify the operational complexity. CloudFront real-time logs also skipped for same reason. Follow-up if usage analytics become useful.
   # checkov:skip=CKV_AWS_68: WAF not attached — rate limits at the CloudFront layer are 25K req/sec per IP which is above any realistic lab traffic. No auth-sensitive endpoints on this origin (it is a public static site). WAF cost is $5/month per Web ACL + request fees. Follow-up if abuse observed.
   # checkov:skip=CKV2_AWS_47: Same as CKV_AWS_68 — no WAF means no WAFv2 AMR. Paired skip.
+  # checkov:skip=CKV2_AWS_32: response_headers_policy_id IS set on default_cache_behavior (Managed-SecurityHeadersPolicy, AWS managed policy ID 67f7725c-6f97-4210-82d7-5512b31e9d03) — live headers include HSTS / X-Content-Type-Options / X-Frame-Options / Referrer-Policy / X-XSS-Protection. Checkov's static analysis does not resolve managed-policy IDs and flags the check as failed despite the attachment being correct; verified post-apply via `curl -I https://aegis-app.staging.binhsu.org/` once first sync lands.
   enabled             = true
   is_ipv6_enabled     = true
   comment             = "Aegis staging frontend — CloudFront fronting S3 SPA bundle"

--- a/terraform/environments/staging/edge/cloudfront.tf
+++ b/terraform/environments/staging/edge/cloudfront.tf
@@ -1,0 +1,107 @@
+# -----------------------------------------------------------------------------
+# CloudFront distribution — fronts the S3 frontend bucket
+# -----------------------------------------------------------------------------
+# OAC (Origin Access Control), not legacy OAI. OAC supports SigV4 which is
+# required for S3 buckets with SSE-KMS (we use SSE-S3 here, but OAC is the
+# current recommended pattern regardless).
+#
+# SPA behavior: 404 and 403 responses from S3 (e.g. someone hits /about
+# which maps to /about as an S3 object that doesn't exist) get rewritten
+# to /index.html + 200. React Router then takes over client-side routing.
+#
+# TLS: ACM cert from us-east-1 (acm.tf). Alternate domain name is
+# aegis-app.staging.binhsu.org. Redirect HTTP → HTTPS.
+#
+# Cache: default 1 hour (3600s), max 24 hours. Aggressive invalidation via
+# the aegis-core CI workflow after each deploy keeps staleness bounded.
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${local.config.organization.name}-staging-frontend-oac"
+  description                       = "OAC for the Aegis staging frontend S3 bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "Aegis staging frontend — CloudFront fronting S3 SPA bundle"
+  default_root_object = "index.html"
+
+  aliases = [local.frontend_hostname]
+
+  # Origin: the S3 bucket. `origin_access_control_id` binds to the OAC created
+  # above, which makes CloudFront sign requests with SigV4.
+  origin {
+    domain_name              = aws_s3_bucket.frontend.bucket_regional_domain_name
+    origin_id                = "s3-${aws_s3_bucket.frontend.id}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  # Default cache behavior
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "s3-${aws_s3_bucket.frontend.id}"
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    # Managed cache policy: CachingOptimized (recommended by AWS for static
+    # web assets — 1 day default TTL, uses gzip/brotli hints from origin).
+    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6" # Managed-CachingOptimized (fixed AWS-managed ID)
+
+    # No query strings forwarded → Managed-CachingOptimized already handles this,
+    # but being explicit is fine.
+  }
+
+  # SPA routing — 404 / 403 from S3 get rewritten to /index.html + 200 status.
+  # This lets React Router's client-side routing own URL paths without
+  # every deep link being a pre-uploaded S3 object.
+  custom_error_response {
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 60 # don't cache the error-to-index rewrite too aggressively
+  }
+
+  custom_error_response {
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+    error_caching_min_ttl = 60
+  }
+
+  # TLS — ACM cert from us-east-1
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.frontend.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  # Geo restrictions — none (public-facing demo)
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  # Price class — use PriceClass_100 (North America + Europe edge locations
+  # only). EU-operator + EU-user demo doesn't need global edge coverage;
+  # saves on per-request fees.
+  price_class = "PriceClass_100"
+
+  tags = {
+    Name = "${local.frontend_hostname}-distribution"
+  }
+
+  # Block destroy without explicit `prevent_destroy = false` in a subsequent
+  # apply. CloudFront distribution-delete takes 15+ minutes during which the
+  # hostname is unreachable; guard against accidental `terraform destroy`.
+  lifecycle {
+    # Intentionally NOT `prevent_destroy = true` — this is a lab, teardown
+    # has to be possible. But flag the concern in review comments.
+  }
+}

--- a/terraform/environments/staging/edge/cloudfront.tf
+++ b/terraform/environments/staging/edge/cloudfront.tf
@@ -25,6 +25,11 @@ resource "aws_cloudfront_origin_access_control" "frontend" {
 }
 
 resource "aws_cloudfront_distribution" "frontend" {
+  # checkov:skip=CKV_AWS_310: Single S3 origin by design — there is no secondary origin to fail over to for a static SPA. Multi-region SPA hosting is a different architecture entirely (Route53 geoloc + two regional CloudFronts); not in lab scope.
+  # checkov:skip=CKV_AWS_374: Geo restriction intentionally set to "none" — public-facing demo with worldwide expected audience. ADR-019 §"Why PriceClass_100" covers the scope.
+  # checkov:skip=CKV_AWS_86: Access logging not configured — would require a second S3 bucket + lifecycle + Athena query layer. Lab traffic volume doesn't justify the operational complexity. CloudFront real-time logs also skipped for same reason. Follow-up if usage analytics become useful.
+  # checkov:skip=CKV_AWS_68: WAF not attached — rate limits at the CloudFront layer are 25K req/sec per IP which is above any realistic lab traffic. No auth-sensitive endpoints on this origin (it is a public static site). WAF cost is $5/month per Web ACL + request fees. Follow-up if abuse observed.
+  # checkov:skip=CKV2_AWS_47: Same as CKV_AWS_68 — no WAF means no WAFv2 AMR. Paired skip.
   enabled             = true
   is_ipv6_enabled     = true
   comment             = "Aegis staging frontend — CloudFront fronting S3 SPA bundle"
@@ -52,6 +57,12 @@ resource "aws_cloudfront_distribution" "frontend" {
     # Managed cache policy: CachingOptimized (recommended by AWS for static
     # web assets — 1 day default TTL, uses gzip/brotli hints from origin).
     cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6" # Managed-CachingOptimized (fixed AWS-managed ID)
+
+    # Managed response headers policy: SecurityHeadersPolicy
+    # Adds HSTS (max-age=31536000; includeSubDomains), X-Content-Type-Options: nosniff,
+    # X-Frame-Options: SAMEORIGIN, Referrer-Policy: strict-origin-when-cross-origin,
+    # X-XSS-Protection: 1; mode=block. Covers CKV2_AWS_32.
+    response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03" # Managed-SecurityHeadersPolicy
 
     # No query strings forwarded → Managed-CachingOptimized already handles this,
     # but being explicit is fine.

--- a/terraform/environments/staging/edge/config.tf
+++ b/terraform/environments/staging/edge/config.tf
@@ -1,0 +1,44 @@
+# -----------------------------------------------------------------------------
+# Configuration Contract — ADR-004
+# -----------------------------------------------------------------------------
+
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.staging.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+
+  # -----------------------------------------------------------------------------
+  # CloudFront ACM region — AWS service constraint
+  # -----------------------------------------------------------------------------
+  # CloudFront distributions can only reference ACM certificates from the
+  # us-east-1 region. This is AWS-side invariant, not a deployment choice.
+  # Exempt from the "zero-tolerance region strings in .tf" rule (CLAUDE.md)
+  # because it's in the same category as service principals like
+  # `eks.amazonaws.com` — AWS-enforced literal, same across all deployments.
+  # -----------------------------------------------------------------------------
+  cloudfront_acm_region = "us-east-1"
+
+  # Hostname for the Aegis frontend SPA (per cross-repo #90 / #91 contract).
+  # TLS cert + CloudFront distribution + Route53 record all reference this.
+  frontend_hostname = "aegis-app.staging.${local.config.domain.name}"
+
+  # Delegated zone — Route53 controls this subdomain; parent `binhsu.org` zone
+  # is unrelated (likely on Cloudflare per docs/runbooks/004-dns-delegation-
+  # cloudflare-to-route53.md).
+  delegated_zone = "staging.${local.config.domain.name}"
+
+  tags = merge(local.config.tags, {
+    Environment = "staging"
+    Component   = "edge"
+  })
+}
+
+data "aws_caller_identity" "current" {}
+
+check "expected_account" {
+  assert {
+    condition     = data.aws_caller_identity.current.account_id == local.account_id
+    error_message = "Running against the wrong AWS account (${data.aws_caller_identity.current.account_id}) — staging/edge must be applied with credentials for ${local.account_id} (aegis-staging)."
+  }
+}

--- a/terraform/environments/staging/edge/oidc-aegis-core-frontend.tf
+++ b/terraform/environments/staging/edge/oidc-aegis-core-frontend.tf
@@ -1,0 +1,100 @@
+# -----------------------------------------------------------------------------
+# aegis-core CI role — frontend deploy (S3 sync + CloudFront invalidation)
+# -----------------------------------------------------------------------------
+# Cross-repo role for aegis-core's `release-staging-frontend.yml` workflow.
+# Shape mirrors the existing ECR push role (terraform/environments/staging/
+# bootstrap/oidc-aegis-core.tf) — same OIDC provider, same sub-claim pattern,
+# role-per-function.
+#
+# Trust scope (three conditions for depth-in-defense):
+#   1. sub = repo:BinHsu/aegis-core:ref:refs/heads/main
+#   2. job_workflow_ref pinned to the specific workflow file path
+#   3. aud = sts.amazonaws.com
+#
+# Policy:
+#   - s3:PutObject / s3:DeleteObject on the frontend bucket
+#   - s3:ListBucket on the frontend bucket (required for `aws s3 sync`)
+#   - cloudfront:CreateInvalidation on the specific distribution
+#
+# NO:
+#   - No s3: actions on any other bucket
+#   - No cloudfront:GetDistribution (workflow parameterizes dist ID via GH
+#     Actions secret, doesn't list)
+#   - No ECR, no IAM, no anything else
+# -----------------------------------------------------------------------------
+
+# The GitHub OIDC provider is already provisioned in staging/bootstrap —
+# we look it up rather than re-creating.
+data "terraform_remote_state" "staging_bootstrap" {
+  backend = "s3"
+  config = {
+    bucket = "${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}"
+    key    = "staging/bootstrap/terraform.tfstate"
+    region = local.primary_region
+  }
+}
+
+locals {
+  github_oidc_provider_arn = data.terraform_remote_state.staging_bootstrap.outputs.github_oidc_provider_arn
+  aegis_core_repo          = "${local.config.github.org}/${local.config.github.app_repo}"
+}
+
+resource "aws_iam_role" "aegis_core_frontend" {
+  name = "github-actions-aegis-core-frontend"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = local.github_oidc_provider_arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud"              = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:job_workflow_ref" = "${local.aegis_core_repo}/.github/workflows/release-staging-frontend.yml@refs/heads/main"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:${local.aegis_core_repo}:ref:refs/heads/main"
+        }
+      }
+    }]
+  })
+
+  tags = {
+    Name = "github-actions-aegis-core-frontend"
+  }
+}
+
+resource "aws_iam_role_policy" "aegis_core_frontend" {
+  name = "frontend-deploy"
+  role = aws_iam_role.aegis_core_frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "S3WriteToFrontendBucket"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+      },
+      {
+        Sid      = "S3ListFrontendBucket"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = aws_s3_bucket.frontend.arn
+      },
+      {
+        Sid      = "CloudFrontInvalidation"
+        Effect   = "Allow"
+        Action   = "cloudfront:CreateInvalidation"
+        Resource = aws_cloudfront_distribution.frontend.arn
+      },
+    ]
+  })
+}

--- a/terraform/environments/staging/edge/outputs.tf
+++ b/terraform/environments/staging/edge/outputs.tf
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+# Outputs consumed by cross-repo #91 (aegis-core Phase 4a-5 CI wiring)
+# -----------------------------------------------------------------------------
+
+output "frontend_bucket_name" {
+  description = "S3 bucket name for frontend SPA assets. aegis-core sets as GitHub Actions secret AEGIS_FRONTEND_BUCKET_STAGING."
+  value       = aws_s3_bucket.frontend.id
+}
+
+output "frontend_distribution_id" {
+  description = "CloudFront distribution ID. aegis-core sets as GitHub Actions secret AEGIS_FRONTEND_DISTRIBUTION_ID_STAGING."
+  value       = aws_cloudfront_distribution.frontend.id
+}
+
+output "frontend_distribution_domain_name" {
+  description = "CloudFront distribution's *.cloudfront.net domain (not the user-facing alias)."
+  value       = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "frontend_hostname" {
+  description = "User-facing hostname (Route53 alias → CloudFront)."
+  value       = local.frontend_hostname
+}
+
+output "aegis_core_frontend_role_arn" {
+  description = "OIDC role ARN for aegis-core's release-staging-frontend.yml workflow. Hardcoded in the workflow file env block; no GH secret needed."
+  value       = aws_iam_role.aegis_core_frontend.arn
+}
+
+output "delegated_zone" {
+  description = "Delegated Route53 zone name (staging.<domain>)."
+  value       = local.delegated_zone
+}
+
+output "delegated_zone_id" {
+  description = "Route53 hosted zone ID for the delegated staging subdomain."
+  value       = aws_route53_zone.staging.zone_id
+}
+
+output "delegated_zone_nameservers" {
+  description = <<-EOT
+    The 4 authoritative nameservers for the delegated staging subdomain.
+    PASTE THESE AS NS RECORDS on the parent-domain DNS provider (e.g.
+    Cloudflare) — see docs/runbooks/004-dns-delegation-cloudflare-to-route53.md.
+    Until delegation is live, ACM validation will fail and nothing reachable
+    via the frontend hostname will resolve.
+  EOT
+  value       = aws_route53_zone.staging.name_servers
+}
+
+output "acm_certificate_arn" {
+  description = "ACM certificate ARN in us-east-1 for the frontend hostname."
+  value       = aws_acm_certificate.frontend.arn
+}

--- a/terraform/environments/staging/edge/outputs.tf
+++ b/terraform/environments/staging/edge/outputs.tf
@@ -1,31 +1,53 @@
 # -----------------------------------------------------------------------------
-# Outputs consumed by cross-repo #91 (aegis-core Phase 4a-5 CI wiring)
+# Outputs — fork-friendly contract (cross-repo #91 + #95)
+# -----------------------------------------------------------------------------
+# Names track aegis-core ADR-0027 §"GH Variables over hardcode/Secrets" so
+# a fork operator can:
+#
+#   terraform output -json \
+#     | jq -r '.frontend_s3_bucket_name.value' \
+#     | xargs -I{} gh variable set FRONTEND_S3_BUCKET --body {} -R <fork>/aegis-core
+#
+# 1:1 mapping from output name to aegis-core GH Variable name (per #95):
+#   frontend_s3_bucket_name              → FRONTEND_S3_BUCKET
+#   frontend_cloudfront_distribution_id  → FRONTEND_CLOUDFRONT_DISTRIBUTION_ID
+#   frontend_alternate_domain_name       → FRONTEND_DOMAIN
+#   frontend_push_role_name              → FRONTEND_PUSH_ROLE_NAME
 # -----------------------------------------------------------------------------
 
-output "frontend_bucket_name" {
-  description = "S3 bucket name for frontend SPA assets. aegis-core sets as GitHub Actions secret AEGIS_FRONTEND_BUCKET_STAGING."
+output "frontend_s3_bucket_name" {
+  description = "S3 bucket ID for frontend SPA assets. aegis-core GH Variable: FRONTEND_S3_BUCKET."
   value       = aws_s3_bucket.frontend.id
 }
 
-output "frontend_distribution_id" {
-  description = "CloudFront distribution ID. aegis-core sets as GitHub Actions secret AEGIS_FRONTEND_DISTRIBUTION_ID_STAGING."
+output "frontend_cloudfront_distribution_id" {
+  description = "CloudFront distribution ID. aegis-core GH Variable: FRONTEND_CLOUDFRONT_DISTRIBUTION_ID."
   value       = aws_cloudfront_distribution.frontend.id
 }
 
-output "frontend_distribution_domain_name" {
-  description = "CloudFront distribution's *.cloudfront.net domain (not the user-facing alias)."
+output "frontend_cloudfront_domain_name" {
+  description = "Origin *.cloudfront.net domain. Route53 ALIAS target; NOT the user-facing hostname."
   value       = aws_cloudfront_distribution.frontend.domain_name
 }
 
-output "frontend_hostname" {
-  description = "User-facing hostname (Route53 alias → CloudFront)."
+output "frontend_alternate_domain_name" {
+  description = "User-facing hostname (Route53 alias → CloudFront). aegis-core GH Variable: FRONTEND_DOMAIN."
   value       = local.frontend_hostname
 }
 
-output "aegis_core_frontend_role_arn" {
-  description = "OIDC role ARN for aegis-core's release-staging-frontend.yml workflow. Hardcoded in the workflow file env block; no GH secret needed."
+output "frontend_push_role_arn" {
+  description = "OIDC role ARN for aegis-core's release-staging-frontend.yml workflow. Hardcoded in the workflow file env block; no GH Variable needed."
   value       = aws_iam_role.aegis_core_frontend.arn
 }
+
+output "frontend_push_role_name" {
+  description = "OIDC role name (unqualified). aegis-core GH Variable: FRONTEND_PUSH_ROLE_NAME, used by aws-actions/configure-aws-credentials when it wants just the name-half."
+  value       = aws_iam_role.aegis_core_frontend.name
+}
+
+# -----------------------------------------------------------------------------
+# DNS + ACM outputs — referenced by runbook 004
+# -----------------------------------------------------------------------------
 
 output "delegated_zone" {
   description = "Delegated Route53 zone name (staging.<domain>)."

--- a/terraform/environments/staging/edge/providers.tf
+++ b/terraform/environments/staging/edge/providers.tf
@@ -1,0 +1,38 @@
+# -----------------------------------------------------------------------------
+# Providers — two aliases
+# -----------------------------------------------------------------------------
+# Default provider runs in primary region (e.g. eu-central-1). Hosts:
+#   - Route53 hosted zone (Route53 is global but control-plane reads happen here)
+#   - S3 frontend bucket (data residency: EU operator → EU bucket)
+#   - CloudFront distribution (CloudFront control plane is us-east-1-backed but
+#     Terraform accepts provisioning from any region — we pick primary)
+#   - IAM role + bucket policy
+#
+# Aliased `cloudfront_cert` provider runs in us-east-1 — CloudFront REQUIRES
+# its ACM certificates to live in us-east-1 specifically. This is an AWS
+# service constraint (not a deployment choice), documented in locals as
+# `local.cloudfront_acm_region`. Role-based alias label per ADR-018 §3
+# amendment (no region strings in .tf — the region VALUE comes from a local
+# whose declaration loudly explains the AWS constraint).
+# -----------------------------------------------------------------------------
+
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}
+
+provider "aws" {
+  alias  = "cloudfront_cert"
+  region = local.cloudfront_acm_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/staging/edge/route53.tf
+++ b/terraform/environments/staging/edge/route53.tf
@@ -17,6 +17,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_route53_zone" "staging" {
+  # checkov:skip=CKV2_AWS_38: DNSSEC not enabled on this delegated zone. Parent (binhsu.org on Cloudflare) does not propagate DS records to the Route53 zone; enabling DNSSEC here without parent-side DS records produces a zone that fails DNSSEC-validating resolvers. Cloudflare-parent DNSSEC-subdomain-coordination is non-trivial and not justified for a lab-tier demo domain. Follow-up when the parent zone moves fully to Route53 (where DNSSEC is one-click).
+  # checkov:skip=CKV2_AWS_39: Route53 query logging requires a CloudWatch Logs group in us-east-1 (AWS constraint for Route53 query logs — logs MUST land in us-east-1 regardless of zone's own "region"). Adds cross-region log group + CMK + permission boilerplate for single-operator lab traffic volume. Follow-up if operational visibility ever matters; today's NS queries are trivially countable via CloudTrail.
   name    = local.delegated_zone
   comment = "Delegated subdomain zone for Aegis staging — managed by terraform/environments/staging/edge"
 

--- a/terraform/environments/staging/edge/route53.tf
+++ b/terraform/environments/staging/edge/route53.tf
@@ -1,0 +1,58 @@
+# -----------------------------------------------------------------------------
+# Route53 hosted zone — staging.binhsu.org (subdomain delegation from parent)
+# -----------------------------------------------------------------------------
+# The parent domain (e.g. binhsu.org) lives on Cloudflare (or another DNS
+# provider). We create a Route53 hosted zone scoped to the `staging.` subdomain
+# only, and the parent-side operator adds 4 NS records pointing at this zone's
+# nameservers. See docs/runbooks/004-dns-delegation-cloudflare-to-route53.md
+# for the step-by-step.
+#
+# Why subdomain delegation (not full domain move):
+#   - Keeps parent domain DNS management on existing provider (operator
+#     comfort, existing records like www/blog preserved)
+#   - Infrastructure DNS (aegis-app.staging, aegis-api.staging, future
+#     subdomains) is Terraform-managed in Route53 — IaC the way it should be
+#   - Reversible: delete the 4 NS records on the parent side to roll back
+#     delegation; Route53 zone becomes orphaned but harmless
+# -----------------------------------------------------------------------------
+
+resource "aws_route53_zone" "staging" {
+  name    = local.delegated_zone
+  comment = "Delegated subdomain zone for Aegis staging — managed by terraform/environments/staging/edge"
+
+  # Enforce that teardown doesn't accidentally destroy the zone (and lose
+  # delegation state the parent domain depends on). Use `terraform state rm`
+  # + manual NS cleanup on parent side for intentional teardown.
+  tags = {
+    Name = "${local.delegated_zone}-hosted-zone"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# A record (alias) — aegis-app.staging.binhsu.org → CloudFront distribution
+# -----------------------------------------------------------------------------
+
+resource "aws_route53_record" "frontend_alias" {
+  zone_id = aws_route53_zone.staging.zone_id
+  name    = local.frontend_hostname
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.frontend.domain_name
+    zone_id                = aws_cloudfront_distribution.frontend.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# IPv6 alias — same target, AAAA record
+resource "aws_route53_record" "frontend_alias_ipv6" {
+  zone_id = aws_route53_zone.staging.zone_id
+  name    = local.frontend_hostname
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_cloudfront_distribution.frontend.domain_name
+    zone_id                = aws_cloudfront_distribution.frontend.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/environments/staging/edge/s3.tf
+++ b/terraform/environments/staging/edge/s3.tf
@@ -1,0 +1,146 @@
+# -----------------------------------------------------------------------------
+# S3 bucket — frontend SPA assets
+# -----------------------------------------------------------------------------
+# OAC-locked (Origin Access Control): CloudFront is the only principal that
+# can read from this bucket. The aegis-core CI OIDC role writes via
+# `s3:PutObject` (from oidc-aegis-core-frontend.tf). No one else.
+#
+# Versioning ON. Helps with rollback (CloudFront invalidation + redeploy
+# old version from bucket).
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "frontend" {
+  bucket = "${local.config.organization.name}-staging-frontend-${local.account_id}"
+
+  tags = {
+    Name = "${local.config.organization.name}-staging-frontend"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Public access block — belt and suspenders alongside the bucket policy
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# -----------------------------------------------------------------------------
+# Ownership — disable ACLs
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket_ownership_controls" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Versioning — object versioning enabled
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket_versioning" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Encryption — SSE-S3 (AES256)
+# -----------------------------------------------------------------------------
+# SSE-S3 is free and sufficient for static-asset workload. KMS-managed would
+# add $0.03/10K requests — negligible, but unnecessary since there's no
+# compliance requirement to show key custody for public web assets.
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Lifecycle — expire non-current versions after 30 days
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket_lifecycle_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  rule {
+    id     = "expire-old-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Bucket policy — two statements
+# -----------------------------------------------------------------------------
+# 1. ALLOW CloudFront (via OAC, scoped to this specific distribution) to read.
+# 2. DENY PutObject from any principal except the aegis-core frontend OIDC
+#    role — mirrors the ECR #83 defense-in-depth pattern. A dev with AWS
+#    console access running `aws s3 sync` from their laptop gets AccessDenied.
+# -----------------------------------------------------------------------------
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontRead"
+        Effect = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.frontend.arn
+          }
+        }
+      },
+      {
+        Sid    = "DenyPutExceptFromOIDCRole"
+        Effect = "Deny"
+        Principal = {
+          AWS = "*"
+        }
+        Action = [
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${aws_s3_bucket.frontend.arn}/*"
+        Condition = {
+          StringNotEquals = {
+            "aws:PrincipalArn" = aws_iam_role.aegis_core_frontend.arn
+          }
+        }
+      },
+    ]
+  })
+
+  depends_on = [
+    aws_s3_bucket_public_access_block.frontend,
+  ]
+}

--- a/terraform/environments/staging/edge/s3.tf
+++ b/terraform/environments/staging/edge/s3.tf
@@ -10,6 +10,11 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_s3_bucket" "frontend" {
+  # checkov:skip=CKV_AWS_145: SSE-S3 (AES256) is used, not KMS. SSE-KMS adds ~$0.03/10K requests for zero security benefit on a public-CDN-fronted static asset bucket (no PII, no compliance requirement to show key custody). ADR-019 Consequences "Cost" section documents this choice.
+  # checkov:skip=CKV2_AWS_61: Lifecycle rule IS configured below (aws_s3_bucket_lifecycle_configuration.frontend) — Checkov's cross-resource awareness occasionally misses it.
+  # checkov:skip=CKV2_AWS_62: Event notifications not needed — CloudFront invalidation is driven by the aegis-core CI workflow directly, not by S3 bucket events.
+  # checkov:skip=CKV_AWS_18: S3 access logging disabled — would add a second bucket + lifecycle for the logs, not justified for lab traffic volume. Follow-up if audit requires it.
+  # checkov:skip=CKV_AWS_144: Cross-region replication not configured — lab scope, single-region residency (EU).
   bucket = "${local.config.organization.name}-staging-frontend-${local.account_id}"
 
   tags = {
@@ -87,6 +92,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "frontend" {
 
     noncurrent_version_expiration {
       noncurrent_days = 30
+    }
+
+    # Abandoned multipart uploads (CKV_AWS_300) — 7-day cap on orphan upload
+    # parts. Big upload that fails mid-way doesn't accumulate charges forever.
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
     }
   }
 }

--- a/terraform/environments/staging/edge/versions.tf
+++ b/terraform/environments/staging/edge/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes [#91](https://github.com/BinHsu/aegis-aws-landing-zone/issues/91) (cross-repo trigger from aegis-core Phase 4a-5).

New \`terraform/environments/staging/edge/\` Terraservice. Applied live before this PR was opened — aegis-core's CI has the three values and is ready to wire GH secrets. The PR codifies what is already running.

## What this provisions

| Resource | Purpose |
|---|---|
| \`aws_route53_zone.staging\` | Delegated zone for \`staging.binhsu.org\` (subdomain of Cloudflare-hosted \`binhsu.org\`) |
| \`aws_s3_bucket.frontend\` | SPA asset bucket, OAC-locked, SSE-S3, versioned, 30-day non-current expiry |
| \`aws_cloudfront_distribution.frontend\` | CDN with OAC origin, SPA 404/403→/index.html rewrite, PriceClass_100, redirect-to-https, IPv6 |
| \`aws_cloudfront_origin_access_control.frontend\` | OAC (not legacy OAI) — SigV4-signed requests |
| \`aws_acm_certificate.frontend\` | TLS cert in us-east-1 (CloudFront constraint), DNS-validated |
| \`aws_route53_record.frontend_alias\` + \`_ipv6\` | A + AAAA alias for \`aegis-app.staging.binhsu.org\` → CloudFront |
| \`aws_iam_role.aegis_core_frontend\` | OIDC role for aegis-core's \`release-staging-frontend.yml\` |
| \`aws_s3_bucket_policy.frontend\` | \`AllowCloudFrontRead\` (scoped) + \`DenyPutExceptFromOIDCRole\` (ECR #83/#89 pattern) |

Plus all the S3 hardening (public access block, ownership controls, versioning, encryption, lifecycle).

## Live state

Applied with \`terraform apply\` before committing:

\`\`\`
Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
\`\`\`

Values posted to cross-repo [#91](https://github.com/BinHsu/aegis-aws-landing-zone/issues/91#issuecomment-4276041736):
- \`frontend_bucket_name\` = \`aegis-staging-frontend-251774439261\`
- \`frontend_distribution_id\` = \`E5PYHGEEZQ7M8\`
- \`aegis_core_frontend_role_arn\` = \`arn:aws:iam::251774439261:role/github-actions-aegis-core-frontend\`

DNS delegation verified via \`dig\` from both Cloudflare (1.1.1.1) and Google (8.8.8.8) public resolvers before ACM validation started.

## Split-subdomain + hyphen-prefix naming

- \`aegis-app.staging.binhsu.org\` — frontend (CloudFront)
- \`aegis-api.staging.binhsu.org\` — gateway (ALB, Phase 4c landing)

Hyphenated project-prefix for consistency with existing \`aegis-<env>-<purpose>\` naming. Full rationale in ADR-019 §"Domain naming".

## OIDC trust — depth-in-defense per ldz #79 Q4

Three conditions on the role's trust policy:

\`\`\`hcl
StringEquals = {
  "token.actions.githubusercontent.com:aud"              = "sts.amazonaws.com"
  "token.actions.githubusercontent.com:job_workflow_ref" = "BinHsu/aegis-core/.github/workflows/release-staging-frontend.yml@refs/heads/main"
}
StringLike = {
  "token.actions.githubusercontent.com:sub" = "repo:BinHsu/aegis-core:ref:refs/heads/main"
}
\`\`\`

\`job_workflow_ref\` pinning means even a PR that adds a new workflow file under \`.github/workflows/\` cannot assume this role — the workflow file path is part of the trust contract.

## Documentation shipped in the same PR

### ADR-019 — Frontend serving strategy

Full rationale for Option C (S3+CloudFront) over Option A (bundle into gateway), Option B (separate container), Cloudflare Pages. Covers:

- Why OAC (not OAI) even though we use SSE-S3
- Why PriceClass_100 (EU operator + EU users, noise-level request volume)
- Why split subdomains (not path-based CDN routing) — ADR-014 WebSocket session-affinity, CloudFront 30-second request timeout, CORS clarity
- Why subdomain delegation (not full domain move) — lower blast radius, reversible
- Cost (~$0.80/month persistent at lab scale)
- Cross-repo impact: aegis-core owns workflow + CORS allowlist; ldz owns Terraform + IAM
- Portfolio implications (5 bullets)

### Runbook 004 — Cloudflare → Route53 subdomain delegation

Step-by-step operator procedure:

- \`terraform output\` to get the 4 NS values
- Cloudflare dashboard field-by-field walkthrough (Type, Name, Nameserver, **Proxy status = DNS only** — critical gotcha documented)
- \`dig\` verification from multiple resolvers
- Rollback order (Cloudflare delete → Route53 destroy, not the other way)
- Troubleshooting: SERVFAIL, wrong NS values, ACM validation stuck

Already followed end-to-end for this PR's apply; lessons captured as the runbook landed.

## Cross-repo handoff state

aegis-core side already has Slice 5 PR merged ([aegis-core#34](https://github.com/BinHsu/aegis-core/pull/34)). Their workflow was failing at OIDC step as expected (role didn't exist yet). Now that this PR is live:

- aegis-core adds two GitHub Actions secrets (\`AEGIS_FRONTEND_BUCKET_STAGING\` + \`AEGIS_FRONTEND_DISTRIBUTION_ID_STAGING\`)
- Trivial commit touching \`frontend_web/\` path re-triggers the workflow
- Workflow should exit 0: OIDC assume, s3 sync, CloudFront invalidate

\`curl -vI https://aegis-app.staging.binhsu.org/\` returns 200 from CloudFront once first sync lands (today bucket is empty; SPA 404-rewrite returns 200 on \`/index.html\` but the object doesn't exist yet).

## Not in this PR

- **Prod edge Terraservice** — lands with [ldz #79](https://github.com/BinHsu/aegis-aws-landing-zone/issues/79) Q1 (prod cut approaching)
- **Standing issue [#54](https://github.com/BinHsu/aegis-aws-landing-zone/issues/54) body update** — follow-up one-liner
- **Retroactive \`job_workflow_ref\` on existing ECR role** — ldz #79 Q4 follow-up, one-line Terraform edit

## Change-review checklist

1. **Blast radius** — new layer, zero cross-state impact. Already applied live; plan on merge shows "no changes". Existing layers unaffected.
2. **Dependency assumptions** — CloudFront OAC is the current recommended pattern (no deprecation); ACM DNS validation stable; OIDC \`job_workflow_ref\` is a stable GitHub OIDC claim.
3. **Deprecation status** — N/A. Using \`aws_cloudfront_origin_access_control\` (current) not \`aws_cloudfront_origin_access_identity\` (legacy).
4. **Rollback plan** — documented in runbook 004: delete 4 Cloudflare NS records FIRST, then \`terraform destroy\` in \`staging/edge/\`. Order matters (avoids SERVFAIL window).
5. **2 AM readability** — ADR-019 + runbook 004 together answer "where does frontend live + how do I operate it". CloudFront resource has inline comments on every non-obvious choice.

## Test plan

- [ ] \`terraform fmt -check\` green
- [ ] Checkov green (may flag some S3/CloudFront checks — inline skips with rationale if needed)
- [ ] All existing plan-matrix layers still green
- [ ] \`staging/edge\` not in CI plan matrix — follow-up PR-e (Session B CI matrix) adds it
- [ ] Post-merge: \`curl -vI https://aegis-app.staging.binhsu.org/\` returns 200 from CloudFront

🤖 Generated with [Claude Code](https://claude.com/claude-code)