### PR TITLE
fix(karpenter): raise NodePool capacity + memory floor (Incident 31)

### DIFF
--- a/terraform/environments/staging/platform/modules/eks-cluster/karpenter-nodepool.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/karpenter-nodepool.tf
@@ -82,6 +82,17 @@ resource "kubectl_manifest" "karpenter_default_nodepool" {
               operator = "In"
               values   = ["2", "4"]
             },
+            # Memory floor — exclude tiny RAM instances (t3.micro 1GB,
+            # t3.small 2GB). Incident 31: Karpenter picked a t3.micro that
+            # could not fit ArgoCD controller's 1Gi memory request after
+            # PR #106 raised the limit, triggering the helm_release cascade.
+            # 3800 MiB ≈ "strictly more than 4GB target", accepting
+            # t3.medium (4GB), t3.large (8GB), m5.large (8GB), c5.large (4GB).
+            {
+              key      = "karpenter.k8s.aws/instance-memory"
+              operator = "Gt"
+              values   = ["3800"]
+            },
             {
               key      = "kubernetes.io/arch"
               operator = "In"
@@ -113,8 +124,15 @@ resource "kubectl_manifest" "karpenter_default_nodepool" {
         consolidateAfter    = "30s"
       }
 
+      # NodePool capacity envelope. Raised from 4 → 8 in Incident 31's
+      # aftermath: the prior cap was tight enough that a single-node outage
+      # (t3.micro replacement) could not accommodate the operator stack's
+      # concurrent cold-start (cert-manager + argocd + kyverno Helm installs
+      # all needed capacity at once + aegis-core workloads). 8 vCPU gives
+      # two m5.large-class nodes or one m5.xlarge, enough headroom for
+      # operator stack + workload + Fargate-evicted burst.
       limits = {
-        cpu    = "4"
+        cpu    = "8"
         memory = "16Gi"
       }
     }


### PR DESCRIPTION
## Summary

Two structural changes to prevent the helm_release cascade pattern captured in Incident 31:

1. **Memory floor** — add `karpenter.k8s.aws/instance-memory > 3800 MiB` requirement. Excludes t3.micro (1GB) and t3.small (2GB) which Karpenter happily picks under cheapest-spot pressure but cannot fit ArgoCD controller's 1Gi memory request (raised in PR #106). Keeps t3.medium (4GB), t3.large (8GB), m5.large (8GB), c5.large (4GB).

2. **CPU cap raised 4 → 8** — the operator stack cold-start (cert-manager + argocd + kyverno + aws-load-balancer-controller + Karpenter itself on Fargate) simultaneously contends for worker capacity during a fresh platform apply. Capping at 4 meant a single t3.micro-replacement could not be scheduled, cascading into `context deadline exceeded` on three different helm_releases. 8 vCPU fits 2×m5.large or 1×m5.xlarge — enough headroom for full operator stack + workload burst.

## Why this matters

The Session C multi-region teardown (Incidents 26–30) and PR #106's ArgoCD memory raise did not interact cleanly in the next cold apply — the first cold apply after those merged hit Incident 31 (ServiceMonitor CRD race + helm_release cascade). The ServiceMonitor race was the symptom; NodePool capacity + instance selection was the underlying enabler.

With both knobs loose enough, future helm value bumps (raising memory, adding replicas, adding charts) no longer risk starving the pool on first cold apply.

## Change-review-discipline.md checklist

**Blast radius**: NodePool selector narrows by memory (dropping two instance types Karpenter never *should* have picked anyway); NodePool cap doubles (more headroom, no new ceiling behavior). Multi-region applies (both slots use this module).

**Dependency assumptions**: `karpenter.k8s.aws/instance-memory` is a stable Karpenter requirement key (v1+). No provider version bump. Existing Helm charts unaffected.

**Deprecation status**: Karpenter v1.0.8 is current; the requirement key schema has not changed since v1.0.

**Rollback plan**: `git revert` + next platform apply. Existing nodes would not be rebalanced automatically; Karpenter's consolidation picks up new NodePool state during normal reconcile.

**2 AM readability**: inline comments on both changes explain the Incident 31 context and the specific instance-type exclusion reasoning.

## Test plan

- [ ] CI: terraform-plan green on length-1 + length-2 variants
- [ ] Next cold apply (probably a dedicated small-scope session): verify Karpenter picks m5.large or t3.medium+ as expected (kubectl get nodes -o wide after boot)
- [ ] Next cold apply: all operator stack pods reach Running within 5 minutes (no Pending-from-capacity events)

## Related

- [Incident 31](docs/incidents.md) — the root-cause write-up
- [PR #106](https://github.com/BinHsu/aegis-aws-landing-zone/pull/106) — ArgoCD memory raise that triggered the tightness
- [ADR-013](docs/decisions/013-eks-architecture.md) — EKS + Karpenter architecture
- Follow-up: `docs/principles/change-review-discipline.md` §X — new item "memory-request change must audit NodePool capacity" — tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)