### PR TITLE
fix: disable ServiceMonitor auto-create in cert-manager + argo-rollouts helm values

### DIFF
--- a/terraform/environments/staging/platform/modules/eks-cluster/cert-manager-helm.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/cert-manager-helm.tf
@@ -53,12 +53,18 @@ resource "helm_release" "cert_manager" {
         }
       }
 
-      # Emit Prometheus metrics via the ServiceMonitor CRD. Auto-discovered
-      # by the platform Prometheus (wide-open selectors per ADR-015).
+      # Metrics endpoint enabled; ServiceMonitor CRD auto-creation disabled.
+      # The ServiceMonitor CRD is shipped by Prometheus Operator (kube-
+      # prometheus-stack) which installs in the workloads layer AFTER
+      # platform. helm_release wait=true would fail at apply time with
+      # "no matches for kind ServiceMonitor" if the chart templates one.
+      # Workloads-layer follow-up: add an explicit ServiceMonitor that
+      # targets the cert-manager metrics Service, once Prometheus Operator
+      # CRDs are guaranteed present.
       prometheus = {
         enabled = true
         servicemonitor = {
-          enabled = true
+          enabled = false
         }
       }
     }),

--- a/terraform/environments/staging/workloads/modules/eks-workloads/argo-rollouts.tf
+++ b/terraform/environments/staging/workloads/modules/eks-workloads/argo-rollouts.tf
@@ -63,12 +63,17 @@ resource "kubectl_manifest" "argo_rollouts" {
                 }])
               }
 
-              # Emit Prometheus metrics via the ServiceMonitor CRD (auto-
-              # discovered by the platform Prometheus per ADR-015).
+              # Metrics endpoint enabled; ServiceMonitor CRD auto-creation
+              # disabled. ArgoCD sync order between kube-prometheus-stack
+              # (provides the CRD) and argo-rollouts is not guaranteed;
+              # same pattern / rationale as cert-manager-helm.tf in the
+              # platform layer. Explicit ServiceMonitor resource added
+              # once CRDs are guaranteed present is the workloads-layer
+              # follow-up.
               metrics = {
                 enabled = true
                 serviceMonitor = {
-                  enabled = true
+                  enabled = false
                 }
               }
             }


### PR DESCRIPTION
## Summary

Platform apply failed on cold-start at [run 24677044105](https://github.com/BinHsu/aegis-aws-landing-zone/actions/runs/24677044105): `no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"` from cert-manager helm_release. Root cause: the ServiceMonitor CRD belongs to Prometheus Operator, which is shipped by kube-prometheus-stack in the workloads layer (i.e., later than platform).

Fix: disable the chart-template-level ServiceMonitor creation on both cert-manager (platform layer) and argo-rollouts (workloads layer, same race with kube-prometheus-stack via ArgoCD sync ordering).

Metrics endpoints stay enabled — a follow-up PR can add explicit `ServiceMonitor` resources in the workloads layer once Prometheus Operator CRDs are guaranteed present.

## Applied from local

Per the γ path discussed mid-session: code is being applied locally using SSO creds to unblock the in-flight cold-apply session (NAT gateway is running; re-triggering CI would cost +30min and +\$1). This PR lands the same code to main for drift integrity.

## Change-review-discipline.md checklist

**Blast radius**: cert-manager metrics no longer auto-scraped; functional admission continues. Same for argo-rollouts. Observability loss is the only effect.

**Dependency assumptions**: kube-prometheus-stack's wide-open selectors (ADR-015 Discovery contract) will pick up a future explicit ServiceMonitor without code change on the consumer side.

**Deprecation status**: N/A (chart values flag).

**Rollback plan**: `git revert` + next platform apply. No state migration. Scrape targets simply re-disappear.

**2 AM readability**: both files now carry a block explaining why ServiceMonitor auto-create is off, what the follow-up is, and where the Prometheus Operator CRDs live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)