### PR TITLE
fix(incident-26): migrate Kyverno to helm_release in platform layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ aegis-aws-landing-zone/
 │       ├── staging/
 │       │   ├── bootstrap/         # Alias, OIDC, ECR, aegis-core CI roles
 │       │   ├── network/           # VPC, subnets, NAT, Flow Logs
-│       │   ├── platform/          # EKS, Karpenter, LBC, ArgoCD
-│       │   └── workloads/         # Namespace, IRSA, NetworkPolicy, observability, Kyverno
+│       │   ├── platform/          # EKS, Karpenter, LBC, ArgoCD, Kyverno
+│       │   └── workloads/         # Namespace, IRSA, NetworkPolicy, observability, GuardDuty
 │       └── prod/bootstrap/        # Alias only
 ├── scripts/
 │   ├── configure-backends.sh      # Sync backend.tf from config

--- a/docs/decisions/016-admission-control.md
+++ b/docs/decisions/016-admission-control.md
@@ -1,7 +1,7 @@
 # 016. Admission Control: Kyverno
 
 ## Status
-Accepted
+Accepted (**amended 2026-04-20**: §Consequences gained a "Layer placement and install path" subsection after Incident 26 — Kyverno moves from `staging/workloads/` as an ArgoCD Application to `staging/platform/` as a `helm_release`. Tool selection is unchanged; only deployment layer + install path changed.)
 
 ## Context
 
@@ -21,7 +21,7 @@ Two mature projects dominate the Kubernetes admission control space:
 
 ## Decision
 
-**Kyverno**, deployed as an ArgoCD Application.
+**Kyverno**, deployed via `helm_release` in the platform layer. (An earlier version of this ADR deployed Kyverno as an ArgoCD Application in the workloads layer; amended 2026-04-20 — see §Consequences "Layer placement and install path.")
 
 ### Rationale
 
@@ -59,3 +59,17 @@ Kyverno's webhook intercepts every pod creation in the cluster. If Kyverno's pod
 Kyverno policies are `ClusterPolicy` CRDs (cluster-scoped, not namespace-scoped). Deleting the Kyverno ArgoCD Application cascades to all policies. This is intentional — teardown should be clean.
 
 The `audit` enforcement mode means violations are logged in the Kyverno policy report but pods are not rejected. This is appropriate for initial rollout to avoid breaking existing platform pods (Karpenter, ArgoCD, LBC). After verifying no false positives, switching to `enforce` mode is a one-line change per policy (`validationFailureAction: Enforce`).
+
+### Layer placement and install path (added 2026-04-20 after Incident 26)
+
+Kyverno runs in the `staging/platform/` layer (alongside Karpenter, AWS Load Balancer Controller, and ArgoCD itself), not in `staging/workloads/`. The install path is `helm_release` with `wait = true` (chart default), not an ArgoCD `Application` CRD created via `kubectl_manifest`.
+
+**Reason 1 — failure-mode surface**: admission control is cluster-level infrastructure. If the Kyverno webhook is down or misbehaving, pod admission across the entire cluster is affected. This is the same surface as LBC (if down, no new Ingresses) and Karpenter (if down, no new nodes) — both of which the project already scopes to the platform layer. Observability (kube-prometheus-stack, in the workloads layer) degrades visibility but leaves the cluster running; admission does not.
+
+**Reason 2 — synchronous CRD handoff**: the four `ClusterPolicy` resources above are Terraform-managed (`kubectl_manifest`), and they require the Kyverno CRD (`ClusterPolicy`) to exist in the cluster at apply time. `helm_release` with `wait = true` blocks Terraform until the chart reports Ready, at which point the CRDs are guaranteed present. An ArgoCD Application wrapped in `kubectl_manifest` only guarantees the Application object exists in etcd; chart sync is asynchronous and the CRD can still be absent for 1–3 minutes. That race caused Incident 26 on the first cold apply of the workloads layer after clean teardown.
+
+**What this does NOT change**: tool selection (Kyverno vs Gatekeeper) is unchanged; all four baseline policies are unchanged; `audit` → `enforce` rollout path is unchanged; teardown semantics are unchanged (deleting the Helm release cascades to all policies, same as deleting the ArgoCD Application did).
+
+**What this DOES change**: lifecycle visibility in the ArgoCD UI is lost for Kyverno itself — an operator must now look at `helm_release.kyverno` state / `kubectl -n kyverno get pods` rather than an ArgoCD Application tile. The platform layer's other components (Karpenter, LBC, ArgoCD) share the same tradeoff and it has not caused friction in practice. The ClusterPolicies remain Terraform-managed, so their state is visible via `terraform state list | grep kyverno`.
+
+**Relation to ADR-015**: ADR-015's "Operator Apps via ArgoCD" pattern covers observability (kube-prometheus-stack), where the discovery contract for workload-authored CRDs (ServiceMonitor, PrometheusRule) is the load-bearing reason for ArgoCD-managed lifecycle. Kyverno's policies are platform-authored, not workload-authored — there is no equivalent discovery contract, and the tradeoff tips the other way.

--- a/terraform/environments/staging/platform/modules/eks-cluster/kyverno-helm.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/kyverno-helm.tf
@@ -1,0 +1,73 @@
+# -----------------------------------------------------------------------------
+# Kyverno admission controller — Helm install (per-cluster) — ADR-016
+# -----------------------------------------------------------------------------
+# Kyverno lives in the platform layer (alongside Karpenter / LB Controller /
+# ArgoCD), not the workloads layer: admission control is cluster-level infra
+# — if Kyverno's webhook is down, pod admission behaviour changes across the
+# whole cluster, comparable to LBC/Karpenter failure modes, and unlike
+# observability (which degrades visibility but leaves the cluster running).
+#
+# Install path is helm_release (not an ArgoCD Application) because the
+# ClusterPolicy CRDs this chart ships must exist synchronously before the
+# platform-authored kubectl_manifest.policy_* resources in kyverno-policies.tf
+# can apply. helm_release with wait=true (default) blocks Terraform until the
+# release reports Ready, guaranteeing CRD availability; an ArgoCD Application
+# wrapped in kubectl_manifest only guarantees the Application object exists in
+# etcd, leaving chart sync async → Incident 26 (cold-apply race).
+#
+# Failure mode: failOpen (chart default) — if Kyverno is down, pods are
+# admitted without policy checks. Acceptable for a lab; production would use
+# failurePolicy: Fail.
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "kyverno" {
+  provider = helm.this
+
+  name             = "kyverno"
+  namespace        = "kyverno"
+  create_namespace = true
+  repository       = "https://kyverno.github.io/kyverno"
+  chart            = "kyverno"
+  version          = "3.4.1"
+
+  values = [
+    yamlencode({
+      admissionController = {
+        replicas = 1
+        resources = {
+          requests = { cpu = "100m", memory = "200Mi" }
+          limits   = { memory = "384Mi" }
+        }
+      }
+
+      backgroundController = {
+        resources = {
+          requests = { cpu = "50m", memory = "64Mi" }
+          limits   = { memory = "128Mi" }
+        }
+      }
+
+      cleanupController = {
+        resources = {
+          requests = { cpu = "50m", memory = "64Mi" }
+          limits   = { memory = "128Mi" }
+        }
+      }
+
+      reportsController = {
+        resources = {
+          requests = { cpu = "50m", memory = "64Mi" }
+          limits   = { memory = "128Mi" }
+        }
+      }
+    }),
+  ]
+
+  depends_on = [
+    aws_eks_cluster.main,
+    helm_release.karpenter,
+    # Cluster-admin via group — needed for CRD delete at teardown.
+    # See Incident 18 + 21.
+    kubectl_manifest.aegis_cluster_admin_binding,
+  ]
+}

--- a/terraform/environments/staging/platform/modules/eks-cluster/kyverno-policies.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/kyverno-policies.tf
@@ -1,105 +1,18 @@
 # -----------------------------------------------------------------------------
-# Kyverno admission controller — ADR-016
+# Baseline Kyverno ClusterPolicies — ADR-016
 # -----------------------------------------------------------------------------
-# Deployed as an ArgoCD Application (same pattern as kube-prometheus-stack
-# in observability.tf). ArgoCD manages the Helm release; Terraform manages
-# the Application CRD and the ClusterPolicy resources.
+# All policies start in `Audit` mode: violations are logged in Kyverno policy
+# reports but pods are NOT rejected. Switch to `Enforce` after verifying no
+# false positives against platform pods (Karpenter, ArgoCD, LBC, CoreDNS).
 #
-# Kyverno intercepts every pod creation via a mutating/validating webhook.
-# Failure mode: failOpen (default) — if Kyverno is down, pods are admitted
-# without policy checks. Acceptable for a lab; production would use failClose.
+# These are platform-authored policies (per ADR-016 §Policies deployed in
+# Phase 4c), co-located with the Kyverno Helm install so the CRD → policy
+# relationship is obvious and the cross-layer handoff is eliminated.
 #
-# Cost: ~100m CPU, ~200Mi memory on a Karpenter Spot node. Negligible.
-# -----------------------------------------------------------------------------
-
-resource "kubectl_manifest" "kyverno" {
-  provider = kubectl.this
-
-  yaml_body = yamlencode({
-    apiVersion = "argoproj.io/v1alpha1"
-    kind       = "Application"
-    metadata = {
-      name      = "kyverno"
-      namespace = "argocd"
-      finalizers = [
-        "resources-finalizer.argocd.argoproj.io",
-      ]
-    }
-    spec = {
-      project = "default"
-
-      source = {
-        repoURL        = "https://kyverno.github.io/kyverno"
-        targetRevision = "3.4.1"
-        chart          = "kyverno"
-
-        helm = {
-          releaseName = "kyverno"
-          values = yamlencode({
-            admissionController = {
-              replicas = 1
-              resources = {
-                requests = { cpu = "100m", memory = "200Mi" }
-                limits   = { memory = "384Mi" }
-              }
-            }
-
-            backgroundController = {
-              resources = {
-                requests = { cpu = "50m", memory = "64Mi" }
-                limits   = { memory = "128Mi" }
-              }
-            }
-
-            cleanupController = {
-              resources = {
-                requests = { cpu = "50m", memory = "64Mi" }
-                limits   = { memory = "128Mi" }
-              }
-            }
-
-            reportsController = {
-              resources = {
-                requests = { cpu = "50m", memory = "64Mi" }
-                limits   = { memory = "128Mi" }
-              }
-            }
-          })
-        }
-      }
-
-      destination = {
-        server    = "https://kubernetes.default.svc"
-        namespace = "kyverno"
-      }
-
-      syncPolicy = {
-        automated = {
-          prune    = true
-          selfHeal = true
-        }
-        syncOptions = [
-          "CreateNamespace=true",
-          "ServerSideApply=true",
-        ]
-      }
-    }
-  })
-
-  depends_on = [kubernetes_namespace_v1.aegis]
-}
-
-# -----------------------------------------------------------------------------
-# Baseline ClusterPolicies — ADR-016
-# -----------------------------------------------------------------------------
-# All policies start in `Audit` mode: violations are logged in Kyverno
-# policy reports but pods are NOT rejected. Switch to `Enforce` after
-# verifying no false positives against platform pods.
-#
-# These are kubectl_manifest (not kubernetes_manifest) because Kyverno's
-# ClusterPolicy CRD only exists after the Kyverno Helm chart is installed.
-# The kubectl provider's deferred schema validation handles this bootstrap
-# ordering — same pattern as Karpenter NodePool in staging/platform.
+# kubectl_manifest (not kubernetes_manifest) because the ClusterPolicy CRD
+# only exists after the Kyverno Helm chart is installed; the kubectl provider
+# defers schema validation to apply-time, which pairs cleanly with helm_release
+# completing synchronously before these resources plan.
 # -----------------------------------------------------------------------------
 
 resource "kubectl_manifest" "policy_deny_privileged" {
@@ -145,7 +58,7 @@ resource "kubectl_manifest" "policy_deny_privileged" {
     }
   })
 
-  depends_on = [kubectl_manifest.kyverno]
+  depends_on = [helm_release.kyverno]
 }
 
 resource "kubectl_manifest" "policy_deny_host_namespaces" {
@@ -189,7 +102,7 @@ resource "kubectl_manifest" "policy_deny_host_namespaces" {
     }
   })
 
-  depends_on = [kubectl_manifest.kyverno]
+  depends_on = [helm_release.kyverno]
 }
 
 resource "kubectl_manifest" "policy_require_limits" {
@@ -237,7 +150,7 @@ resource "kubectl_manifest" "policy_require_limits" {
     }
   })
 
-  depends_on = [kubectl_manifest.kyverno]
+  depends_on = [helm_release.kyverno]
 }
 
 resource "kubectl_manifest" "policy_require_labels" {
@@ -281,5 +194,5 @@ resource "kubectl_manifest" "policy_require_labels" {
     }
   })
 
-  depends_on = [kubectl_manifest.kyverno]
+  depends_on = [helm_release.kyverno]
 }

--- a/terraform/environments/staging/workloads/main.tf
+++ b/terraform/environments/staging/workloads/main.tf
@@ -5,7 +5,8 @@
 # module.workloads_primary; length-2 also instantiates module.workloads_slave_1.
 # Each instance gets its own provider quad (aws / kubernetes / kubectl)
 # bound to that slot's region + cluster, and its own GuardDuty detector,
-# IRSA role, namespace, NetworkPolicies, Kyverno App, observability App.
+# IRSA role, namespace, NetworkPolicies, observability App. (Kyverno lives
+# in the platform layer per ADR-016 — see Incident 26 for why.)
 # -----------------------------------------------------------------------------
 
 module "workloads_primary" {


### PR DESCRIPTION
## Summary

- Fixes **Incident 26** (Kyverno `ClusterPolicy` CRD race on cold apply of the workloads layer) by moving Kyverno from `staging/workloads/` (ArgoCD Application) to `staging/platform/` (`helm_release`).
- Kept tool selection (Kyverno vs Gatekeeper), all 4 baseline policies, and `audit` mode unchanged. Only the layer + install path changed.
- Amends ADR-016 with a new §Consequences "Layer placement and install path" subsection documenting the move, reasons, and what DOES / does NOT change.

**Why `helm_release` and not `time_sleep`**: the incident's Prevention §2 lists `time_sleep 180s` as a fragile stopgap. `helm_release wait=true` is synchronous by construction and eliminates the race class entirely.

**Why `platform/` and not keep in `workloads/`**: admission control is cluster-level infra (same blast-radius class as Karpenter / LBC). Placing it in `platform/` also makes `helm_release` the natural install path (matches the layer's existing pattern) instead of being a lone exception inside `workloads/`.

## Change-review-discipline.md checklist

### 2.1 Blast radius
- Platform layer apply (next cold apply): adds `helm_release.kyverno` + 4 `kubectl_manifest.policy_*` per cluster slot (primary + slave_1 in length-2).
- Workloads layer apply (next cold apply): removes 5 `kubectl_manifest` resources (the Application + 4 Policies).
- Runtime blast: Kyverno webhook still `failOpen` (chart default). If Kyverno is misbehaving, pod admission proceeds without policy checks — same behavior as before the move.

### 2.2 Dependency assumptions
- `helm_release.kyverno depends_on = [aws_eks_cluster.main, helm_release.karpenter, kubectl_manifest.aegis_cluster_admin_binding]` — mirrors LBC's deps. Karpenter provides nodes; cluster-admin binding is needed for CRD cleanup at teardown (Incidents 18 + 21).
- `kubectl_manifest.policy_* depends_on = [helm_release.kyverno]` — helm_release.wait=true (chart default) guarantees CRDs present when this plans.

### 2.3 Deprecation status
- Kyverno Helm chart `3.4.1` — unchanged from prior install. Tracked in `docs/principles/change-review-discipline.md` §4 version table.
- `helm_release` resource + `kubectl_manifest` resource — stable schemas on current provider pins.
- No Terraform provider bump, no Kubernetes API bump, no GitHub Actions bump.

### 2.4 Rollback plan
- `git revert` + next platform + workloads cold apply.
- State impact: next cold apply after revert would re-create Kyverno as an ArgoCD Application in workloads/, restoring the Incident 26 race. Acceptable only as temporary rollback while root-cause of any new-incident is investigated.
- No current state entry exists for Kyverno anywhere (Session C teardown was clean), so no `terraform state mv` pollution to undo.

### 2.5 2 AM readability
- `platform/modules/eks-cluster/kyverno-helm.tf` header block (~20 lines) explains: why platform and not workloads; why helm_release and not ArgoCD Application; explicit reference to Incident 26.
- `platform/modules/eks-cluster/kyverno-policies.tf` header block explains: why co-located with the chart; why `kubectl_manifest` (deferred schema validation) pairs cleanly with helm_release.
- ADR-016 §Consequences "Layer placement and install path" has the full reasoning for anyone who starts at the ADR.

## Test plan

- [ ] CI: terraform-plan matrix green on length-1 + length-2 variants (staging/platform should show +5 resources per slot; staging/workloads should show -5 resources per slot)
- [ ] CI: Checkov green (no new IAM; Helm release is stdlib)
- [ ] Next Session cold apply: platform layer `gh workflow run terraform-apply-workload.yml -f env=staging` completes without the Inc 26 ClusterPolicy-not-valid-for-cluster error
- [ ] Next Session cold apply: `kubectl -n kyverno get pods` shows all Kyverno pods Running; `kubectl get clusterpolicy` shows 4 baseline policies in Audit mode
- [ ] Next Session teardown: `terraform destroy` on platform layer removes Kyverno pods cleanly (cluster-admin binding already guards against CRD delete hangs per Incident 18)

## Related

- docs/incidents.md Incident 26
- ADR-016 Admission Control (amended in this PR)
- Sibling PR #106 — Incidents 29 (ArgoCD OOM) + 30 (teardown sweep) fixes
- Memory index entry for ADR-016 layer decision will persist across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)