### PR TITLE
docs: collateral count bump for ADR-024

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ aws-landing-zone-lab/
     ├── design-narrative.md         # 2-minute pitch + key decisions + war stories
     ├── interview-notes.md          # Reader's guide for recruiters / architect peers
     ├── incidents.md                # Append-only postmortems (32 as of 2026-04-21; unchanged this session)
-    ├── decisions/                  # 23 ADRs (NNN-<topic>.md)
+    ├── decisions/                  # 24 ADRs (NNN-<topic>.md)
     ├── runbooks/                   # 6 per-layer operational runbooks
     ├── principles/                 # Cross-cutting discipline docs (change-review, break-glass-apply)
     └── personal/                   # Gitignored — private portfolio brief

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Complete improvement index and reliability map: [`docs/improvements/README.md`](
 | [021](docs/decisions/021-observability-scaling-path.md) | Observability scaling path (three-rung ladder; amended for ADR-022) |
 | [022](docs/decisions/022-observability-backend-grafana-cloud.md) | Observability backend — Grafana Cloud free tier |
 | [023](docs/decisions/023-observability-responsibility-model.md) | Observability responsibility model (platform vs service domain) |
+| [024](docs/decisions/024-landing-zone-repo-topology.md) | Terraform repo topology — single repo with state/IAM/CI isolation |
 
 ## Runbooks
 


### PR DESCRIPTION
## Summary

Two-line collateral update to keep counts and lists in sync after PRs #123 + #124 merged:

- `CLAUDE.md` directory structure: `23 ADRs` → `24 ADRs`
- `README.md` ADR list: append row for ADR-024 (Terraform repo topology)

## Why deferred

PRs #123 and #124 both opened against main with the count claim of `23 ADRs`. Bumping in either PR would have caused a count-drift conflict when the other landed. Bumping in a third PR after both upstream landed avoids the cascade.

## Test plan

- [ ] `grep "24 ADRs" CLAUDE.md` returns the directory structure line
- [ ] README ADR list shows continuous `[001]` through `[024]` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)