### PR TITLE
feat(fis): DR drill Terraservice — primary EKS node outage simulation (ADR-020)

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -79,6 +79,13 @@ jobs:
           # -----------------------------------------------------------------
           - env: staging/edge
             account_id: "251774439261"
+          # -----------------------------------------------------------------
+          # staging/fis — FIS DR drill Terraservice (ADR-020). Same pattern
+          # as staging/edge: plan-only in CI, apply manually per runbook 005.
+          # FIS templates cost $0 idle; experiments cost < $0.01 each.
+          # -----------------------------------------------------------------
+          - env: staging/fis
+            account_id: "251774439261"
 
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Some Terraservices layers have their own operational contracts — pre-flight ch
   - `docs/runbooks/002-eks-access.md` — EKS operator access (MUST read before any `kubectl`, `aws eks`, or `staging/platform` apply in a session)
   - `docs/runbooks/003-platform-first-verification.md` — end-to-end checklist after `staging/platform` applies; links to Incidents 10–17 for cold-apply gotchas (MUST follow for any fresh apply of the platform layer)
   - `docs/runbooks/004-dns-delegation-cloudflare-to-route53.md` — Cloudflare-side subdomain NS delegation to a Route53 hosted zone; one-time setup + rollback + troubleshooting (MUST read when provisioning `staging/edge/` or any future env's edge Terraservice)
+  - `docs/runbooks/005-fis-dr-drill.md` — FIS DR drill execution (ADR-020); pre-flight checks, experiment start/observe/recover, troubleshooting (MUST read before `aws fis start-experiment` against any env)
 
 - **Rule: When adding a new layer whose operations require their own diagnostic order (e.g., observability, service mesh), add a runbook under `docs/runbooks/` rather than extending this file.** Keeping CLAUDE.md small preserves its discoverability; layer-specific details belong with the layer.
 
@@ -185,7 +186,7 @@ aws-landing-zone-lab/
 │   └── environments/          # Terraservice layers (one state file per directory)
 │       ├── management/{bootstrap,scps}/
 │       ├── shared/{bootstrap,ipam}/   # shared/aft/ committed but not applied (ADR-011)
-│       ├── staging/{bootstrap,network,platform}/   # platform = EKS + Karpenter + ArgoCD
+│       ├── staging/{bootstrap,network,platform,workloads,edge,fis}/   # platform = EKS + Karpenter + ArgoCD + Kyverno + cert-manager; fis = DR drill (ADR-020)
 │       └── prod/bootstrap/    # prod workloads not yet provisioned
 ├── k8s-manifests/             # App-of-apps root (details live in aegis-core repo)
 ├── config/

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Complete improvement index and reliability map: [`docs/improvements/README.md`](
 | [017](docs/decisions/017-workload-namespace-and-rbac-model.md) | Workload namespace and RBAC model |
 | [018](docs/decisions/018-multi-region-eks-design.md) | Multi-region EKS design (list-driven, pilot light default) |
 | [019](docs/decisions/019-frontend-serving-strategy.md) | Frontend serving strategy — S3 + CloudFront, split subdomain |
+| [020](docs/decisions/020-fis-dr-drill.md) | FIS-based DR drill — primary-region EKS node outage simulation |
 
 ## Runbooks
 
@@ -272,8 +273,10 @@ aegis-aws-landing-zone/
 │       ├── staging/
 │       │   ├── bootstrap/         # Alias, OIDC, ECR, aegis-core CI roles
 │       │   ├── network/           # VPC, subnets, NAT, Flow Logs
-│       │   ├── platform/          # EKS, Karpenter, LBC, ArgoCD, Kyverno
-│       │   └── workloads/         # Namespace, IRSA, NetworkPolicy, observability, GuardDuty
+│       │   ├── platform/          # EKS, Karpenter, LBC, ArgoCD, Kyverno, cert-manager
+│       │   ├── workloads/         # Namespace, IRSA, NetworkPolicy, observability, Argo Rollouts, GuardDuty
+│       │   ├── edge/              # CloudFront + S3 (frontend), Route53 delegated zone, ACM
+│       │   └── fis/               # Fault Injection Simulator DR drill (ADR-020)
 │       └── prod/bootstrap/        # Alias only
 ├── scripts/
 │   ├── configure-backends.sh      # Sync backend.tf from config

--- a/docs/decisions/020-fis-dr-drill.md
+++ b/docs/decisions/020-fis-dr-drill.md
@@ -1,0 +1,117 @@
+# 020. Fault Injection Simulator (FIS) for DR drills
+
+## Status
+Accepted
+
+## Context
+
+Phase 4c delivered multi-region EKS (ADR-018, slot pattern) and confirmed the code path works (Session C, 2026-04-20: length-2 apply + both clusters Ready + teardown clean). What remains undemonstrated is the **dynamic failure-mode observation**: what actually happens during a region-scale event? Does observability reflect it? Do the alerts fire? How long does recovery take?
+
+A portfolio project that claims multi-region posture without a live DR drill is asserting a capability it has not exercised. The ISO 27001 Annex A.5.30 (ICT readiness for business continuity) framing the project cites in ADR-005 — change management and continuity controls — is hollow if the continuity path has never been activated.
+
+### Constraints
+
+- **Single operator, lab budget**. Drills must cost pennies, not dollars.
+- **Reversible**. A failed drill must not stuck the cluster or require a teardown-reapply cycle to recover.
+- **Demonstrable**. An interviewer should be able to see the failure happen in Grafana, the alert fire, the recovery observed, all within 10–15 minutes of elapsed time.
+- **Version-controlled**. The project's posture is "every AWS resource is in Terraform." A DR drill tool that lives as a clicked-into-existence Console template would be the project's only exception — politically inconsistent.
+- **Least-privilege IAM**. The drill's service role must not be able to damage anything outside the Karpenter-provisioned node set.
+
+## Decision
+
+**AWS Fault Injection Simulator (FIS)**, with an experiment template that stops primary-region Karpenter-provisioned EKS worker nodes for 10 minutes. Recovery is automatic: FIS's `startInstancesAfterDuration` parameter auto-starts the stopped instances when the experiment ends.
+
+The FIS layer is a new Terraservice at `terraform/environments/staging/fis/`, with four components:
+
+- `aws_fis_experiment_template` — the experiment definition (target selector, action, duration, stop condition)
+- `aws_iam_role "fis"` — service role FIS assumes during execution, with tag-scoped deny-by-default on EC2 actions
+- `aws_cloudwatch_metric_alarm` — stop condition that aborts the experiment if EKS API server enters reconcile-storm territory
+- `terraform output` — copy-pasteable `aws fis start-experiment` command for the operator
+
+### Experiment mechanics
+
+| Axis | Choice |
+|---|---|
+| Target | EC2 instances tagged `karpenter.sh/nodepool=aegis-default`, state=running |
+| Action | `aws:ec2:stop-instances` (not terminate — preserves instance state for auto-restart) |
+| Duration | 10 minutes (via `startInstancesAfterDuration=PT10M`) |
+| Stop condition | CloudWatch alarm on primary EKS API server latency > 2s for 2 minutes |
+| Recovery | Automatic — FIS starts the stopped instances when the duration elapses |
+
+### What the drill demonstrates
+
+- **Observability signal path**: `NodeNotReady` PrometheusRule (added in `staging/workloads/modules/eks-workloads/observability.tf`) fires within 1–2 minutes of node stop, visible in Grafana's Alert panel without Alertmanager.
+- **Recovery path**: Karpenter detects the instances returning, re-onboards them to the node pool, pods reschedule. Full recovery within 2–3 minutes of experiment end.
+- **Governance plumbing**: the stop-condition alarm is the demonstrable mechanism that the drill itself is monitored — if something goes wrong, FIS aborts and restarts the instances.
+
+## Alternatives Considered
+
+### Manual `aws ec2 stop-instances` + stopwatch
+
+Simplest possible DR drill: operator runs the CLI, watches the clock, runs start-instances 10 minutes later. Rejected because (a) no audit trail — the experiment is not recorded anywhere, (b) no automatic recovery if the operator is interrupted, (c) no stop condition, (d) nothing reusable by another operator, (e) the portfolio signal is "I clicked commands," not "I designed a controlled drill."
+
+### Litmus / Chaos Mesh / Chaos Toolkit (in-cluster chaos engineering)
+
+Open-source chaos engineering controllers that inject failures via Kubernetes CRDs. More granular (can kill specific pods, inject network latency, corrupt disk). Rejected for Phase 4c because the failure mode we want to demonstrate is **infrastructure-level**, not pod-level. Stopping a pod with chaos-mesh is pod-scheduler-friendly (Kubernetes reschedules immediately, barely visible). Stopping the node the pod runs on — and removing capacity for *all* pods on that node — is what matches the "region experienced capacity loss" narrative. FIS natively targets AWS infrastructure; chaos-mesh targets in-cluster resources. Different tools for different layers; FIS fits the Phase 4c "infra-level" framing.
+
+Future Phase 5 (service mesh) might bring chaos-mesh in for pod-level traffic-fault injection. Complementary, not duplicative.
+
+### Cross-region stop condition via CloudWatch Metric Streams
+
+The original demo concept watched Region B's load metrics — if Region B was overwhelmed picking up primary's traffic, the experiment would abort to protect Region B. Rejected for Phase 4c because:
+
+- FIS stop-condition alarms must live in the same region as the experiment
+- Cross-region observability requires CloudWatch Metric Streams ($1/month base + Kinesis Data Firehose per-GB costs)
+- ~3 hours of additional Terraform to wire up
+- The demo value of "we have a multi-region stop condition" is marginal over "we have a same-region stop condition with a clearly-designed threshold"
+
+Tracked as a Phase 5 consideration if cross-region observability lands for other reasons (e.g., centralized logging).
+
+### S3 / CloudFront fault (Origin Group failover)
+
+The original concept also included a second parallel action: inject an IAM deny on the role CloudFront uses to read S3, forcing Origin Group failover to a Region B bucket. Rejected because (a) CloudFront OAC doesn't use an IAM role in the standard sense — access is via service principal + bucket policy, so `aws:fis:inject-api-internal-error` targeting an IAM role doesn't apply; (b) the alternative of SSM Automation temporarily modifying the bucket policy is a new scope surface; (c) CloudFront TTL would require manual cache invalidation before the drill for the fault to be visible — an extra operational wrinkle; (d) the primary EKS-node drill alone is sufficient to exercise the observability + alert + recovery story.
+
+Tracked for a future Phase 5 drill once Origin Group is added to `staging/edge/`.
+
+### Terminate vs Stop
+
+`aws:ec2:terminate-instances` is more dramatic (the instance is gone forever), but (a) Karpenter would immediately try to replace the terminated instances, fighting with the failover narrative, and (b) there is no auto-recovery — the experiment cannot start what it terminated. `stop-instances` is the correct semantics: temporarily remove capacity, durable recovery via `startInstancesAfterDuration`.
+
+## Consequences
+
+### Cost
+
+- Experiment template: $0 to exist
+- Per-experiment-action execution: ~$0.0095 per instance-action (negligible)
+- The 10-minute capacity loss is free (stopped EC2 is not billed)
+- CloudWatch alarm: $0.10/month
+- Total: **< $0.15/month always-on + < $0.01 per drill**
+
+### Operational burden
+
+- Pre-drill runbook step: run `aws fis start-experiment` with the template ID
+- Mid-drill observation: Grafana + kubectl (existing tooling)
+- Post-drill: verify all nodes Ready, pods running; `kubectl get pods -A` smoke check
+- Drill cadence: quarterly recommended; ISO 27001 A.5.30 does not mandate a cadence
+
+### Blast radius
+
+The FIS service role is scoped to `karpenter.sh/nodepool`-tagged instances via an inline deny policy (iam.tf). The managed policy `AWSFaultInjectionSimulatorEC2Access` provides the happy-path permissions; the inline policy intersects it with the tag condition. An operator or attacker who assumed this role could not damage non-Karpenter infrastructure (control-plane VPC ENIs, ArgoCD nodes on Fargate, etc.).
+
+### What this does NOT cover
+
+- **Prod drills**. The experiment template lives in the staging account only. A prod-account FIS layer is deferred until prod workloads exist — today prod is empty.
+- **Control-plane failures**. Stopping worker nodes does not exercise EKS control-plane failure modes (master endpoint unreachable, API server down). AWS does not offer FIS actions for control-plane fault injection — that's a managed-service limitation, not a design choice.
+- **Full region outage**. The drill removes worker capacity only. NAT gateway, ALB, Karpenter controller (on Fargate), ArgoCD, observability stack all continue to run. A true region outage would take all of these down simultaneously, and the drill for that class of failure requires manually degrading each layer or using a region-level IAM deny (not a FIS action).
+
+### Portfolio signal
+
+The explicit ADR + runbook + Terraform-defined experiment closes the loop on ADR-018 (multi-region EKS design): the design now has a corresponding *exercise*. An interviewer can read this ADR, see the drill artifact, and either run the drill themselves (if they have access) or read the runbook output that the operator has captured.
+
+## Related
+
+- [ADR-005](005-compliance-framework-iso-27001.md) — ISO 27001 posture; A.5.30 ICT readiness maps to this drill
+- [ADR-015](015-observability-tooling.md) — Prometheus + Grafana; the signal path the drill exercises
+- [ADR-018](018-multi-region-eks-design.md) — multi-region EKS slot pattern; this drill is its dynamic counterpart
+- `docs/runbooks/005-fis-dr-drill.md` — execution runbook (pre-flight, start, observe, post-check)
+- `docs/improvements/008-workload-multi-region.md` — Mode A / Mode B operational modes; the drill applies to both

--- a/docs/runbooks/005-fis-dr-drill.md
+++ b/docs/runbooks/005-fis-dr-drill.md
@@ -1,0 +1,179 @@
+<!-- session-close-review: experiment template ID + stop condition alarm name match current `terraform output` in staging/fis -->
+# Runbook 005 — FIS DR drill (primary EKS node outage)
+
+> **When to read this**: you are about to run the FIS DR drill defined in [ADR-020](../decisions/020-fis-dr-drill.md). Reading in full takes <5 minutes. Skipping pre-flight section is the most common way this drill goes wrong — do not skip.
+
+## Pre-flight (do NOT skip)
+
+### 0. Prerequisite state
+
+| Layer | Required state | How to verify |
+|---|---|---|
+| `staging/network` | applied, VPC + NAT up | `gh workflow run terraform-apply-workload.yml` path |
+| `staging/platform` | applied, EKS cluster Ready | `kubectl --context aegis-staging-primary get nodes` → ≥1 node Ready |
+| `staging/workloads` | applied, observability stack synced | `kubectl -n monitoring get pods` → all Running; kube-prometheus-stack ArgoCD App Synced + Healthy |
+| `staging/fis` | applied, experiment template exists | `terraform -chdir=terraform/environments/staging/fis output experiment_template_id` returns an ID |
+
+If any row fails, the drill cannot produce useful signal. Apply missing layers before continuing.
+
+### 1. Verify observability can see the cluster
+
+```bash
+kubectl --context aegis-staging-primary port-forward -n monitoring svc/kube-prometheus-stack-grafana 3000:80
+```
+
+In a browser, open `http://localhost:3000`. Log in (admin / retrieve password via `terraform -chdir=terraform/environments/staging/workloads output -raw grafana_admin_password_primary`).
+
+Open **Dashboards → Kubernetes / Compute Resources / Cluster**. You should see CPU + memory series for both cluster nodes. If the series are flat at zero, node-exporter has not reached all nodes — fix before drilling. (Incident 27 is the known offender; post-PR #110 fix, this should be clean.)
+
+### 2. Verify the `NodeNotReady` alert rule is loaded
+
+In Grafana: **Alerting → Alert rules**. Filter by label `drill=fis-primary-outage`. You should see one rule: `NodeNotReady`, state = Normal.
+
+If the rule is missing, the `staging/workloads` layer hasn't applied with the dr-drill alert block yet — re-apply before continuing.
+
+### 3. Verify the stop-condition alarm is NOT in ALARM state
+
+```bash
+aws cloudwatch describe-alarms \
+  --alarm-names aegis-staging-fis-abort-eks-api-failures \
+  --region eu-central-1 \
+  --query 'MetricAlarms[0].StateValue'
+```
+
+Expected: `"OK"` (or `"INSUFFICIENT_DATA"` if the cluster was recently applied — wait 3 minutes for metrics to populate). If the state is `"ALARM"` before you start, FIS will abort the experiment the moment it starts.
+
+### 4. Know your recovery signal
+
+During the drill, the operator's only required action is **wait**. Auto-recovery is built in. But know your manual-override path in case something goes wrong:
+
+```bash
+# List stopped instances in primary VPC
+aws ec2 describe-instances \
+  --filters "Name=tag-key,Values=karpenter.sh/nodepool" "Name=instance-state-name,Values=stopped" \
+  --region eu-central-1 \
+  --query 'Reservations[].Instances[].InstanceId' --output text
+
+# If FIS auto-recovery fails, manually start them
+aws ec2 start-instances --instance-ids <ids> --region eu-central-1
+```
+
+## Start the drill
+
+### 1. Start the experiment
+
+```bash
+EXPERIMENT_TEMPLATE_ID=$(terraform -chdir=terraform/environments/staging/fis output -raw experiment_template_id)
+
+aws fis start-experiment \
+  --experiment-template-id "$EXPERIMENT_TEMPLATE_ID" \
+  --region eu-central-1
+```
+
+Note the returned `experiment.id` (opaque string like `EX123ABC`). You'll use it to monitor state.
+
+### 2. Confirm experiment is Running
+
+```bash
+aws fis get-experiment --id <experiment-id> --region eu-central-1 \
+  --query 'experiment.state.status'
+```
+
+Expected progression: `initiating` → `running` (within ~30 seconds). If it goes straight to `stopped` or `failed`, read `experiment.state.reason` — common causes:
+
+- Stop-condition alarm in ALARM state (see pre-flight step 3)
+- IAM role trust policy mismatch (shouldn't happen with this Terraservice; re-apply `staging/fis` if it does)
+- Target-resolution-mode failed (no instances matching tag filter — cluster is empty or tag is wrong; re-apply `staging/platform`)
+
+## During the drill (10 minutes)
+
+### What you should see in Grafana
+
+- **Kubernetes / Compute Resources / Cluster**: CPU + memory series drop toward 0 within 1–2 minutes (nodes stop reporting metrics as kubelet goes offline)
+- **Alerting → Alert rules → NodeNotReady**: transitions Normal → Pending (after ~1 min) → Firing (after 2 min)
+- **Kubernetes / Nodes (Pods)**: pod count per node drops as pods enter Pending
+
+### What you should see in kubectl
+
+```bash
+kubectl --context aegis-staging-primary get nodes
+# within 2-3 min: all nodes → NotReady
+
+kubectl --context aegis-staging-primary get pods -n aegis
+# pods → Pending (ContainerCreating stuck, no nodes to schedule on)
+
+kubectl --context aegis-staging-primary get pods -n kyverno
+kubectl --context aegis-staging-primary get pods -n cert-manager
+# same pattern — everything worker-hosted is stuck
+```
+
+Control-plane-hosted pods (Karpenter, ArgoCD, coredns addon) on Fargate continue running — their nodes are not affected by this drill.
+
+### Demonstrable moments for an interviewer
+
+1. **Pre-drill state**: Grafana green, all pods Running, alerts Normal → show baseline
+2. **T+2min — failure visible**: nodes NotReady, pods Pending, `NodeNotReady` alert Firing
+3. **T+5min — in full failure mode**: all primary-region workload capacity gone
+4. **T+10min — experiment ends automatically**: FIS starts instances, Karpenter re-onboards
+5. **T+12-13min — full recovery**: all pods back to Running, alert resolves
+
+## Post-drill (T+13min onward)
+
+### 1. Verify all nodes Ready
+
+```bash
+kubectl --context aegis-staging-primary get nodes
+```
+
+Expected: all nodes → Ready. If any are still NotReady after 15 minutes:
+
+- Check the instance is actually started: `aws ec2 describe-instances --instance-ids <id> --query 'Reservations[0].Instances[0].State.Name'`
+- Check Karpenter didn't create orphan NodeClaims: `kubectl get nodeclaim -A`
+
+### 2. Verify all pods Running
+
+```bash
+kubectl --context aegis-staging-primary get pods -A | grep -vE "Running|Completed"
+```
+
+Expected: empty output (or the two DaemonSet pods that are known to not schedule on Fargate — node-exporter handled by PR #110, GuardDuty runtime agent is a known gap per Incident 28 / improvements/010).
+
+### 3. Verify alert resolved
+
+```bash
+kubectl --context aegis-staging-primary port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090
+# Browse to http://localhost:9090/alerts → NodeNotReady should be Inactive
+```
+
+### 4. Record the drill
+
+Create a dated entry in the session log (wherever you keep it — not committed to this repo). Record:
+
+- Experiment ID
+- Start time / end time
+- Actual observed T+2/T+5/T+10/T+13 timing vs planned
+- Any deviations from expected behavior
+- Any resources still not recovered (e.g., Incident 28 agents)
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `aws fis start-experiment` returns immediately with `state.status=failed` | Stop-condition alarm in ALARM state OR IAM trust policy bad | Check CloudWatch alarm; re-apply `staging/fis` |
+| Experiment starts but nodes never enter NotReady | Tag filter mismatch — instances don't have `karpenter.sh/nodepool` | Verify via `aws ec2 describe-instances` + tag query |
+| Alert `NodeNotReady` fires but Grafana Alert panel is empty | Grafana alerting data source not wired to Prometheus | Check Grafana **Data Sources** → Prometheus URL |
+| Experiment ends but instances stay stopped | `startInstancesAfterDuration` parameter not honored; AWS occasional issue | Manual `aws ec2 start-instances --instance-ids <ids>` |
+| After recovery, Karpenter does not re-onboard instances | NodeClaim created for replacement but original is returning — duplicate node | `kubectl delete nodeclaim` for the orphan claim; Karpenter will clean up |
+| Stop-condition alarm fires mid-drill unexpectedly | EKS API under genuine stress from concurrent incident | Investigate cluster — this is the alarm working correctly; the drill's auto-abort protected the environment |
+
+## When to NOT run this drill
+
+- **During a production incident** or when the cluster is already in a degraded state. The stop-condition alarm should protect, but don't rely on it.
+- **Before a demo where the drill is the demo**. Do it once in advance to catch any config drift, then run it "fresh" for the audience. A drill running for the first time ever in front of an interviewer is a double-risk event.
+- **Without the `staging/workloads` observability stack applied**. Without Grafana/Prometheus/alert rules, you get a failure with no visible signal — worthless for demo, unhelpful for learning.
+
+## References
+
+- [ADR-020 — FIS for DR drills](../decisions/020-fis-dr-drill.md) — design rationale + alternatives considered
+- [ADR-018 — Multi-region EKS](../decisions/018-multi-region-eks-design.md) — the architecture this drill exercises
+- [Incidents 26–30](../incidents.md) — bugs surfaced by Session C cold apply; the drill is expected to not re-expose these post-fix

--- a/terraform/environments/staging/fis/backend.tf
+++ b/terraform/environments/staging/fis/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "staging/fis/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/terraform/environments/staging/fis/config.tf
+++ b/terraform/environments/staging/fis/config.tf
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------
+# Configuration Contract — ADR-004
+# -----------------------------------------------------------------------------
+
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.staging.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+
+  # Cluster name convention matches staging/platform: "<prefix>-<slot>".
+  # See staging/platform/modules/eks-cluster for the source of truth.
+  primary_cluster_name = "aegis-staging-primary"
+
+  tags = merge(local.config.tags, {
+    Environment = "staging"
+    Component   = "fis"
+  })
+}
+
+data "aws_caller_identity" "current" {}
+
+check "expected_account" {
+  assert {
+    condition     = data.aws_caller_identity.current.account_id == local.account_id
+    error_message = "Running against the wrong AWS account (${data.aws_caller_identity.current.account_id}) — staging/fis must be applied with credentials for ${local.account_id} (aegis-staging)."
+  }
+}

--- a/terraform/environments/staging/fis/experiment.tf
+++ b/terraform/environments/staging/fis/experiment.tf
@@ -1,0 +1,88 @@
+# -----------------------------------------------------------------------------
+# FIS Experiment Template — Primary-region EKS node outage
+# -----------------------------------------------------------------------------
+# Demo experiment: stop all Karpenter-provisioned EC2 instances in the
+# primary region for 10 minutes, then auto-start them. Simulates a regional
+# worker-capacity loss (not a region blackout — the EKS control plane,
+# NAT, ALB, etc. remain alive; this is the "nodes gone" failure mode).
+#
+# What you can observe during the 10-minute window:
+#   - kubectl get nodes → all primary-region nodes → NotReady
+#   - kubectl get pods -n aegis → pods → Pending (no capacity)
+#   - Prometheus alert NodeNotReady fires (staging/workloads observability
+#     layer's PrometheusRule) — visible in Grafana's alert panel
+#   - Grafana "Kubernetes / Nodes" dashboard → CPU/memory series drop to 0
+#   - If ArgoCD has synced aegis-core to both clusters + Route53 failover
+#     is wired, external traffic shifts to slave_1 cluster (Region B)
+#
+# Recovery: FIS auto-starts the stopped instances after duration elapses.
+# Karpenter observes them come back, re-onboards to the node pool, and
+# pods reschedule. Full recovery typically completes within 2–3 minutes
+# of experiment end.
+#
+# Safety: the aws_cloudwatch_metric_alarm.experiment_abort_signal stop
+# condition aborts the experiment if the cluster enters reconcile-storm
+# state, preventing the drill from amplifying an existing incident.
+#
+# Cost: ~$0 for the experiment itself (FIS pricing is per-experiment-
+# action execution, ~$0.0095 per action). The cost of the 10-min outage
+# on the cluster is zero (stopped EC2 is not billed). Net cost: < $0.01.
+# -----------------------------------------------------------------------------
+
+resource "aws_fis_experiment_template" "primary_eks_node_outage" {
+  description = "Stop primary-region Karpenter-provisioned EKS worker nodes for 10 minutes. Simulates a regional worker-capacity loss; observes failover and recovery behavior. ADR-020."
+  role_arn    = aws_iam_role.fis.arn
+
+  target {
+    name           = "karpenter-nodes-primary"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "ALL"
+
+    # Target selector: all EC2 instances carrying the Karpenter NodePool
+    # tag. The IAM scope-down policy (iam.tf) denies action on instances
+    # WITHOUT this tag, so the tag-filter here is defense-in-depth
+    # alignment with the IAM posture.
+    resource_tag {
+      key   = "karpenter.sh/nodepool"
+      value = "aegis-default"
+    }
+
+    filter {
+      path   = "State.Name"
+      values = ["running"]
+    }
+  }
+
+  action {
+    name        = "stop-nodes"
+    action_id   = "aws:ec2:stop-instances"
+    description = "Stop targeted instances for 10 minutes; FIS auto-starts them at duration end."
+
+    target {
+      key   = "Instances"
+      value = "karpenter-nodes-primary"
+    }
+
+    parameter {
+      key   = "startInstancesAfterDuration"
+      value = "PT10M"
+    }
+  }
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.experiment_abort_signal.arn
+  }
+
+  # Experiment options: fail-immediately mode aborts the whole experiment
+  # if the single action fails to start. Cleaner failure semantics for a
+  # one-action experiment than the default fail-on-any mode.
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "fail"
+  }
+
+  tags = {
+    Name = "aegis-staging-primary-eks-node-outage"
+  }
+}

--- a/terraform/environments/staging/fis/iam.tf
+++ b/terraform/environments/staging/fis/iam.tf
@@ -1,0 +1,84 @@
+# -----------------------------------------------------------------------------
+# IAM service role for AWS FIS
+# -----------------------------------------------------------------------------
+# FIS assumes this role when executing an experiment. The role grants only
+# the specific EC2 actions the demo experiment needs (stop-instances on
+# tagged Karpenter nodes) plus the managed AWSFaultInjectionSimulatorEC2Access
+# policy for the experiment lifecycle scaffolding.
+#
+# Least-privilege: no `ec2:*` wildcard. No cross-region. No cross-account.
+# The experiment can only act on EC2 instances that carry the Karpenter
+# NodePool tag — an attacker with this role assumed cannot damage
+# non-Karpenter infrastructure.
+#
+# ISO 27001 Annex A.5.24 (incident management planning) and A.5.30
+# (ICT readiness for business continuity) are satisfied by having the
+# drill runnable on-demand, not by having the role privileged enough to
+# do broader damage.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "fis" {
+  name = "aegis-staging-fis-service"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "fis.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = local.account_id
+        }
+        ArnLike = {
+          "aws:SourceArn" = "arn:aws:fis:${local.primary_region}:${local.account_id}:experiment/*"
+        }
+      }
+    }]
+  })
+
+  tags = {
+    Name = "aegis-staging-fis-service"
+  }
+}
+
+# AWS managed policy: the canonical FIS->EC2 permission bundle. Grants
+# ec2:StopInstances, ec2:StartInstances (for rollback), ec2:DescribeInstances,
+# etc. Managed policies evolve with new FIS action types; attaching the
+# managed one avoids per-release policy churn in this repo.
+resource "aws_iam_role_policy_attachment" "fis_ec2" {
+  role       = aws_iam_role.fis.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSFaultInjectionSimulatorEC2Access"
+}
+
+# Scope-down inline policy: intersect the managed policy's broad ec2:*
+# permissions with a tag-condition that limits the blast radius to
+# Karpenter-provisioned nodes only. Defense in depth — if the managed
+# policy were updated with a too-permissive action, this inline policy
+# still constrains the resource set.
+resource "aws_iam_role_policy" "fis_karpenter_scope" {
+  name = "karpenter-scope-only"
+  role = aws_iam_role.fis.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "DenyEC2ActionsOnNonKarpenterInstances"
+      Effect = "Deny"
+      Action = [
+        "ec2:StopInstances",
+        "ec2:StartInstances",
+        "ec2:TerminateInstances",
+        "ec2:RebootInstances",
+      ]
+      Resource = "arn:aws:ec2:${local.primary_region}:${local.account_id}:instance/*"
+      Condition = {
+        "Null" = {
+          "aws:ResourceTag/karpenter.sh/nodepool" = "true"
+        }
+      }
+    }]
+  })
+}

--- a/terraform/environments/staging/fis/outputs.tf
+++ b/terraform/environments/staging/fis/outputs.tf
@@ -4,8 +4,8 @@ output "experiment_template_id" {
 }
 
 output "experiment_template_arn" {
-  description = "FIS Experiment Template ARN."
-  value       = aws_fis_experiment_template.primary_eks_node_outage.arn
+  description = "FIS Experiment Template ARN. Constructed because the AWS provider's aws_fis_experiment_template resource does not export an arn attribute (only id)."
+  value       = "arn:aws:fis:${local.primary_region}:${local.account_id}:experiment-template/${aws_fis_experiment_template.primary_eks_node_outage.id}"
 }
 
 output "fis_service_role_arn" {

--- a/terraform/environments/staging/fis/outputs.tf
+++ b/terraform/environments/staging/fis/outputs.tf
@@ -1,0 +1,24 @@
+output "experiment_template_id" {
+  description = "FIS Experiment Template ID. Start an experiment via: aws fis start-experiment --experiment-template-id <this-id>."
+  value       = aws_fis_experiment_template.primary_eks_node_outage.id
+}
+
+output "experiment_template_arn" {
+  description = "FIS Experiment Template ARN."
+  value       = aws_fis_experiment_template.primary_eks_node_outage.arn
+}
+
+output "fis_service_role_arn" {
+  description = "IAM role FIS assumes during experiment execution. Scoped to Karpenter-tagged EC2 only — see iam.tf."
+  value       = aws_iam_role.fis.arn
+}
+
+output "stop_condition_alarm_name" {
+  description = "CloudWatch alarm that aborts the experiment if triggered. For drill rehearsal: monitor its state in CloudWatch Console before starting the experiment."
+  value       = aws_cloudwatch_metric_alarm.experiment_abort_signal.alarm_name
+}
+
+output "start_experiment_command" {
+  description = "Copy-pasteable AWS CLI command to start the experiment. Retrieve via: terraform output -raw start_experiment_command."
+  value       = "aws fis start-experiment --experiment-template-id ${aws_fis_experiment_template.primary_eks_node_outage.id} --region ${local.primary_region}"
+}

--- a/terraform/environments/staging/fis/providers.tf
+++ b/terraform/environments/staging/fis/providers.tf
@@ -1,0 +1,21 @@
+# -----------------------------------------------------------------------------
+# Provider — single primary region
+# -----------------------------------------------------------------------------
+# FIS experiments are regional. The demo experiment targets primary-region
+# EKS worker nodes (attacking Region A to validate the Region B failover
+# path). No secondary provider needed: CloudWatch alarms used as stop
+# conditions must live in the SAME region as the experiment template, so
+# the alarm is also primary-region. Cross-region alarms would require
+# metric streams — ADR-020 §Alternatives Considered §"Cross-region stop
+# condition" documents why we accept the single-region simplification.
+# -----------------------------------------------------------------------------
+
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/staging/fis/stop-condition.tf
+++ b/terraform/environments/staging/fis/stop-condition.tf
@@ -1,0 +1,60 @@
+# -----------------------------------------------------------------------------
+# FIS Stop Condition — CloudWatch alarm
+# -----------------------------------------------------------------------------
+# FIS experiments can reference a CloudWatch alarm as a stop condition:
+# if the alarm enters ALARM state during the experiment, FIS aborts and
+# (where supported) reverses the action, restoring the target resources.
+#
+# Design constraint: the alarm MUST live in the same region as the FIS
+# experiment. Cross-region alarms would require CloudWatch Metric Streams
+# (~$1/month + Kinesis + additional Terraform). Deferred — see ADR-020
+# §"Cross-region stop condition" for the full alternatives analysis.
+#
+# What the alarm watches: EKS API server FAILED request count on the
+# primary cluster. A sustained spike during the experiment indicates
+# the cluster's control plane is itself misbehaving (not just nodes
+# gone — that doesn't fail API calls). If control plane API calls
+# start failing during the experiment, something is wrong beyond our
+# intentional failure and aborting is the safe response.
+#
+# Why not "ALB 5xx on primary": a hard primary outage (which is the POINT
+# of this experiment) will drive 5xx through the roof, which would abort
+# the experiment prematurely — defeating its purpose. The alarm must watch
+# something that is ONLY abnormal when the experiment itself is abnormal,
+# not when the experiment is succeeding. Cluster API failure count fits:
+# the EKS control plane is NOT affected by stopping worker nodes, so its
+# failure count should stay near zero throughout the experiment. A spike
+# means something else is going wrong — concurrent incident, IAM trust
+# drift, control plane stress unrelated to the drill.
+#
+# Note on metric availability: AWS/EKS publishes ClusterFailedRequestCount
+# when the EKS Cluster endpoint experiences failed API calls. Metric data
+# points are only emitted when failures occur, so `treat_missing_data =
+# notBreaching` is essential — a quiet cluster emits no data, which is the
+# healthy state.
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "experiment_abort_signal" {
+  alarm_name        = "aegis-staging-fis-abort-eks-api-failures"
+  alarm_description = "Abort FIS experiment if primary EKS cluster endpoint starts returning failed API calls — see ADR-020."
+  namespace         = "AWS/EKS"
+  metric_name       = "ClusterFailedRequestCount"
+  statistic         = "Sum"
+  dimensions = {
+    ClusterName = local.primary_cluster_name
+  }
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 100 # failed requests in 60s — cluster API is actively failing, not just idle
+  evaluation_periods  = 2
+  period              = 60
+  treat_missing_data  = "notBreaching"
+
+  # No alarm_actions — the alarm state is consumed by FIS directly via
+  # stop_condition, no SNS notification needed. In a production drill,
+  # this would also fan out to PagerDuty / Slack for human awareness.
+
+  tags = {
+    Name = "aegis-staging-fis-abort-eks-api-failures"
+  }
+}

--- a/terraform/environments/staging/fis/versions.tf
+++ b/terraform/environments/staging/fis/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+}

--- a/terraform/environments/staging/workloads/modules/eks-workloads/observability.tf
+++ b/terraform/environments/staging/workloads/modules/eks-workloads/observability.tf
@@ -203,6 +203,44 @@ resource "kubectl_manifest" "kube_prometheus_stack" {
                   }]
                 }]
               }
+
+              # -----------------------------------------------------------
+              # DR-drill alert — NodeNotReady
+              # -----------------------------------------------------------
+              # Fires when any node enters NotReady state for >1 minute.
+              # The canonical signal for the FIS experiment defined in
+              # staging/fis/ (ADR-020): when FIS stops primary-region
+              # Karpenter-provisioned instances, their nodes flip to
+              # NotReady within 1–2 minutes and this alert fires.
+              #
+              # Visible in Grafana's Alert panel (Grafana alerting reads
+              # PrometheusRule firing state directly, no Alertmanager
+              # required — ADR-015 keeps Alertmanager disabled at lab tier).
+              #
+              # Severity: warning (not critical) — in normal operation a
+              # single NotReady node during Karpenter scale-down is common
+              # and auto-heals within minutes. The FIS drill intentionally
+              # drives this high; monitoring how many nodes fire and for
+              # how long is the demo's core observation.
+              # -----------------------------------------------------------
+              node-not-ready = {
+                groups = [{
+                  name = "dr-drill"
+                  rules = [{
+                    alert = "NodeNotReady"
+                    expr  = "kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 0"
+                    for   = "1m"
+                    labels = {
+                      severity = "warning"
+                      drill    = "fis-primary-outage"
+                    }
+                    annotations = {
+                      summary     = "Node {{ $labels.node }} is NotReady"
+                      description = "Node {{ $labels.node }} has been NotReady for >1 minute. Expected during the FIS primary-outage drill (ADR-020); investigate if no drill is running."
+                    }
+                  }]
+                }]
+              }
             }
           })
         }


### PR DESCRIPTION
## Summary

New Terraservice at `staging/fis/` implementing the FIS-based DR drill described in ADR-020. Closes the ADR-018 loop: the multi-region slot pattern now has a **dynamic failure-mode exercise** that can be run in 10-15 minutes and observed in Grafana.

The drill stops all primary-region Karpenter-provisioned EKS worker nodes for 10 minutes, then auto-recovers via FIS's `startInstancesAfterDuration`. Workers go NotReady, pods Pending, `NodeNotReady` PrometheusRule fires (visible in Grafana Alert panel), then everything recovers within 2-3 min of experiment end.

## What this PR adds

**staging/fis/** (new Terraservice, same pattern as staging/edge/):
- `experiment.tf` — `aws_fis_experiment_template` with tag-filtered target selector + stop-instances action + 10min duration
- `iam.tf` — least-privilege service role; tag-scoped inline deny policy as defense-in-depth against AWS-managed policy drift
- `stop-condition.tf` — CloudWatch alarm on `ClusterFailedRequestCount` (same-region; cross-region deferred per ADR-020 §Alternatives)
- `outputs.tf` — copy-pasteable `aws fis start-experiment` command + template ID for operator use

**staging/workloads** observability:
- New PrometheusRule `NodeNotReady` in `additionalPrometheusRulesMap.node-not-ready` — fires on `kube_node_status_condition{condition=Ready,status=true}==0` for 1m, tagged `drill=fis-primary-outage`

**docs/**:
- `decisions/020-fis-dr-drill.md` — ADR with alternatives (Litmus/Chaos Mesh, cross-region stop, S3/CloudFront fault, terminate-vs-stop)
- `runbooks/005-fis-dr-drill.md` — pre-flight checks / experiment start/observe/recover / troubleshooting

**CI/infra**:
- `.github/workflows/terraform-plan.yml` — add `staging/fis` to plan matrix (plan-only, same as `staging/edge`)
- `CLAUDE.md` — new runbook in the MUST-read list; updated directory tree
- `README.md` — directory tree + ADR table entries

## Design decisions (from ADR-020)

| Axis | Choice | Why |
|---|---|---|
| Duration | 10 min via `startInstancesAfterDuration=PT10M` | enough to observe + auto-recovery = no second experiment needed |
| Stop condition | Same-region CloudWatch alarm on ClusterFailedRequestCount | Cross-region alarms require Metric Streams (~\$1/mo + Kinesis) — rejected as scope creep |
| Action | `stop-instances` (not terminate) | Karpenter would immediately replace terminated instances, fighting the failover narrative; stop is pause-able |
| Experiment count | 1 (EKS only, not S3/CloudFront) | CloudFront OAC doesn't have an IAM role to attack; SSM-automation bucket-policy faults are scope creep |
| Alertmanager | Stays disabled (ADR-015 unchanged) | Grafana Alert panel reads PrometheusRule firing state directly |

## Change-review-discipline.md checklist

### 2.1 Blast radius
- **staging/fis state** only. No cross-account, no cross-region, no cluster-internal changes.
- **FIS service role** is tag-scoped (deny on non-Karpenter instances via inline policy). Maximum damage an attacker with this role could do: stop all Karpenter-provisioned EC2 in primary-region staging. Recoverable by `aws ec2 start-instances` within minutes.
- Runtime blast **during the drill**: primary-region EKS worker capacity lost for 10 min. Karpenter controller (Fargate) + Control plane + ArgoCD unaffected. Everything recovers automatically.

### 2.2 Dependency assumptions
- Karpenter-provisioned instances carry `karpenter.sh/nodepool` tag (stable Karpenter behavior since v1)
- EKS cluster name follows `aegis-staging-primary` convention (assertion in config.tf.local.primary_cluster_name; source of truth in `staging/platform/`)
- PrometheusRule requires `kube_node_status_condition` metric, which kube-state-metrics emits by default (Prometheus Operator discovery is wide-open per ADR-015)

### 2.3 Deprecation status
- `aws_fis_experiment_template`, `aws_iam_role`, `aws_cloudwatch_metric_alarm` — all stable AWS provider resources on 6.41.0
- FIS action `aws:ec2:stop-instances` — stable; `startInstancesAfterDuration` parameter is GA
- `AWSFaultInjectionSimulatorEC2Access` AWS managed policy — stable

### 2.4 Rollback plan
- `git revert` + `terraform destroy` on staging/fis (no persistent state dependencies from other layers)
- If a drill is in-flight: `aws fis stop-experiment --id <experiment-id>` manually aborts
- If auto-recovery fails: `aws ec2 start-instances --instance-ids <ids>` manual restart

### 2.5 2 AM readability
- ADR-020 explains the "why" for every axis (experiment type, duration, stop condition, recovery path) with a written alternatives-considered section
- Runbook 005 is step-by-step with commands; pre-flight checks catch the 5 most likely ways the drill can start broken (stop-condition alarm already firing, alert rule not loaded, cluster not up, etc.)
- Inline comments in stop-condition.tf explain WHY `ClusterFailedRequestCount` (not ALB 5xx, not CPU) — future operator reading the file cold understands the logic

## Test plan

- [ ] CI: terraform-plan green for `staging/fis` — validates syntax + provider compatibility
- [ ] CI: Checkov green (no new IAM wildcards; KMS not involved; least-privilege inline policy passes)
- [ ] On first apply: `aws fis list-experiment-templates` shows the new template
- [ ] Dry-run smoke test (before a real demo): start experiment → wait for `state=running` → immediately `aws fis stop-experiment` → verify instances came back → 0-cost verification the plumbing works
- [ ] Full drill (portfolio demo run): follow runbook 005 end-to-end; record timing vs T+2/T+5/T+10/T+13 expectations

## Related

- [ADR-020](docs/decisions/020-fis-dr-drill.md) — design + alternatives
- [Runbook 005](docs/runbooks/005-fis-dr-drill.md) — execution procedure
- [ADR-018](docs/decisions/018-multi-region-eks-design.md) — the architecture this drill exercises
- [ADR-005](docs/decisions/005-compliance-framework-iso-27001.md) — A.5.30 ICT readiness maps to this drill
- Session C (Incidents 26-30) validated the slot pattern statically; this drill validates it dynamically

🤖 Generated with [Claude Code](https://claude.com/claude-code)