### PR TITLE
feat(phase4c): install cert-manager (platform) + Argo Rollouts (workloads) (ldz #102 #103)

### DIFF
--- a/docs/principles/change-review-discipline.md
+++ b/docs/principles/change-review-discipline.md
@@ -146,7 +146,8 @@ The living inventory of what's deployed and when it expires. Maintained in this 
 | ArgoCD | 7.6.12 (chart) | — | Quarterly review | [ADR-013](../decisions/013-eks-architecture.md) |
 | kube-prometheus-stack | 72.6.2 (chart) | — | Dependabot or manual review | [ADR-015](../decisions/015-observability-tooling.md) |
 | Kyverno | 3.4.1 (chart) | — | Dependabot or manual review | [ADR-016](../decisions/016-admission-control.md) |
-| cert-manager | Not deployed | — | Phase 5 (service mesh + per-pod TLS) | — |
+| cert-manager | v1.16.2 (chart) | — | Dependabot or manual review | aegis-core [ADR-0031](https://github.com/BinHsu/aegis-core/blob/main/docs/adr/0031-mtls-without-service-mesh.md) |
+| Argo Rollouts | 2.37.7 (chart) | — | Dependabot or manual review | aegis-core [ADR-0030](https://github.com/BinHsu/aegis-core/blob/main/docs/adr/0030-progressive-delivery-controller.md) |
 
 ---
 

--- a/terraform/environments/staging/platform/modules/eks-cluster/cert-manager-clusterissuer.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/cert-manager-clusterissuer.tf
@@ -1,0 +1,93 @@
+# -----------------------------------------------------------------------------
+# cert-manager ClusterIssuer bootstrap — aegis-core ADR-0031
+# -----------------------------------------------------------------------------
+# Three-object bootstrap chain for a self-signed CA ClusterIssuer:
+#
+#   1. `selfsigned-bootstrap` (kind: SelfSigned) — signs only our own CA cert
+#   2. `aegis-staging-ca`     (kind: Certificate, isCA: true) — the CA itself,
+#                              signed by #1; stores key + cert in a Secret
+#   3. `aegis-staging-selfsigned-ca` (kind: ClusterIssuer, ca: { secretName })
+#                              — the consumer-facing issuer; aegis-core's
+#                              per-workload Certificates reference this name.
+#
+# Why not a single SelfSigned ClusterIssuer? Because a pure SelfSigned issuer
+# signs each workload cert with its own ephemeral key — every cert is its own
+# trust anchor. A CA-type issuer signs all workload certs with one key,
+# producing a single trust chain that workloads can pin or validate against.
+# That single chain is what mTLS between gateway and engine needs.
+#
+# Cost: zero external dependency, zero AWS cost. Future swap to AWS Private
+# CA is a ClusterIssuer backend change (~$400/mo) — aegis-core ADR-0031
+# §Migration notes the trigger criteria.
+#
+# Naming: `aegis-staging-selfsigned-ca` is the exact name aegis-core's
+# Certificate CRs reference via `issuerRef`. Changing the name breaks the
+# cross-repo contract — do not rename without cross-repo coordination.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "selfsigned_bootstrap_issuer" {
+  provider = kubectl.this
+
+  yaml_body = yamlencode({
+    apiVersion = "cert-manager.io/v1"
+    kind       = "ClusterIssuer"
+    metadata = {
+      name = "selfsigned-bootstrap"
+    }
+    spec = {
+      selfSigned = {}
+    }
+  })
+
+  depends_on = [helm_release.cert_manager]
+}
+
+resource "kubectl_manifest" "aegis_staging_ca_cert" {
+  provider = kubectl.this
+
+  yaml_body = yamlencode({
+    apiVersion = "cert-manager.io/v1"
+    kind       = "Certificate"
+    metadata = {
+      name      = "aegis-staging-ca"
+      namespace = "cert-manager"
+    }
+    spec = {
+      isCA        = true
+      commonName  = "aegis-staging-ca"
+      secretName  = "aegis-staging-ca-keypair"
+      duration    = "87600h" # 10 years — CA cert, lab-tier
+      renewBefore = "720h"   # 30 days
+      privateKey = {
+        algorithm = "ECDSA"
+        size      = 256
+      }
+      issuerRef = {
+        name  = "selfsigned-bootstrap"
+        kind  = "ClusterIssuer"
+        group = "cert-manager.io"
+      }
+    }
+  })
+
+  depends_on = [kubectl_manifest.selfsigned_bootstrap_issuer]
+}
+
+resource "kubectl_manifest" "aegis_staging_ca_issuer" {
+  provider = kubectl.this
+
+  yaml_body = yamlencode({
+    apiVersion = "cert-manager.io/v1"
+    kind       = "ClusterIssuer"
+    metadata = {
+      name = "aegis-staging-selfsigned-ca"
+    }
+    spec = {
+      ca = {
+        secretName = "aegis-staging-ca-keypair"
+      }
+    }
+  })
+
+  depends_on = [kubectl_manifest.aegis_staging_ca_cert]
+}

--- a/terraform/environments/staging/platform/modules/eks-cluster/cert-manager-helm.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/cert-manager-helm.tf
@@ -1,0 +1,72 @@
+# -----------------------------------------------------------------------------
+# cert-manager — Helm install (per-cluster)
+# -----------------------------------------------------------------------------
+# Installed in the platform layer (not workloads) for the same reason as
+# Kyverno: the TF-managed ClusterIssuer in cert-manager-clusterissuer.tf
+# requires synchronous CRD availability (Certificate + ClusterIssuer CRDs),
+# which only helm_release (wait = true) guarantees. See Incident 26 for the
+# precedent.
+#
+# Consumed by aegis-core per ADR-0031 (mTLS without service mesh):
+#   - aegis-core creates Certificate CRs per workload (gateway, engine)
+#   - cert-manager generates K8s Secrets with cert + key + chain
+#   - aegis-core workloads mount the Secrets and reload on rotation
+#
+# ClusterIssuer backend: self-signed CA (bootstrap chain in the sibling file).
+# Path to AWS Private CA is a future ClusterIssuer backend swap, no app-code
+# change — aegis-core ADR-0031 §"Migration" documents the swap.
+#
+# CRDs are installed by the chart (installCRDs=true) rather than by a
+# separate ArgoCD-managed CRD Application, keeping the layer self-contained.
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "cert_manager" {
+  provider = helm.this
+
+  name             = "cert-manager"
+  namespace        = "cert-manager"
+  create_namespace = true
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = "v1.16.2"
+
+  values = [
+    yamlencode({
+      installCRDs = true
+
+      resources = {
+        requests = { cpu = "50m", memory = "64Mi" }
+        limits   = { memory = "128Mi" }
+      }
+
+      webhook = {
+        resources = {
+          requests = { cpu = "25m", memory = "32Mi" }
+          limits   = { memory = "64Mi" }
+        }
+      }
+
+      cainjector = {
+        resources = {
+          requests = { cpu = "25m", memory = "64Mi" }
+          limits   = { memory = "128Mi" }
+        }
+      }
+
+      # Emit Prometheus metrics via the ServiceMonitor CRD. Auto-discovered
+      # by the platform Prometheus (wide-open selectors per ADR-015).
+      prometheus = {
+        enabled = true
+        servicemonitor = {
+          enabled = true
+        }
+      }
+    }),
+  ]
+
+  depends_on = [
+    aws_eks_cluster.main,
+    helm_release.karpenter,
+    kubectl_manifest.aegis_cluster_admin_binding,
+  ]
+}

--- a/terraform/environments/staging/workloads/main.tf
+++ b/terraform/environments/staging/workloads/main.tf
@@ -5,8 +5,9 @@
 # module.workloads_primary; length-2 also instantiates module.workloads_slave_1.
 # Each instance gets its own provider quad (aws / kubernetes / kubectl)
 # bound to that slot's region + cluster, and its own GuardDuty detector,
-# IRSA role, namespace, NetworkPolicies, observability App. (Kyverno lives
-# in the platform layer per ADR-016 — see Incident 26 for why.)
+# IRSA role, namespace, NetworkPolicies, observability App, Argo Rollouts
+# App. (Kyverno + cert-manager live in the platform layer per ADR-016 — see
+# Incident 26 for why.)
 # -----------------------------------------------------------------------------
 
 module "workloads_primary" {

--- a/terraform/environments/staging/workloads/modules/eks-workloads/argo-rollouts.tf
+++ b/terraform/environments/staging/workloads/modules/eks-workloads/argo-rollouts.tf
@@ -1,0 +1,106 @@
+# -----------------------------------------------------------------------------
+# Argo Rollouts controller + ALB traffic-router plugin — aegis-core ADR-0030
+# -----------------------------------------------------------------------------
+# Deployed as an ArgoCD Application (same pattern as kube-prometheus-stack
+# in observability.tf). ArgoCD manages the Helm release lifecycle; Terraform
+# manages the Application CRD itself.
+#
+# Unlike Kyverno (which lives in platform/ as helm_release because downstream
+# TF resources need synchronous CRD availability), Argo Rollouts' CRDs
+# (Rollout, AnalysisTemplate) are consumed by aegis-core ONLY — ldz Terraform
+# creates no Argo Rollouts CRDs. There is no race concern, so the ArgoCD
+# Application pattern is correct for this component.
+#
+# ALB traffic-router plugin: the rollouts-plugin-trafficrouter-alb binary is
+# declared via Helm values `controller.trafficRouterPlugins`; the chart
+# materializes it into a ConfigMap the controller reads at startup. aegis-core
+# C-5a Rollout CRs reference the plugin as `trafficRouting: { plugins: {
+# argoproj-labs/alb: { ... } } }`.
+#
+# Consumed by aegis-core per ADR-0030:
+#   - C-5a: step-based canary (10% → 30% → 60% → 100%)
+#   - C-5b (Phase 4d): SLO-gated canary via AnalysisTemplate
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "argo_rollouts" {
+  provider = kubectl.this
+
+  yaml_body = yamlencode({
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "Application"
+    metadata = {
+      name      = "argo-rollouts"
+      namespace = "argocd"
+      finalizers = [
+        "resources-finalizer.argocd.argoproj.io",
+      ]
+    }
+    spec = {
+      project = "default"
+
+      source = {
+        repoURL        = "https://argoproj.github.io/argo-helm"
+        targetRevision = "2.37.7"
+        chart          = "argo-rollouts"
+
+        helm = {
+          releaseName = "argo-rollouts"
+          values = yamlencode({
+            controller = {
+              resources = {
+                requests = { cpu = "50m", memory = "128Mi" }
+                limits   = { memory = "256Mi" }
+              }
+
+              # ALB traffic-router plugin — chart materializes this as a
+              # ConfigMap the controller reads on startup. Plugin binary is
+              # downloaded at runtime; sha256 pinning is documented in the
+              # upstream plugin repo.
+              trafficRouterPlugins = {
+                trafficRouterPlugins = yamlencode([{
+                  name     = "argoproj-labs/alb"
+                  location = "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-alb/releases/download/v0.4.1/rollout-plugin-alb-linux-amd64"
+                }])
+              }
+
+              # Emit Prometheus metrics via the ServiceMonitor CRD (auto-
+              # discovered by the platform Prometheus per ADR-015).
+              metrics = {
+                enabled = true
+                serviceMonitor = {
+                  enabled = true
+                }
+              }
+            }
+
+            dashboard = {
+              enabled = true
+              resources = {
+                requests = { cpu = "25m", memory = "64Mi" }
+                limits   = { memory = "128Mi" }
+              }
+            }
+          })
+        }
+      }
+
+      destination = {
+        server    = "https://kubernetes.default.svc"
+        namespace = "argo-rollouts"
+      }
+
+      syncPolicy = {
+        automated = {
+          prune    = true
+          selfHeal = true
+        }
+        syncOptions = [
+          "CreateNamespace=true",
+          "ServerSideApply=true",
+        ]
+      }
+    }
+  })
+
+  depends_on = [kubernetes_namespace_v1.aegis]
+}


### PR DESCRIPTION
## Summary

Closes cross-repo [#102](https://github.com/BinHsu/aegis-aws-landing-zone/issues/102) and [#103](https://github.com/BinHsu/aegis-aws-landing-zone/issues/103). Installs two Phase 4c prerequisites consumed by aegis-core:

- **cert-manager** — per-workload mTLS certificates (aegis-core [ADR-0031](https://github.com/BinHsu/aegis-core/blob/main/docs/adr/0031-mtls-without-service-mesh.md))
- **Argo Rollouts + ALB traffic-router plugin** — progressive delivery for aegis-core's canary deployments (aegis-core [ADR-0030](https://github.com/BinHsu/aegis-core/blob/main/docs/adr/0030-progressive-delivery-controller.md))

## Placement rationale (split across layers)

Follows the pattern established in PR #107 for Kyverno:

**cert-manager → `staging/platform/` as `helm_release`**
- ldz Terraform creates a 3-object bootstrap chain (`SelfSigned` → CA `Certificate` → CA `ClusterIssuer`) co-located with the chart
- These TF resources require synchronous CRD availability (same race class as Incident 26)
- `helm_release` with `wait = true` is the only install path that guarantees CRDs are present when the kubectl_manifest resources plan

**Argo Rollouts → `staging/workloads/` as ArgoCD Application**
- ldz Terraform creates zero Rollouts CRDs; Rollout authoring is entirely aegis-core's concern
- No race concern → ArgoCD Application pattern is correct
- ALB traffic-router plugin enabled via chart Helm values

This is the "placement follows TF-dependency + failure-mode-surface" principle from ADR-016's §Consequences amendment (PR #107).

## Cross-repo contract

| Resource | Name / ARN | Used by aegis-core as |
|---|---|---|
| ClusterIssuer | `aegis-staging-selfsigned-ca` | `Certificate.issuerRef.name` — **do NOT rename without cross-repo coordination** |
| Trust chain | Secret `cert-manager/aegis-staging-ca-keypair` (CA chain) | pod mounts via cert-manager rotation |
| Plugin | `argoproj-labs/alb` (in rollouts ConfigMap) | `Rollout.spec.strategy.canary.trafficRouting.plugins` |

Path to AWS Private CA is a ClusterIssuer backend swap (aegis-core ADR-0031 §Migration) — no aegis-core code change, only `kind: CA` → `kind: AWSPCAClusterIssuer` + adding the private CA issuer chart.

## Change-review-discipline.md checklist

### 2.1 Blast radius
- `cert-manager` (platform): cluster-level infrastructure. Webhook intercepts Certificate/Issuer CRD ops; if broken, cert issuance for every workload stops. Same blast class as Kyverno / LBC.
- `argo-rollouts` (workloads): controller-only; if broken, rollouts stop progressing but existing pods keep running. Lower blast than cert-manager.

### 2.2 Dependency assumptions
- `helm_release.cert_manager` `depends_on = [aws_eks_cluster.main, helm_release.karpenter, aegis_cluster_admin_binding]` — mirrors Kyverno.
- ClusterIssuer chain: each step `depends_on` the previous (bootstrap SelfSigned → CA Certificate → CA ClusterIssuer). `helm_release.wait=true` guarantees CRDs present.
- `kubectl_manifest.argo_rollouts` `depends_on = [kubernetes_namespace_v1.aegis]` — same as observability.
- ALB traffic-router plugin binary URL hits `github.com/argoproj-labs/...` at controller startup. Egress path: cluster → NAT → internet. No IRSA needed.

### 2.3 Deprecation status
- cert-manager chart `v1.16.2` — current stable (2026 Q1); tracked in change-review-discipline.md §4 version table.
- Argo Rollouts chart `2.37.7` tracks controller `v1.7.2` — latest GA; tracked in §4.
- ALB traffic-router plugin `v0.4.1` — active upstream; future bumps are chart-level (plugin URL lives in chart values).

### 2.4 Rollback plan
- `git revert` + next platform apply (cert-manager removed) + next workloads apply (Argo Rollouts Application removed, ArgoCD prunes the release).
- If reverted while aegis-core has already shipped Certificate / Rollout CRs, those CRs become orphaned (no issuer / controller to reconcile them). aegis-core would need a coordinated revert.
- No persistent state anywhere except the CA secret in `cert-manager` ns, which is cluster-lifecycle-bounded (gone on teardown).

### 2.5 2 AM readability
- `cert-manager-helm.tf` header explains why platform (not workloads) + cross-references Incident 26.
- `cert-manager-clusterissuer.tf` header explains the 3-object bootstrap chain reason (CA-type issuer vs pure SelfSigned; trust chain vs per-cert anchor).
- `argo-rollouts.tf` header contrasts with Kyverno: why ArgoCD Application is correct here (no TF-managed CRDs) vs why helm_release was needed there.
- All three files name the cross-repo ADRs explicitly in comments.

## Test plan

- [ ] CI: terraform-plan matrix green on length-1 + length-2
- [ ] CI: Checkov green (no new IAM; Helm releases are stdlib)
- [ ] Next Session cold apply: platform layer `kubectl -n cert-manager get pods` all Running; `kubectl get clusterissuer` shows `selfsigned-bootstrap` + `aegis-staging-selfsigned-ca` both Ready; `kubectl -n cert-manager get secret aegis-staging-ca-keypair` exists
- [ ] Next Session cold apply: workloads layer ArgoCD shows `argo-rollouts` Application Synced + Healthy; `kubectl -n argo-rollouts get pods` all Running
- [ ] Next Session cold apply: a test `Certificate` CR referencing `aegis-staging-selfsigned-ca` reaches Ready within 30s
- [ ] Next Session cold apply: Prometheus has both cert-manager and argo-rollouts ServiceMonitor targets scraped (visible in Prometheus UI `/targets`)

## Related

- Cross-repo [ldz #102](https://github.com/BinHsu/aegis-aws-landing-zone/issues/102) — cert-manager install
- Cross-repo [ldz #103](https://github.com/BinHsu/aegis-aws-landing-zone/issues/103) — Argo Rollouts install
- Platform contract [ldz #54](https://github.com/BinHsu/aegis-aws-landing-zone/issues/54)
- Sibling PR #107 — Kyverno → platform/helm_release (precedent this PR follows)
- Sibling PR #108 — staging/edge ACM for aegis-api (ldz #101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)