### PR TITLE
chore(workloads): bump aws provider ~> 5.0 → ~> 6.40 + commit lockfile

### DIFF
--- a/terraform/environments/staging/workloads/.terraform.lock.hcl
+++ b/terraform/environments/staging/workloads/.terraform.lock.hcl
@@ -1,0 +1,96 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.19.0"
+  constraints = "~> 1.19"
+  hashes = [
+    "h1:3E8E5zdLYTLsP9h+Ibvez8m+S0Qqa7QULHvcq8PcnWg=",
+    "h1:9QkxPjp0x5FZFfJbE+B7hBOoads9gmdfj9aYu5N4Sfc=",
+    "h1:quymfa/OKEfWI5JXFEwGbUY2aAy0vet3rA9JWJam+3k=",
+    "zh:1dec8766336ac5b00b3d8f62e3fff6390f5f60699c9299920fc9861a76f00c71",
+    "zh:43f101b56b58d7fead6a511728b4e09f7c41dc2e3963f59cf1c146c4767c6cb7",
+    "zh:4c4fbaa44f60e722f25cc05ee11dfaec282893c5c0ffa27bc88c382dbfbaa35c",
+    "zh:51dd23238b7b677b8a1abbfcc7deec53ffa5ec79e58e3b54d6be334d3d01bc0e",
+    "zh:5afc2ebc75b9d708730dbabdc8f94dd559d7f2fc5a31c5101358bd8d016916ba",
+    "zh:6be6e72d4663776390a82a37e34f7359f726d0120df622f4a2b46619338a168e",
+    "zh:72642d5fcf1e3febb6e5d4ae7b592bb9ff3cb220af041dbda893588e4bf30c0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1da03e3239867b35812ee031a1060fed6e8d8e458e2eaca48b5dd51b35f56f7",
+    "zh:b98b6a6728fe277fcd133bdfa7237bd733eae233f09653523f14460f608f8ba2",
+    "zh:bb8b071d0437f4767695c6158a3cb70df9f52e377c67019971d888b99147511f",
+    "zh:dc89ce4b63bfef708ec29c17e85ad0232a1794336dc54dd88c3ba0b77e764f71",
+    "zh:dd7dd18f1f8218c6cd19592288fde32dccc743cde05b9feeb2883f37c2ff4b4e",
+    "zh:ec4bd5ab3872dedb39fe528319b4bba609306e12ee90971495f109e142d66310",
+    "zh:f610ead42f724c82f5463e0e71fa735a11ffb6101880665d93f48b4a67b9ad82",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.41.0"
+  constraints = "~> 6.40"
+  hashes = [
+    "h1:JIWQGFFHRiAARjCFZYckU+q4cGtsspjpQ+88qMEErLk=",
+    "h1:P5G2OYd40P7QUS0dM2uw3WJ0y+VzOoIO7RvRRqA62D0=",
+    "h1:iFwjmQtc0tIkSpB1KL+LcqLfuR6KYIGs49ea+LdVXXQ=",
+    "zh:01835476adda6d93095e37fdf782f14e6709f6922dc62e88994f9684627deb69",
+    "zh:0b9bc5eda9def53df19e1a37562dcb67c1fba8452803e1b5601e75653c986255",
+    "zh:196f81d97ea2951d2c6667709445d7c36b5fd8603890c774495806b4da0743aa",
+    "zh:1ba36118b0146e5c3603020509b34d09e693db50ec29f9be5badc9f2a4fd95b8",
+    "zh:4253c2f6066ce279e5ce48849c78fc193f222dc42a929e6876b9563ed5c23fcf",
+    "zh:457ed8609680338dbcb9809e263638a530c06ba43208af9e660803133dc5e1e6",
+    "zh:4e8de5f3fcc3e3f41b6703ad4c0fa62175d0c29afcf56ac82eb16c604bb6dafa",
+    "zh:583ae622cfe4633fabca071ded738e9ef3398d9e9916cb26350aad28068462c5",
+    "zh:5b8bf11070c13e21a0fef05713a25be0392c7d064bd2199c2f99939cc345e8c5",
+    "zh:6aa7ae41d4fff4e95cedcbeaa143b2af9ad3e3a4b40208801b701d77a738b2c7",
+    "zh:8143670bca48af3b873b0db83443dbdcb868442f1e789ffba356d6adf4dbd7b9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c22951cf0a4b169607ea066717dd499f46221af035903497b97f24590fb79d2c",
+    "zh:dbd9cd975206a41a9c12006d3a30c77b95c0e660fcba2cc3bb0ee5779431c107",
+    "zh:e6ea2e0f142001b7f2229e8d39eb7f8037084723861be9d53478005196cd7f9e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "h1:7nJdsd1RMPBtOjDXidB37+KSDN5VcOWkbkow69qJVGc=",
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/terraform/environments/staging/workloads/guardduty.tf
+++ b/terraform/environments/staging/workloads/guardduty.tf
@@ -7,7 +7,7 @@
 # before the first apply.
 #
 # Two EKS-specific features:
-#   - EKS_AUDIT_LOG_MONITORING: anomaly detection on K8s API audit logs
+#   - EKS_AUDIT_LOGS: anomaly detection on K8s API audit logs
 #     (privilege escalation, anonymous auth, suspicious API calls)
 #   - EKS_RUNTIME_MONITORING: container-level runtime agent (crypto mining,
 #     reverse shell, DNS exfiltration, file integrity changes)
@@ -32,7 +32,7 @@ resource "aws_guardduty_detector" "staging" {
 
 resource "aws_guardduty_detector_feature" "eks_audit_log" {
   detector_id = aws_guardduty_detector.staging.id
-  name        = "EKS_AUDIT_LOG_MONITORING"
+  name        = "EKS_AUDIT_LOGS"
   status      = "ENABLED"
 }
 

--- a/terraform/environments/staging/workloads/versions.tf
+++ b/terraform/environments/staging/workloads/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.40"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Summary

Aligns `staging/workloads` with the project-wide aws provider v6.40 baseline (other layers on `~> 6.40` since PR #84 / #92). Workloads was the last layer still pinned to `~> 5.0`, and its `.terraform.lock.hcl` was untracked — CI re-derived a fresh lockfile every run, silently picking up new aws 5.x releases.

Prep for the upcoming workloads slot-pattern refactor PR. Splitting the bump out keeps the slot-pattern PR review focused.

## Changes

| File | Change |
|---|---|
| `versions.tf` | `aws ~> 5.0` → `aws ~> 6.40` |
| `.terraform.lock.hcl` | new file. `terraform init -upgrade` then `terraform providers lock -platform=linux_amd64 -platform=darwin_amd64 -platform=darwin_arm64`. Resolves to aws v6.41.0. Multi-platform hashes so CI (linux_amd64) and local dev (darwin_arm64 / darwin_amd64) both verify. |
| `guardduty.tf` | `aws_guardduty_detector_feature.eks_audit_log.name` value `EKS_AUDIT_LOG_MONITORING` → `EKS_AUDIT_LOGS`. v5 accepted the legacy alias; v6 tightened validation and only accepts the canonical v2 API name. Caught by `terraform validate` after the bump. |

## Verification

State is empty (`terraform state list` returns "No state file was found!" — confirmed via SSO query against the live shared-account backend). Bump is therefore a pure code-level change; next workload apply (Session C) creates everything fresh against v6.41.

| Check | Result |
|---|---|
| `terraform init -upgrade` | success — aws v6.41.0 |
| `terraform validate` | success after the EKS_AUDIT_LOGS rename |
| `terraform fmt -check -recursive` | success (exit 0) |
| `terraform plan` | not run — needs platform remote_state populated; same gap as platform layer's own absence from CI plan matrix. Real plan deferred to Session C apply. |

## Change-review checklist (per docs/principles/change-review-discipline.md)

1. **Blast radius** — empty state. Code-level only. Next apply creates fresh against v6.41.
2. **Dependency assumptions** — aws provider v6.40 is the project baseline (PR #84 for network, PR #92 for platform). No new external dependency.
3. **Deprecation status** — surveyed workloads/ for v5→v6 affected APIs (`data.aws_region.name`, `aws_iam_role.inline_policy`, `aws_guardduty_detector.datasources`): none in use. The `EKS_AUDIT_LOG_MONITORING` enum was the only hit, fixed in this PR. Reference: HashiCorp aws provider v6 upgrade guide § "GuardDuty Detector Feature: Removed Aliased Names".
4. **Rollback plan** — revert this commit; lockfile regenerates as v5.x on next init. State empty so no apply-time impact.
5. **2 AM readability** — single semver bump + one enum rename. Diff is 3 files, 6 lines. Reviewable in under a minute.

## Test plan

- [ ] Checkov green
- [ ] All baseline-layer plans in CI matrix stay green (no cross-layer contract change)
- [ ] After merge, no auto-apply triggered (workloads is workload-tier, not baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)