### PR TITLE
feat(observability): platform layer — ESO + CRDs + KSM + Alloy (ADR-022 PR-1 of 4)

### DIFF
--- a/config/landing-zone.example.yaml
+++ b/config/landing-zone.example.yaml
@@ -147,3 +147,20 @@ eks:
   #     - region: eu-central-1
   #       role: primary
   #       mode: active
+
+# Grafana Cloud free tier — observability backend (ADR-022).
+# Optional: present this block to enable the platform observability stack
+# (External Secrets Operator, prometheus-operator-crds, kube-state-metrics,
+# Grafana Alloy). Omit to deploy the EKS platform without observability.
+# Runbook 006 documents the one-time Grafana Cloud signup that produces the
+# values below.
+# grafana_cloud:
+#   org_slug: aegis-staging
+#   # Mimir Prometheus remote_write endpoint — copy from Grafana Cloud stack
+#   # details page ("Prometheus" tile → "Details" → "URL"). NOT derivable from
+#   # org_slug alone; the hostname varies by stack provisioning region.
+#   mimir_url: "https://prometheus-prod-NN-prod-eu-west-N.grafana.net/api/prom/push"
+#   # Numeric user ID for Mimir HTTP basic auth — copy from same stack details
+#   # page ("Username / Instance ID" field). Password is the alloy-token
+#   # provisioned by Terraform in staging/observability/ (PR-2).
+#   mimir_user_id: "1234567"

--- a/config/schema.json
+++ b/config/schema.json
@@ -234,6 +234,28 @@
         }
       }
     },
+    "grafana_cloud": {
+      "type": "object",
+      "description": "Grafana Cloud free tier observability backend (ADR-022). Optional — present this block to enable the platform observability stack (ESO, prometheus-operator-crds, kube-state-metrics, Grafana Alloy). Omit to deploy the EKS platform without observability. Runbook 006 documents the one-time signup producing these values.",
+      "required": ["org_slug", "mimir_url", "mimir_user_id"],
+      "additionalProperties": false,
+      "properties": {
+        "org_slug": {
+          "type": "string",
+          "description": "Grafana Cloud stack slug (matches URL path at <slug>.grafana.net)"
+        },
+        "mimir_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Mimir Prometheus remote_write endpoint from stack details page. NOT derivable from org_slug — hostname varies by stack provisioning region."
+        },
+        "mimir_user_id": {
+          "type": "string",
+          "pattern": "^[0-9]+$",
+          "description": "Numeric user ID for Mimir HTTP basic auth, from stack details page"
+        }
+      }
+    },
     "eks": {
       "type": "object",
       "description": "EKS platform configuration keyed by workload environment name (e.g. staging, prod). Optional — only environments that deploy a platform layer need an entry.",

--- a/terraform/environments/staging/bootstrap/kms-secrets.tf
+++ b/terraform/environments/staging/bootstrap/kms-secrets.tf
@@ -1,0 +1,57 @@
+# -----------------------------------------------------------------------------
+# SSM Parameter Store SecureString encryption key — ADR-022
+# -----------------------------------------------------------------------------
+# Single account-level KMS key used to encrypt SecureString values under
+# /aegis/staging/grafana-cloud/*. Lives in the bootstrap layer (not platform)
+# because:
+#
+#   - Runbook 006 Part 2 requires `alias/aegis-staging-secrets` to exist
+#     BEFORE the operator puts the Grafana Cloud bootstrap token (Part 2
+#     happens BEFORE any observability TF apply). Baseline-layer auto-apply
+#     on PR merge satisfies that prerequisite without a session-gated
+#     gh workflow run.
+#
+#   - Tearing down and re-applying platform (session cadence) must NOT
+#     rotate this key — SSM PS values encrypted with the old key would
+#     become undecryptable on the new key. Bootstrap persists across
+#     session teardown.
+#
+# Multi-region posture (ADR-022 §Multi-region): single KMS key in the
+# primary region. Both EKS cluster slots' External Secrets Operator IRSA
+# roles read cross-region from primary-region SSM PS via the kms:ViaService
+# condition in their IAM policy. Avoids per-region KMS + SSM replication;
+# trade-off is slave cluster's ESO makes cross-region API calls on refresh
+# (1h default) — accepted for lab cardinality.
+#
+# Key policy grants kms:* to account root only. IRSA roles in the platform
+# layer attach kms:Decrypt via their own IAM policies, which avoids circular
+# bootstrap ↔ platform updates every time a new cluster slot lands.
+# -----------------------------------------------------------------------------
+
+resource "aws_kms_key" "secrets" {
+  description             = "SSM PS SecureString encryption for /aegis/staging/grafana-cloud/* (ADR-022)"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableRootAccountAdmin"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${local.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+    ]
+  })
+
+  tags = merge(local.tags, {
+    Name = "aegis-staging-secrets"
+  })
+}
+
+resource "aws_kms_alias" "secrets" {
+  name          = "alias/aegis-staging-secrets"
+  target_key_id = aws_kms_key.secrets.key_id
+}

--- a/terraform/environments/staging/bootstrap/outputs.tf
+++ b/terraform/environments/staging/bootstrap/outputs.tf
@@ -56,3 +56,18 @@ output "bazel_cache_bucket_arn" {
   description = "S3 bucket ARN for Bazel remote cache"
   value       = aws_s3_bucket.bazel_cache.arn
 }
+
+# -----------------------------------------------------------------------------
+# SSM PS SecureString encryption key — consumed by staging/platform
+# (ESO IRSA policy) and staging/observability (aws_ssm_parameter.key_id).
+# -----------------------------------------------------------------------------
+
+output "secrets_kms_key_arn" {
+  description = "KMS key ARN for /aegis/staging/grafana-cloud/* SSM PS SecureString encryption (ADR-022)"
+  value       = aws_kms_key.secrets.arn
+}
+
+output "secrets_kms_key_alias" {
+  description = "KMS key alias (alias/aegis-staging-secrets) — matches Runbook 006 Part 2 step 5"
+  value       = aws_kms_alias.secrets.name
+}

--- a/terraform/environments/staging/platform/config.tf
+++ b/terraform/environments/staging/platform/config.tf
@@ -9,6 +9,17 @@ locals {
   primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
 
   # -----------------------------------------------------------------------------
+  # Grafana Cloud observability — optional per ADR-022
+  # -----------------------------------------------------------------------------
+  # Presence of config.grafana_cloud gates the whole platform observability
+  # stack (ESO, prometheus-operator-crds, kube-state-metrics, Alloy). A forker
+  # can omit this block and deploy the EKS platform without observability;
+  # re-applying with grafana_cloud populated adds the stack idempotently.
+  # -----------------------------------------------------------------------------
+  grafana_cloud         = try(local.config.grafana_cloud, null)
+  observability_enabled = local.grafana_cloud != null
+
+  # -----------------------------------------------------------------------------
   # EKS compute footprint — drives per-cluster module instantiation
   # -----------------------------------------------------------------------------
   eks_regions = try(
@@ -122,6 +133,32 @@ data "terraform_remote_state" "staging_network" {
 }
 
 data "aws_caller_identity" "current" {}
+
+# -----------------------------------------------------------------------------
+# SSM PS SecureString encryption key — created in staging/bootstrap (ADR-022)
+# -----------------------------------------------------------------------------
+# Looked up by alias rather than via terraform_remote_state so platform
+# state does not depend on bootstrap state at plan time. Alias is a stable
+# contract (`alias/aegis-staging-secrets`) owned by staging/bootstrap/
+# kms-secrets.tf; the check block below produces a readable error if a
+# forker applies platform before bootstrap.
+# -----------------------------------------------------------------------------
+
+data "aws_kms_alias" "secrets" {
+  count = local.observability_enabled ? 1 : 0
+
+  name = "alias/aegis-staging-secrets"
+}
+
+check "secrets_kms_key_exists" {
+  assert {
+    condition = (
+      !local.observability_enabled
+      || try(data.aws_kms_alias.secrets[0].target_key_arn, "") != ""
+    )
+    error_message = "config.grafana_cloud is set but KMS alias 'alias/aegis-staging-secrets' is missing. Apply staging/bootstrap first (baseline layer, auto-applied on PR merge — see staging/bootstrap/kms-secrets.tf)."
+  }
+}
 
 check "network_layer_applied" {
   assert {

--- a/terraform/environments/staging/platform/main.tf
+++ b/terraform/environments/staging/platform/main.tf
@@ -51,6 +51,12 @@ module "cluster_primary" {
   ci_role_arn     = local.ci_role_arn
   github_org      = local.config.github.org
   github_app_repo = local.config.github.app_repo
+
+  # Observability — ADR-022 (conditional on config.grafana_cloud presence)
+  observability_enabled = local.observability_enabled
+  primary_region        = local.primary_region
+  secrets_kms_key_arn   = try(data.aws_kms_alias.secrets[0].target_key_arn, "")
+  grafana_cloud         = local.grafana_cloud
 }
 
 module "cluster_slave_1" {
@@ -82,4 +88,10 @@ module "cluster_slave_1" {
   ci_role_arn     = local.ci_role_arn
   github_org      = local.config.github.org
   github_app_repo = local.config.github.app_repo
+
+  # Observability — ADR-022 (conditional on config.grafana_cloud presence)
+  observability_enabled = local.observability_enabled
+  primary_region        = local.primary_region
+  secrets_kms_key_arn   = try(data.aws_kms_alias.secrets[0].target_key_arn, "")
+  grafana_cloud         = local.grafana_cloud
 }

--- a/terraform/environments/staging/platform/modules/eks-cluster/alloy.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/alloy.tf
@@ -1,0 +1,161 @@
+# -----------------------------------------------------------------------------
+# Grafana Alloy — scrape + remote_write + rule forward (ADR-022 Layer 1)
+# -----------------------------------------------------------------------------
+# Single Deployment instance per cluster. Three jobs:
+#
+#   1. Discover scrape targets via prometheus-operator CRDs (ServiceMonitor,
+#      PodMonitor) and scrape them through Alloy's prometheus.scrape runtime.
+#   2. Remote-write all samples to Grafana Cloud Mimir with an external
+#      `cluster` label so primary/slave streams are distinguishable in the
+#      shared stack (ADR-022 §External label convention).
+#   3. Forward PrometheusRule CRDs to the Mimir ruler API for server-side
+#      evaluation — cluster control-plane loss does not silence alerts on
+#      metrics still being remote-written.
+#
+# Not used: DaemonSet mode with the Unix exporter. Rationale — Fargate pods
+# forbid host mounts (Incident 27), and KSM + kubelet cAdvisor already cover
+# the signals Phase 4 cares about (NodeNotReady, CPU/memory pressure, deprec
+# API). Node-level /proc metrics can be added in a future PR by deploying a
+# separate alloy-daemonset release with a Fargate anti-affinity rule.
+#
+# `wait = false`: the Alloy pod references the `alloy-token` K8s Secret
+# created by ExternalSecret in staging/observability/ (PR-2). Before that
+# layer applies, the Secret does not exist and the pod stays
+# CreateContainerConfigError. helm_release wait=true would block Terraform
+# forever on first apply of platform; false lets Terraform confirm the
+# release is installed and move on. Observability-layer apply creates the
+# Secret and pods self-heal on next restart.
+#
+# Auth: Basic auth username = mimir_user_id (from config), password = env
+# var GRAFANA_CLOUD_TOKEN sourced from the alloy-token K8s Secret.
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "alloy" {
+  count = var.observability_enabled ? 1 : 0
+
+  provider = helm.this
+
+  name       = "alloy"
+  namespace  = "monitoring"
+  repository = "https://grafana.github.io/helm-charts"
+  chart      = "alloy"
+  version    = "0.9.2"
+
+  wait = false
+
+  values = [
+    yamlencode({
+      alloy = {
+        configMap = {
+          content = <<-ALLOY
+            // ---------------------------------------------------------------
+            // Scrape discovery — Prometheus Operator CRDs (ServiceMonitor /
+            // PodMonitor). Wide-open selectors so any workload team's CRDs
+            // auto-register (ADR-023 Discovery contract).
+            // ---------------------------------------------------------------
+            prometheus.operator.servicemonitors "default" {
+              forward_to = [prometheus.relabel.drop_pii_and_low_value.receiver]
+            }
+
+            prometheus.operator.podmonitors "default" {
+              forward_to = [prometheus.relabel.drop_pii_and_low_value.receiver]
+            }
+
+            // ---------------------------------------------------------------
+            // PII + low-value label drops (ADR-022 §Cardinality and PII)
+            // Platform-owned guardrail — executes before remote_write so
+            // user-identifying labels cannot accidentally land in Mimir.
+            // ---------------------------------------------------------------
+            prometheus.relabel "drop_pii_and_low_value" {
+              forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+
+              rule {
+                action = "labeldrop"
+                regex  = "user_id|email|ip_addr|client_ip|user_agent|session_id"
+              }
+
+              rule {
+                action = "labeldrop"
+                regex  = "go_.*|process_.*|promhttp_.*"
+              }
+            }
+
+            // ---------------------------------------------------------------
+            // Remote write → Grafana Cloud Mimir
+            // `cluster` external label distinguishes primary vs slave_1
+            // streams in the shared stack (ADR-022 §External label).
+            // ---------------------------------------------------------------
+            prometheus.remote_write "grafana_cloud" {
+              endpoint {
+                url = "${var.grafana_cloud.mimir_url}"
+
+                basic_auth {
+                  username = "${var.grafana_cloud.mimir_user_id}"
+                  password = env("GRAFANA_CLOUD_TOKEN")
+                }
+              }
+
+              external_labels = {
+                cluster = "${var.region_key}",
+              }
+            }
+
+            // ---------------------------------------------------------------
+            // Rule forward → Mimir ruler (server-side evaluation)
+            // PrometheusRule CRDs reconciled to Mimir via ruler HTTP API.
+            // ---------------------------------------------------------------
+            mimir.rules.kubernetes "default" {
+              address = "${var.grafana_cloud.mimir_url}"
+
+              basic_auth {
+                username = "${var.grafana_cloud.mimir_user_id}"
+                password = env("GRAFANA_CLOUD_TOKEN")
+              }
+
+              rule_selector {}
+              rule_namespace_selector {}
+            }
+          ALLOY
+        }
+
+        # alloy-token K8s Secret created by ExternalSecret in the
+        # staging/observability/ layer; mounted as env var so Alloy's
+        # env("GRAFANA_CLOUD_TOKEN") in the config above resolves.
+        extraEnv = [
+          {
+            name = "GRAFANA_CLOUD_TOKEN"
+            valueFrom = {
+              secretKeyRef = {
+                name = "alloy-token"
+                key  = "token"
+              }
+            }
+          },
+        ]
+
+        resources = {
+          requests = { cpu = "100m", memory = "256Mi" }
+          limits   = { memory = "512Mi" }
+        }
+      }
+
+      controller = {
+        type     = "deployment"
+        replicas = 1
+      }
+
+      # Chart's built-in ServiceMonitor for Alloy self-metrics — CRDs from
+      # prometheus-operator-crds are installed before this release
+      # (see depends_on below).
+      serviceMonitor = {
+        enabled = true
+      }
+    }),
+  ]
+
+  depends_on = [
+    helm_release.prometheus_operator_crds,
+    helm_release.external_secrets,
+    kubectl_manifest.cluster_secret_store,
+  ]
+}

--- a/terraform/environments/staging/platform/modules/eks-cluster/external-secrets-helm.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/external-secrets-helm.tf
@@ -1,0 +1,121 @@
+# -----------------------------------------------------------------------------
+# External Secrets Operator — Helm install + ClusterSecretStore (ADR-022)
+# -----------------------------------------------------------------------------
+# Installed as helm_release (not an ArgoCD Application) for the same reason
+# as cert-manager / Kyverno: the ClusterSecretStore kubectl_manifest in this
+# file references ExternalSecret CRDs that must exist synchronously. helm
+# wait=true blocks Terraform until the release reports Ready, guaranteeing
+# CRD availability. See Incident 26 for the async-apply race pattern this
+# avoids.
+#
+# ClusterSecretStore (cluster-scoped, one per cluster) declares the SSM PS
+# backend with ParameterStore provider + IRSA JWT auth. Each cluster's ESO
+# uses its own IRSA role (external-secrets-iam.tf); both target the PRIMARY
+# region's SSM PS (per ADR-022 §Multi-region). ExternalSecret resources
+# referencing this store live in the staging/observability/ layer (PR-2).
+#
+# Service account annotation wires IRSA: the chart creates the
+# external-secrets ServiceAccount in the external-secrets namespace;
+# `eks.amazonaws.com/role-arn` triggers the AWS IAM webhook to inject a
+# projected service account token into ESO pods.
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "external_secrets" {
+  count = var.observability_enabled ? 1 : 0
+
+  provider = helm.this
+
+  name             = "external-secrets"
+  namespace        = "external-secrets"
+  create_namespace = true
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  version          = "0.10.4"
+
+  values = [
+    yamlencode({
+      installCRDs = true
+
+      serviceAccount = {
+        annotations = {
+          "eks.amazonaws.com/role-arn" = aws_iam_role.external_secrets[0].arn
+        }
+      }
+
+      resources = {
+        requests = { cpu = "50m", memory = "64Mi" }
+        limits   = { memory = "128Mi" }
+      }
+
+      webhook = {
+        resources = {
+          requests = { cpu = "25m", memory = "32Mi" }
+          limits   = { memory = "64Mi" }
+        }
+      }
+
+      certController = {
+        resources = {
+          requests = { cpu = "25m", memory = "32Mi" }
+          limits   = { memory = "64Mi" }
+        }
+      }
+
+      # ServiceMonitor auto-create disabled for the same reason as cert-manager:
+      # the ServiceMonitor CRD is shipped by prometheus-operator-crds (sibling
+      # file in this module) — helm_release wait=true on ESO would race with
+      # CRD availability on first apply. Workloads-layer follow-up adds an
+      # explicit ServiceMonitor targeting ESO's /metrics endpoint.
+      serviceMonitor = {
+        enabled = false
+      }
+    }),
+  ]
+
+  depends_on = [
+    aws_eks_cluster.main,
+    helm_release.karpenter,
+    kubectl_manifest.aegis_cluster_admin_binding,
+  ]
+}
+
+# -----------------------------------------------------------------------------
+# ClusterSecretStore — SSM PS provider, IRSA JWT auth
+# -----------------------------------------------------------------------------
+# Cluster-scoped (applies to ExternalSecrets in any namespace). Single store
+# per cluster; primary and slave both point at primary-region SSM PS. Name is
+# fixed (`aegis-ssm`) — staging/observability/ ExternalSecrets reference this
+# name literally.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "cluster_secret_store" {
+  count = var.observability_enabled ? 1 : 0
+
+  provider = kubectl.this
+
+  yaml_body = yamlencode({
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ClusterSecretStore"
+    metadata = {
+      name = "aegis-ssm"
+    }
+    spec = {
+      provider = {
+        aws = {
+          service = "ParameterStore"
+          region  = var.primary_region
+          auth = {
+            jwt = {
+              serviceAccountRef = {
+                name      = "external-secrets"
+                namespace = "external-secrets"
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  depends_on = [helm_release.external_secrets]
+}

--- a/terraform/environments/staging/platform/modules/eks-cluster/external-secrets-iam.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/external-secrets-iam.tf
@@ -1,0 +1,82 @@
+# -----------------------------------------------------------------------------
+# External Secrets Operator — IRSA (ADR-022 §IAM policy)
+# -----------------------------------------------------------------------------
+# One IRSA role per cluster slot. Trust policy binds to the
+# external-secrets:external-secrets ServiceAccount created by the ESO chart.
+# Permission policy is scoped to the /aegis/staging/grafana-cloud/* SSM PS
+# path in the PRIMARY region — both primary and slave cluster ESO instances
+# read cross-region from the single primary-region SSM PS (per ADR-022
+# §Multi-region). Slave clusters therefore hit primary-region SSM + KMS
+# APIs on each refresh; acceptable at 1h default cadence + lab cardinality.
+#
+# The KMS statement uses `kms:ViaService = ssm.<primary_region>.amazonaws.com`
+# so ESO cannot use kms:Decrypt via any path except SSM — a direct kms:Decrypt
+# on a ciphertext blob retrieved by other means would fail the condition.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "external_secrets" {
+  count = var.observability_enabled ? 1 : 0
+
+  provider = aws.this
+
+  name = "${var.cluster_name}-external-secrets"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = aws_iam_openid_connect_provider.cluster.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.oidc_host}:aud" = "sts.amazonaws.com"
+          "${local.oidc_host}:sub" = "system:serviceaccount:external-secrets:external-secrets"
+        }
+      }
+    }]
+  })
+
+  tags = merge(var.tags, {
+    Name       = "${var.cluster_name}-external-secrets"
+    RegionRole = var.region_key
+  })
+}
+
+resource "aws_iam_role_policy" "external_secrets" {
+  count = var.observability_enabled ? 1 : 0
+
+  provider = aws.this
+
+  name = "${var.cluster_name}-external-secrets"
+  role = aws_iam_role.external_secrets[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadGrafanaCloudSSMParameters"
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+        ]
+        Resource = [
+          "arn:aws:ssm:${var.primary_region}:${var.account_id}:parameter/aegis/staging/grafana-cloud/*",
+        ]
+      },
+      {
+        Sid      = "DecryptGrafanaCloudSSMParameters"
+        Effect   = "Allow"
+        Action   = "kms:Decrypt"
+        Resource = var.secrets_kms_key_arn
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "ssm.${var.primary_region}.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}

--- a/terraform/environments/staging/platform/modules/eks-cluster/kube-state-metrics.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/kube-state-metrics.tf
@@ -1,0 +1,52 @@
+# -----------------------------------------------------------------------------
+# kube-state-metrics — K8s object state exporter (ADR-022 Layer 1 deps)
+# -----------------------------------------------------------------------------
+# KSM emits `kube_*` metrics (kube_pod_status_phase, kube_node_status_condition,
+# kube_deployment_status_replicas, ...) that platform alerts — and the service-
+# level SLO alerts aegis-core ships — both depend on.
+#
+# Was implicitly bundled inside kube-prometheus-stack (ADR-015). With the
+# reversal to Alloy + prometheus-operator-crds (ADR-022), KSM must be
+# installed explicitly: prometheus-operator-crds is CRDs-only and does not
+# ship KSM. Without this release, `kube_node_status_condition` would stop
+# emitting and Incident 29's NodeNotReady alert goes permanently silent.
+#
+# Self-scraping: chart ships a ServiceMonitor (prometheus.monitor.enabled)
+# that Alloy picks up via its prometheus.operator.servicemonitors component
+# — no explicit ServiceMonitor manifest needed here.
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "kube_state_metrics" {
+  count = var.observability_enabled ? 1 : 0
+
+  provider = helm.this
+
+  name       = "kube-state-metrics"
+  namespace  = "monitoring"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-state-metrics"
+  version    = "5.25.1"
+
+  values = [
+    yamlencode({
+      resources = {
+        requests = { cpu = "25m", memory = "64Mi" }
+        limits   = { memory = "128Mi" }
+      }
+
+      # ServiceMonitor auto-creation — relies on CRDs from
+      # prometheus-operator-crds (sibling file). Explicit depends_on on that
+      # release ensures CRDs are present before this release's post-install
+      # hooks attempt to create the ServiceMonitor.
+      prometheus = {
+        monitor = {
+          enabled = true
+        }
+      }
+    }),
+  ]
+
+  depends_on = [
+    helm_release.prometheus_operator_crds,
+  ]
+}

--- a/terraform/environments/staging/platform/modules/eks-cluster/prometheus-operator-crds.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/prometheus-operator-crds.tf
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------
+# prometheus-operator CRDs — schema only, no controller (ADR-022 Layer 2)
+# -----------------------------------------------------------------------------
+# Installs ONLY the Prometheus Operator CRDs (ServiceMonitor, PodMonitor,
+# PrometheusRule, Probe, AlertmanagerConfig, ...). No Operator controller,
+# no Prometheus server, no Alertmanager. Alloy (sibling alloy.tf) consumes
+# these CRDs to discover scrape targets and forwards PrometheusRule content
+# to Grafana Cloud Mimir ruler for server-side evaluation.
+#
+# Why helm_release (not ArgoCD Application): the CRDs shipped by this chart
+# are the portable contract surface (ADR-023) that TF-managed manifests in
+# the staging/workloads/ and staging/observability/ layers reference as
+# kubectl_manifest. ArgoCD-synced CRDs would race with those manifests on
+# first apply (Incident 28 pattern). helm_release wait=true guarantees CRDs
+# exist before downstream TF apply completes.
+#
+# Chart version pinning: CRDs move slowly — a bump requires a Kubernetes-
+# API-compat audit on the downstream manifests (ServiceMonitor / PodMonitor /
+# PrometheusRule CRs authored in aegis-core + staging/observability).
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "prometheus_operator_crds" {
+  count = var.observability_enabled ? 1 : 0
+
+  provider = helm.this
+
+  name             = "prometheus-operator-crds"
+  namespace        = "monitoring"
+  create_namespace = true
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus-operator-crds"
+  version          = "16.0.1"
+
+  depends_on = [
+    aws_eks_cluster.main,
+    helm_release.karpenter,
+    kubectl_manifest.aegis_cluster_admin_binding,
+  ]
+}

--- a/terraform/environments/staging/platform/modules/eks-cluster/variables.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/variables.tf
@@ -79,3 +79,35 @@ variable "argocd_apps_path" {
   type        = string
   default     = "apps/staging"
 }
+
+# -----------------------------------------------------------------------------
+# Observability stack inputs (ADR-022)
+# -----------------------------------------------------------------------------
+
+variable "observability_enabled" {
+  description = "Gate for the platform observability stack (ESO + prometheus-operator-crds + kube-state-metrics + Alloy). Driven by config.grafana_cloud presence at the parent layer. When false, none of these four Helm releases are created."
+  type        = bool
+  default     = false
+}
+
+variable "primary_region" {
+  description = "Primary AWS region (from config.regions[].role=primary). Per ADR-022 §Multi-region, the Grafana Cloud SSM PS parameters live only in the primary region; slave clusters' ESO reads cross-region. Used in the ESO IRSA policy's resource ARNs + kms:ViaService condition."
+  type        = string
+  default     = ""
+}
+
+variable "secrets_kms_key_arn" {
+  description = "ARN of alias/aegis-staging-secrets (created in staging/bootstrap/kms-secrets.tf). Used in the ESO IRSA policy's kms:Decrypt statement. Empty string when observability_enabled=false."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_cloud" {
+  description = "Grafana Cloud stack endpoints (ADR-022). Consumed by Alloy remote_write config. Null when observability_enabled=false."
+  type = object({
+    org_slug      = string
+    mimir_url     = string
+    mimir_user_id = string
+  })
+  default = null
+}


### PR DESCRIPTION
## Summary

First of 4 PRs implementing ADR-022 / ADR-023 observability reversal to Grafana Cloud. Adds the **platform-layer half** — four Helm releases gated on `config.grafana_cloud` presence plus the KMS key Runbook 006 Part 2 expects. No workload-layer changes yet (that's PR-3) and no new observability TF layer yet (PR-2).

### What lands here
- **`staging/bootstrap/`** — `aws_kms_key.secrets` + `alias/aegis-staging-secrets` so Runbook 006 Part 2 pre-apply CLI works and session teardown doesn't rotate the decryption key.
- **`staging/platform/modules/eks-cluster/`** — 5 new files (per-cluster, both slots):
  - External Secrets Operator + IRSA + ClusterSecretStore (primary-region SSM PS cross-region per ADR-022 §Multi-region)
  - `prometheus-operator-crds` (CRDs-only, no controller)
  - `kube-state-metrics` (replaces the implicit KSM that kube-prometheus-stack bundled — without this, Inc 29 NodeNotReady goes silent)
  - Grafana Alloy Deployment (CRD-discovered scrape + PII/low-value label drops + Mimir remote_write with `cluster` external label + PrometheusRule → Mimir ruler forward)
- **Config** — `grafana_cloud:` optional section in example.yaml + schema.json (`org_slug`, `mimir_url`, `mimir_user_id`)

### Gating
Everything new is behind `local.observability_enabled = local.grafana_cloud != null`. Forker with no Grafana Cloud signup: `terraform plan` shows zero new resources.

## 5-step change-review-discipline checklist

1. **Blast radius**: two TF layers (bootstrap baseline, platform workload). Config-gated — omit `grafana_cloud` and nothing changes. No deletions.
2. **Dependency assumptions**: bootstrap → platform ordering (already the case; check block surfaces readable error if violated). ESO IRSA uses `var.primary_region` not region literals.
3. **Deprecation status** (per upstream upgrade guides):
   - external-secrets 0.10.x — current GA
   - prometheus-operator-crds 16.x — current GA (17+ requires K8s 1.32+, which we run)
   - kube-state-metrics 5.25.x — current v5
   - grafana/alloy 0.9.x — current; v1.0 is recent major
   - All TF providers unchanged from existing `versions.tf`
4. **Rollback plan**: `git revert`. All new resources, no in-place state migration. In-cluster cleanup delets cleanly (ESO + CSS + CRDs chart + KSM + Alloy). KMS key deletion has 30-day window.
5. **2 AM readability**: each new file has a preamble explaining why the component exists + why `helm_release` vs ArgoCD Application + why `wait = false` on Alloy (Secret dep from PR-2).

## Cross-repo state
- **aegis-core #46 (`cross-repo/blocking`)**: ACK'd 2026-04-21 with 3 coordination points. CP1 tracked in ldz #126 (fulfilled in PR-2). CP2 (Grafana CRD namespace layout) ACK'd today — `observability` ns, primary-cluster only, cluster-wide `instanceSelector`. CP3 their side.
- **aegis-core #58 LAN smoke**: still pending — gates cold-apply, not this PR merge.

## Not in this PR
- **PR-2** — new `staging/observability/` peer layer (grafana-operator + Grafana Cloud tokens + `team-webhooks-slack-aegis` ExternalSecret, closes ldz #126 CP1)
- **PR-3** — `staging/workloads` — remove kube-prometheus-stack + explicit ServiceMonitors for cert-manager + argo-rollouts
- **PR-4** — `terraform-teardown-workload.yml` — CRD pre-delete stage + layer teardown order (observability → workloads → platform)

## Not applied this session
Per `project_cold_apply_deferred_to_big_bang.md`, cold-apply waits until all 3 gates close (ADR-022 impl merged ✨; aegis-core image-ready ✅; aegis-core LAN smoke signal ⏳). This PR is code-only.

## Test plan

- [ ] Checkov passes
- [ ] `terraform plan` in both `staging/bootstrap` and `staging/platform` shows the expected diffs when `grafana_cloud` is present in config and zero diffs when absent
- [ ] `validate-config.py` accepts example.yaml with the new optional `grafana_cloud` block
- [ ] Cold-apply deferred to future session per cold-apply-deferred memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)