### PR TITLE
feat(oidc): add job_workflow_ref condition to aegis-core ECR push role

### DIFF
--- a/terraform/environments/staging/bootstrap/oidc-aegis-core.tf
+++ b/terraform/environments/staging/bootstrap/oidc-aegis-core.tf
@@ -36,6 +36,22 @@ resource "aws_iam_role" "aegis_core_ecr" {
         }
         StringLike = {
           "token.actions.githubusercontent.com:sub" = "repo:${local.github_org}/${local.github_app_repo}:ref:refs/heads/main"
+
+          # job_workflow_ref pins the role to a single aegis-core workflow file.
+          # Prevents the "merged-PR workflow-injection" attack class: an
+          # attacker landing a new .github/workflows/*.yml on main and reusing
+          # this role would fail STS because the injected file's
+          # job_workflow_ref would not match.
+          #
+          # Per aegis-core #79 Q4 (2026-04-19): the filename is locked to
+          # .github/workflows/release-staging-image.yml — a dedicated workflow
+          # scoped to ECR push only (rest of aegis-core CI stays read-only on
+          # tokens). Refuse any other workflow, including a "Re-run failed
+          # jobs" from a non-main SHA.
+          #
+          # Sibling to the workflow-level `if:` gate aegis-core committed to.
+          # IAM is the enforcement layer; the `if:` is reviewer-visible depth.
+          "token.actions.githubusercontent.com:job_workflow_ref" = "${local.github_org}/${local.github_app_repo}/.github/workflows/release-staging-image.yml@refs/heads/main"
         }
       }
     }]


### PR DESCRIPTION
## Summary

Closes outstanding Q4 ask from cross-repo [#79](https://github.com/BinHsu/aegis-aws-landing-zone/issues/79). aegis-core confirmed the workflow filename (`release-staging-image.yml`) on 2026-04-19; this PR lands the corresponding `job_workflow_ref` condition key on the `github-actions-aegis-core-ecr` trust policy, as committed in the 2026-04-19 cross-repo reply.

## What changes

- `terraform/environments/staging/bootstrap/oidc-aegis-core.tf` — one extra `StringLike` condition on the ECR push role's trust policy:

  ```
  "token.actions.githubusercontent.com:job_workflow_ref" =
    "${local.github_org}/${local.github_app_repo}/.github/workflows/release-staging-image.yml@refs/heads/main"
  ```

Cache role (`github-actions-aegis-core-cache`) intentionally **not** modified — Bazel cache reads/writes happen from multiple CI workflows, not a dedicated file.

## Why this particular condition key

- **Blocks workflow-injection structurally.** PR lands on `aegis-core` main adding `.github/workflows/malicious.yml` → injected file's `job_workflow_ref` is different → STS refuses the token before IAM action runs.
- **Zero operational cost** (one line in trust policy), zero CI-speed cost, huge security-cost coverage.
- **Layer choice — IAM, not aegis-core workflow.** Trust policy is the single source of truth for enforcement. aegis-core's workflow-level `if:` gate stays as reviewer-visible defense-in-depth.

## Why the other OIDC condition keys are not added

| Candidate | Verdict | Why |
|---|---|---|
| `environment` | Defer | Requires GitHub Environments approval flow; overkill for staging where every main push is auto-promoted. Revisit on the `aegis-core-prod` push role when that lands (#79 Q1, separate PR). |
| `actor` | Reject | Brittle. Any teammate addition → IAM update round-trip. A compromised teammate account passes `actor` anyway. |

## Verification

| Check | Result |
|---|---|
| `terraform fmt -check` | exit 0 |
| `terraform validate` | success |
| `terraform plan` | deferred to PR's baseline-apply CI |

## Change-review checklist

1. **Blast radius** — one IAM role trust policy. Narrowing (adding an extra AND condition), not widening. Worst case: aegis-core's release-staging-image.yml is renamed/moved → role assumption fails → one-line trust-policy fix; rollback is `git revert`.
2. **Dependency assumptions** — assumes aegis-core ships the exact path `.github/workflows/release-staging-image.yml` (confirmed on [#79 2026-04-19 comment](https://github.com/BinHsu/aegis-aws-landing-zone/issues/79#issuecomment-4278530875)).
3. **Deprecation status** — `job_workflow_ref` is a stable GitHub OIDC claim since 2022. Reference: [GitHub OIDC token claims docs](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-token-claims).
4. **Rollback plan** — `git revert` + CI apply; trust policy reverts to `sub`-only and aegis-core's role keeps working unchanged.
5. **2 AM readability** — inline comment in the .tf explains what the condition blocks, why, and links back to #79.

## Outstanding from #79 after this PR

- **Q1** prod ECR repo + role split — waits for aegis-core prod-cut PR (separate ldz PR, bundled with lifecycle-policy tag diff)
- **Q2** `countNumber` bump for multi-arch — waits for aegis-core multi-arch ETA
- **Q3** multi-arch gotchas — no ldz action; distroless arm64 already pinned on aegis-core's MODULE.bazel
- **Q4** this PR — **DONE**

## Test plan

- [ ] Checkov green
- [ ] baseline-apply plan (triggered on merge) reports exactly 1 in-place change on `aws_iam_role.aegis_core_ecr.assume_role_policy`
- [ ] After apply lands, verify aegis-core's next `release-staging-image.yml` push succeeds (no ldz change beyond this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)