### PR TITLE
feat(edge): ACM cert for aegis-api.staging.binhsu.org (ldz #101)

### DIFF
--- a/terraform/environments/staging/edge/acm-api.tf
+++ b/terraform/environments/staging/edge/acm-api.tf
@@ -1,0 +1,75 @@
+# -----------------------------------------------------------------------------
+# ACM certificate — TLS for aegis-api.staging.binhsu.org (gateway ALB)
+# -----------------------------------------------------------------------------
+# Unlike the frontend cert (us-east-1, CloudFront-bound), this cert lives in
+# the primary region because its consumer is an ALB provisioned by
+# aws-load-balancer-controller from aegis-core's gateway Ingress — ALBs
+# require a regional ACM cert.
+#
+# Validation: DNS-based via the delegated Route53 zone (aws_route53_zone.staging
+# in route53.tf — managed by this layer). No cross-region dance needed since
+# both cert and zone are reachable from the default provider.
+#
+# Cross-repo contract: ldz #101 (ACM + Route53 request from aegis-core).
+# aegis-core's gateway Ingress references output.api_acm_certificate_arn
+# via the `alb.ingress.kubernetes.io/certificate-arn` annotation.
+#
+# Route53 ALIAS record for the hostname itself is NOT created here — the ALB
+# DNS name does not exist at this layer's apply time (LBC creates the ALB
+# only after aegis-core's Ingress syncs, which happens post-apply). Record
+# creation is documented as a manual one-shot in the PR description and in
+# cross-repo #101, or alternatively covered by external-dns (not installed
+# as of this PR). See the outputs.tf `api_route53_creation_hint` output for
+# the exact command.
+# -----------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "api" {
+  domain_name               = local.api_hostname
+  subject_alternative_names = [] # single-SAN for now
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "${local.api_hostname}-acm"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# DNS validation records — in the delegated Route53 zone
+# -----------------------------------------------------------------------------
+
+resource "aws_route53_record" "api_acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.api.domain_validation_options :
+    dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id         = aws_route53_zone.staging.zone_id
+  name            = each.value.name
+  type            = each.value.type
+  records         = [each.value.record]
+  ttl             = 60
+  allow_overwrite = true
+}
+
+# -----------------------------------------------------------------------------
+# Cert validation — blocks downstream consumers (aegis-core Ingress) until
+# ACM reports ISSUED. Without this, the ALB would provision with a cert that
+# is still PENDING_VALIDATION and terminate TLS incorrectly.
+# -----------------------------------------------------------------------------
+
+resource "aws_acm_certificate_validation" "api" {
+  certificate_arn         = aws_acm_certificate.api.arn
+  validation_record_fqdns = [for r in aws_route53_record.api_acm_validation : r.fqdn]
+
+  timeouts {
+    create = "10m"
+  }
+}

--- a/terraform/environments/staging/edge/config.tf
+++ b/terraform/environments/staging/edge/config.tf
@@ -23,6 +23,12 @@ locals {
   # TLS cert + CloudFront distribution + Route53 record all reference this.
   frontend_hostname = "aegis-app.staging.${local.config.domain.name}"
 
+  # Hostname for the Aegis gateway API (per cross-repo #101 contract).
+  # TLS cert lives in the regional ACM (eu-central-1), not us-east-1 —
+  # the consumer is an ALB provisioned by aws-load-balancer-controller
+  # from aegis-core's Ingress, and ALB requires a regional ACM cert.
+  api_hostname = "aegis-api.staging.${local.config.domain.name}"
+
   # Delegated zone — Route53 controls this subdomain; parent `binhsu.org` zone
   # is unrelated (likely on Cloudflare per docs/runbooks/004-dns-delegation-
   # cloudflare-to-route53.md).

--- a/terraform/environments/staging/edge/outputs.tf
+++ b/terraform/environments/staging/edge/outputs.tf
@@ -93,7 +93,7 @@ output "api_route53_creation_hint" {
   description = "Copy-pasteable shell commands to create the aegis-api ALIAS record post-ArgoCD-sync. The ALB does not exist at edge-layer apply time; the record is a manual one-shot (or future: external-dns). Retrieve via `terraform output -raw api_route53_creation_hint`."
   value       = <<-EOT
     # Run after aws-load-balancer-controller has provisioned the ALB from
-    # aegis-core's gateway Ingress (visible via `kubectl -n aegis get ingress`).
+    # aegis-core's gateway Ingress (kubectl -n aegis get ingress).
     ALB_DNS=$(kubectl -n aegis get ingress aegis-gateway \
       -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
     ALB_ZONE=$(aws elbv2 describe-load-balancers \

--- a/terraform/environments/staging/edge/outputs.tf
+++ b/terraform/environments/staging/edge/outputs.tf
@@ -90,20 +90,17 @@ output "api_acm_certificate_arn" {
 }
 
 output "api_route53_creation_hint" {
-  description = <<-EOT
-    Commands to create the ALIAS record for $api_hostname after ArgoCD has
-    synced aegis-core's gateway Ingress and aws-load-balancer-controller has
-    provisioned the ALB. The ALB does not exist at this layer's apply time,
-    so the record is a manual one-shot (or future: handled by external-dns).
-
-      ALB_DNS=$(kubectl -n aegis get ingress aegis-gateway \
-        -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-      ALB_ZONE=$(aws elbv2 describe-load-balancers \
-        --query "LoadBalancers[?DNSName=='$ALB_DNS'].CanonicalHostedZoneId | [0]" \
-        --output text)
-      aws route53 change-resource-record-sets \
-        --hosted-zone-id ${aws_route53_zone.staging.zone_id} \
-        --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"${local.api_hostname}\",\"Type\":\"A\",\"AliasTarget\":{\"HostedZoneId\":\"$ALB_ZONE\",\"DNSName\":\"$ALB_DNS\",\"EvaluateTargetHealth\":false}}}]}"
+  description = "Copy-pasteable shell commands to create the aegis-api ALIAS record post-ArgoCD-sync. The ALB does not exist at edge-layer apply time; the record is a manual one-shot (or future: external-dns). Retrieve via `terraform output -raw api_route53_creation_hint`."
+  value       = <<-EOT
+    # Run after aws-load-balancer-controller has provisioned the ALB from
+    # aegis-core's gateway Ingress (visible via `kubectl -n aegis get ingress`).
+    ALB_DNS=$(kubectl -n aegis get ingress aegis-gateway \
+      -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    ALB_ZONE=$(aws elbv2 describe-load-balancers \
+      --query "LoadBalancers[?DNSName=='$ALB_DNS'].CanonicalHostedZoneId | [0]" \
+      --output text)
+    aws route53 change-resource-record-sets \
+      --hosted-zone-id ${aws_route53_zone.staging.zone_id} \
+      --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"${local.api_hostname}\",\"Type\":\"A\",\"AliasTarget\":{\"HostedZoneId\":\"$ALB_ZONE\",\"DNSName\":\"$ALB_DNS\",\"EvaluateTargetHealth\":false}}}]}"
   EOT
-  value       = local.api_hostname
 }

--- a/terraform/environments/staging/edge/outputs.tf
+++ b/terraform/environments/staging/edge/outputs.tf
@@ -74,3 +74,36 @@ output "acm_certificate_arn" {
   description = "ACM certificate ARN in us-east-1 for the frontend hostname."
   value       = aws_acm_certificate.frontend.arn
 }
+
+# -----------------------------------------------------------------------------
+# API (gateway ALB) — cross-repo #101
+# -----------------------------------------------------------------------------
+
+output "api_hostname" {
+  description = "Gateway ALB hostname (aegis-api.staging.<domain>). aegis-core gateway Ingress references this in the `alb.ingress.kubernetes.io/host` / rules[].host field."
+  value       = local.api_hostname
+}
+
+output "api_acm_certificate_arn" {
+  description = "ACM certificate ARN in the primary region for the gateway ALB hostname. aegis-core gateway Ingress consumes this in the `alb.ingress.kubernetes.io/certificate-arn` annotation."
+  value       = aws_acm_certificate_validation.api.certificate_arn
+}
+
+output "api_route53_creation_hint" {
+  description = <<-EOT
+    Commands to create the ALIAS record for $api_hostname after ArgoCD has
+    synced aegis-core's gateway Ingress and aws-load-balancer-controller has
+    provisioned the ALB. The ALB does not exist at this layer's apply time,
+    so the record is a manual one-shot (or future: handled by external-dns).
+
+      ALB_DNS=$(kubectl -n aegis get ingress aegis-gateway \
+        -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+      ALB_ZONE=$(aws elbv2 describe-load-balancers \
+        --query "LoadBalancers[?DNSName=='$ALB_DNS'].CanonicalHostedZoneId | [0]" \
+        --output text)
+      aws route53 change-resource-record-sets \
+        --hosted-zone-id ${aws_route53_zone.staging.zone_id} \
+        --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"${local.api_hostname}\",\"Type\":\"A\",\"AliasTarget\":{\"HostedZoneId\":\"$ALB_ZONE\",\"DNSName\":\"$ALB_DNS\",\"EvaluateTargetHealth\":false}}}]}"
+  EOT
+  value       = local.api_hostname
+}


### PR DESCRIPTION
## Summary

Closes the ACM half of cross-repo [#101](https://github.com/BinHsu/aegis-aws-landing-zone/issues/101).

- Adds a regional (eu-central-1) ACM certificate for `aegis-api.staging.binhsu.org`
- DNS-validated against the existing delegated Route53 zone (`staging.binhsu.org`)
- `aws_acm_certificate_validation` blocks downstream until ACM reports ISSUED
- Exposes two new outputs for aegis-core: `api_acm_certificate_arn` and `api_hostname`

## Why regional (not us-east-1)

The frontend cert in `acm.tf` is us-east-1 because CloudFront requires its cert there. The API cert's consumer is an ALB provisioned by `aws-load-balancer-controller` from aegis-core's gateway Ingress — ALB requires a **regional** ACM cert (same region as the load balancer). Primary region (`eu-central-1`) is the correct home.

## Why no Route53 ALIAS record

The ALB does not exist at this layer's apply time. LBC provisions it post-apply, only after ArgoCD syncs aegis-core's Ingress. Two paths to close the gap:

1. **Manual one-shot** (this PR): after first successful ArgoCD sync, the operator runs the command template in `output.api_route53_creation_hint`. Exactly the path cross-repo #101 acknowledges (`record creation can either be manual (one-shot after first sync) or automated via external-dns`).
2. **external-dns** (future): installing external-dns as an ArgoCD Application lets the controller watch aegis-core's Ingress annotations and create the record automatically. Out of scope for this PR — flag as follow-up if the manual step becomes friction.

## Change-review-discipline.md checklist

### 2.1 Blast radius
- **staging/edge only** — no cross-account, no cross-layer, no state migration. Adds 3 resources (acm certificate + validation record(s) + validation-wait).
- Runtime: no workload impact. aegis-core will consume the new outputs in its own PR.

### 2.2 Dependency assumptions
- Delegated Route53 zone (`aws_route53_zone.staging`) already exists in this layer — same pattern as frontend cert in `acm.tf`.
- Cross-repo: aegis-core's gateway Ingress references `api_acm_certificate_arn` via annotation — coordinated via #101 / platform-contract #54.

### 2.3 Deprecation status
- `aws_acm_certificate` + `aws_acm_certificate_validation` resources: stable on AWS provider 6.41.0.
- DNS-01 validation: AWS-native, no deprecation.
- No Terraform provider bump.

### 2.4 Rollback plan
- `git revert` + next edge-layer apply. ACM cert destruction is fast; Route53 validation records delete automatically with the cert's lifecycle.
- No state entry anywhere else depends on these outputs yet (aegis-core's PR to consume them hasn't landed).

### 2.5 2 AM readability
- `acm-api.tf` header block explains: why regional (not us-east-1); what the ALB consumer looks like; why the ALIAS record is deferred. Cross-repo issue reference in header.
- Output descriptions are verbose — `api_route53_creation_hint` includes a copy-pasteable command with the exact hosted zone ID templated in.

## Test plan

- [ ] CI: terraform-plan matrix green on length-1 + length-2 (edge layer runs single-region, so no multi-slot variance)
- [ ] CI: Checkov green
- [ ] On next edge-layer apply: `terraform output api_acm_certificate_arn` returns the ISSUED cert ARN
- [ ] On next edge-layer apply: DNS validation CNAME is visible in Route53; cert reaches ISSUED within 5m
- [ ] Post-aegis-core Ingress sync: `dig aegis-api.staging.binhsu.org` resolves the record added via the hint command; `curl -v https://aegis-api.staging.binhsu.org` shows the ALB-terminated cert chain

## Related

- Cross-repo [ldz #101](https://github.com/BinHsu/aegis-aws-landing-zone/issues/101) (this closes the ACM half; Route53 half deferred to manual / external-dns)
- Platform contract [ldz #54](https://github.com/BinHsu/aegis-aws-landing-zone/issues/54)
- Sibling PR (follow-up): ArgoCD Applications for cert-manager + Argo Rollouts (ldz #102 / #103)

🤖 Generated with [Claude Code](https://claude.com/claude-code)