### PR TITLE
fix(incidents): Inc 29 ArgoCD OOM + Inc 30 teardown sweep fail-loudly

### DIFF
--- a/.github/workflows/terraform-teardown-workload.yml
+++ b/.github/workflows/terraform-teardown-workload.yml
@@ -250,16 +250,27 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
-      # Safety-net sweep: delete EKS-auto-created security groups in the
-      # target VPC before Terraform tries to destroy the VPC itself. EKS
-      # creates a cluster SG (tagged aws:eks:cluster-name) that is NOT
-      # managed by any Terraform resource — AWS is supposed to clean it up
-      # when the cluster is deleted, but this can race/fail leaving the
-      # VPC with a DependencyViolation on destroy. Pre-deleting these
-      # orphan SGs lets Terraform's VPC destroy proceed cleanly.
-      # See docs/incidents.md Incident 20.
-      - name: Sweep orphan EKS security groups in target VPC
+      # Safety-net sweep: clear EKS-auto-created network interfaces and
+      # security groups in the target VPC before Terraform tries to destroy
+      # the VPC. EKS creates a cluster SG (tagged aws:eks:cluster-name) and
+      # control-plane ENIs that are NOT managed by any Terraform resource —
+      # AWS releases them asynchronously after the cluster is deleted, and
+      # any ENI still in the `available` state will block SG delete, which
+      # in turn blocks subnet delete with DependencyViolation.
+      #
+      # Order matters: ENIs first, then SGs. Reverse order hits the exact
+      # DependencyViolation that the sweep exists to prevent.
+      #
+      # Fail loudly: if the sweep cannot clear a resource, the step exits
+      # non-zero instead of masking the error with `|| true`. A silent
+      # sweep-failure was the root cause of Incident 30 — the step claimed
+      # success while AWS was rejecting the delete.
+      #
+      # See docs/incidents.md Incidents 20 + 30.
+      - name: Sweep orphan EKS ENIs + security groups in target VPC
         run: |
+          set -eo pipefail
+
           # Filter by component tags rather than by Name tag: PR-c (#84)
           # refactored the VPC name from `<env>-vpc` to `<env>-<region_key>-vpc`
           # (e.g. `staging-primary-vpc`). Matching on Name alone would silently
@@ -276,8 +287,30 @@ jobs:
             echo "::notice::No VPCs tagged for ${{ inputs.env }}/network in this region; nothing to sweep."
             exit 0
           fi
+
           for VPC_ID in $VPC_IDS; do
-            echo "::notice::Sweeping orphan EKS SGs in VPC $VPC_ID"
+            echo "::notice::Sweeping VPC $VPC_ID"
+
+            # Step 1: delete orphan ENIs (status=available). These are the
+            # control-plane ENIs AWS hasn't reclaimed yet after cluster delete.
+            ENI_IDS=$(aws ec2 describe-network-interfaces \
+              --region ${{ env.AWS_REGION }} \
+              --filters "Name=vpc-id,Values=$VPC_ID" \
+                        "Name=status,Values=available" \
+              --query 'NetworkInterfaces[].NetworkInterfaceId' \
+              --output text)
+            for ENI in $ENI_IDS; do
+              echo "::notice::Deleting orphan ENI $ENI"
+              if ! aws ec2 delete-network-interface \
+                     --region ${{ env.AWS_REGION }} \
+                     --network-interface-id "$ENI" 2> /tmp/eni-err.log; then
+                echo "::error::Failed to delete ENI $ENI:"
+                cat /tmp/eni-err.log
+                exit 1
+              fi
+            done
+
+            # Step 2: delete orphan EKS cluster SGs (tagged aws:eks:cluster-name).
             SG_IDS=$(aws ec2 describe-security-groups \
               --region ${{ env.AWS_REGION }} \
               --filters "Name=vpc-id,Values=$VPC_ID" \
@@ -286,8 +319,41 @@ jobs:
               --output text)
             for SG in $SG_IDS; do
               echo "::notice::Deleting orphan EKS SG $SG"
-              aws ec2 delete-security-group --region ${{ env.AWS_REGION }} --group-id "$SG" || true
+              if ! aws ec2 delete-security-group \
+                     --region ${{ env.AWS_REGION }} \
+                     --group-id "$SG" 2> /tmp/sg-err.log; then
+                echo "::error::Failed to delete SG $SG:"
+                cat /tmp/sg-err.log
+                exit 1
+              fi
             done
+
+            # Step 3: verify no available-state ENIs remain before handing off
+            # to terraform destroy. Control-plane ENI reclaim is asynchronous;
+            # poll for up to 5 minutes.
+            echo "::notice::Verifying VPC $VPC_ID is clear of available ENIs"
+            for i in $(seq 1 30); do
+              REMAINING=$(aws ec2 describe-network-interfaces \
+                --region ${{ env.AWS_REGION }} \
+                --filters "Name=vpc-id,Values=$VPC_ID" \
+                          "Name=status,Values=available" \
+                --query 'length(NetworkInterfaces)' --output text)
+              if [ "$REMAINING" = "0" ]; then
+                break
+              fi
+              echo "::notice::$REMAINING ENIs still available in VPC $VPC_ID; waiting 10s (attempt $i/30)"
+              sleep 10
+            done
+            if [ "$REMAINING" != "0" ]; then
+              echo "::error::VPC $VPC_ID still has $REMAINING available ENIs after 5m; aborting teardown"
+              aws ec2 describe-network-interfaces \
+                --region ${{ env.AWS_REGION }} \
+                --filters "Name=vpc-id,Values=$VPC_ID" \
+                          "Name=status,Values=available" \
+                --query 'NetworkInterfaces[].[NetworkInterfaceId,Description,Groups[].GroupName]' \
+                --output text
+              exit 1
+            fi
           done
 
       - name: Check layer exists

--- a/terraform/environments/staging/platform/modules/eks-cluster/argocd.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/argocd.tf
@@ -23,9 +23,11 @@ resource "helm_release" "argocd" {
     yamlencode({
       controller = {
         replicas = 1
+        # Cold-start reconcile peak (3 Applications including kube-prometheus-stack)
+        # routinely exceeds chart-default 512Mi → OOMKilled on bring-up. See Incident 29.
         resources = {
-          requests = { cpu = "100m", memory = "256Mi" }
-          limits   = { cpu = "500m", memory = "512Mi" }
+          requests = { cpu = "100m", memory = "512Mi" }
+          limits   = { cpu = "500m", memory = "1Gi" }
         }
       }
 


### PR DESCRIPTION
## Summary

- **Incident 29** — `argocd-application-controller` OOMKilled on cold-start reconcile peak (primary cluster, Session C). Raise controller memory: requests 256Mi→512Mi, limits 512Mi→1Gi.
- **Incident 30** — Teardown sweep silently fails when orphan control-plane ENIs still hold the EKS cluster SG; `|| true` hides the `DependencyViolation`, sweep claims success, `terraform destroy` then hits the same error on subnet. Fix: (a) delete ENIs before SGs; (b) drop `|| true` and fail loudly with AWS error text; (c) poll ENI count to zero (5m) before handing off to destroy.

Neither incident has a cold-apply validation in this PR — next Session's regular cold apply is the natural test bed. Both are narrow, reversible changes.

## Change-review-discipline.md checklist

### 2.1 Blast radius
- **Inc 29** (argocd.tf): single Helm release values diff on **staging/platform** only. Affects ArgoCD controller in both EKS slots (primary + slave_1) on next platform apply. Blast = argo control loop for staging workloads.
- **Inc 30** (teardown-workload.yml): affects teardown sweep only; no apply-path impact. Blast = teardown reliability, not runtime.

### 2.2 Dependency assumptions
- **Inc 29**: assumes Karpenter node has ≥1Gi headroom for the controller pod. On `c7i-flex.large` Spot (2 vCPU / 4 GiB) this is trivial (already runs ~4 pods at similar size).
- **Inc 30**: assumes AWS releases control-plane ENIs within 5 minutes of cluster delete. Observed worst case in Incident 30 diagnosis was <2m. 5m has margin without being excessive.

### 2.3 Deprecation status
- `aws ec2 describe-network-interfaces` / `delete-network-interface` / `delete-security-group`: stable AWS EC2 APIs, no deprecation.
- `helm_release` `values` with nested `resources.requests`/`limits`: ArgoCD Helm chart 7.6.12, stable schema.
- No Terraform provider version bump; no GitHub Actions version bump.

### 2.4 Rollback plan
- **Inc 29**: `git revert` + next platform apply (baseline auto-applies on merge; platform is workload-gated, so the revert lands on next cold apply). Rollback time = seconds of Git + minutes of next apply.
- **Inc 30**: `git revert` + merge. Teardown workflow re-reads from main on each dispatch. Rollback time = single merge. If the new stricter sweep becomes stuck (edge case: AWS deleting ENI takes >5m), the prior sweep's `|| true` behavior is restored by revert.

### 2.5 2 AM readability
- Inc 29: new comment above the `controller.resources` block explicitly references Incident 29 and names the root cause (cold-start reconcile peak).
- Inc 30: rewritten step comment explains order (ENIs first), why (DependencyViolation), and the fail-loudly rationale (Incident 30). Inline `::error::` lines print the AWS error text for diagnosis.

## Test plan

- [ ] CI: terraform-plan matrix green on both length-1 + length-2 variants
- [ ] CI: Checkov green (no new resources, just value bumps)
- [ ] Next Session cold apply: `argocd-application-controller-0` reaches Running 1/1 on primary without restarts within 5 minutes
- [ ] Next Session teardown: sweep step emits `::notice::Deleting orphan ENI ...` before SG deletions; `terraform destroy` on network layer completes without DependencyViolation on subnet
- [ ] Negative test (manual, optional): introduce a pre-existing available ENI in the VPC → teardown step should `::error::` and exit 1 instead of silently proceeding

## Related

- docs/incidents.md Incidents 29 + 30
- Follow-up PR #2 will fix Incident 26 (Kyverno cold-apply race) by migrating Kyverno to `helm_release` in the platform layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)