### PR TITLE
feat(observability): new staging/observability peer layer — grafana-operator + GC tokens (ADR-022 PR-2 of 4)

### DIFF
--- a/.github/workflows/terraform-apply-workload.yml
+++ b/.github/workflows/terraform-apply-workload.yml
@@ -205,3 +205,64 @@ jobs:
         if: steps.exists.outputs.exists == 'true'
         working-directory: terraform/environments/${{ inputs.env }}/workloads
         run: terraform apply -auto-approve -input=false -no-color
+
+  # Observability layer — Grafana Cloud downstream identities + grafana-operator
+  # (primary-only) + platform Grafana*/PrometheusRule CRDs. ADR-022 PR-2.
+  # Runs after workloads because team-webhooks ExternalSecret targets the
+  # `aegis` namespace, which is created by workloads.
+  # No `environment:` — approval was granted at apply-network. If config does
+  # not include a grafana_cloud block, the whole layer plans to zero resources
+  # (observability_enabled gate in config.tf).
+  apply-observability:
+    name: Apply ${{ inputs.env }}/observability
+    needs: apply-workloads
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Write config
+        run: |
+          mkdir -p config
+          cat <<'EOFCONFIG' > config/landing-zone.yaml
+          ${{ secrets.LANDING_ZONE_CONFIG }}
+          EOFCONFIG
+
+      - name: Resolve target account ID
+        id: acct
+        run: |
+          ACCOUNT_ID=$(python3 -c "
+          import yaml
+          c = yaml.safe_load(open('config/landing-zone.yaml'))
+          print(c['accounts']['${{ inputs.env }}']['id'])
+          ")
+          echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Check layer exists
+        id: exists
+        run: |
+          if [[ -d "terraform/environments/${{ inputs.env }}/observability" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::observability layer does not exist for ${{ inputs.env }} — nothing to apply"
+          fi
+
+      - name: Terraform Init
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/observability
+        run: terraform init -input=false
+
+      - name: Terraform Apply
+        if: steps.exists.outputs.exists == 'true'
+        working-directory: terraform/environments/${{ inputs.env }}/observability
+        run: terraform apply -auto-approve -input=false -no-color

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -86,6 +86,16 @@ jobs:
           # -----------------------------------------------------------------
           - env: staging/fis
             account_id: "251774439261"
+          # -----------------------------------------------------------------
+          # staging/observability — new layer shipped in ADR-022 PR-2.
+          # Provisions Grafana Cloud downstream identities + grafana-operator
+          # (primary-only) + platform Grafana* + PrometheusRule CRDs.
+          # Plan against live state should show "no changes" once applied.
+          # Catches future drift on Grafana Cloud resources, SSM PS paths,
+          # or grafana-operator chart version bumps.
+          # -----------------------------------------------------------------
+          - env: staging/observability
+            account_id: "251774439261"
 
     steps:
       - uses: actions/checkout@v6

--- a/terraform/environments/staging/observability/README.md
+++ b/terraform/environments/staging/observability/README.md
@@ -1,0 +1,55 @@
+# staging/observability
+
+Peer Terraservice layer for Grafana Cloud downstream identities + the primary-only grafana-operator install. Implements the control-plane half of the observability stack described in [ADR-022](../../../../docs/decisions/022-observability-backend-grafana-cloud.md) and [ADR-023](../../../../docs/decisions/023-observability-responsibility-model.md).
+
+## What this layer owns
+
+- **Downstream Grafana Cloud identities** — Cloud Access Policy (Alloy, metrics:write + logs:write) and stack Service Account (grafana-operator, stack Admin). Both are provisioned from the one-time bootstrap token in SSM PS via the `grafana/grafana` Terraform provider.
+- **SSM PS SecureString writeback** — Alloy token, grafana-operator token, and the `team-webhooks-slack-aegis` placeholder (ldz #126 Coordination Point 1 for aegis-core).
+- **ExternalSecret CRDs** — three resources that sync the SSM PS values into Kubernetes Secrets via the `aegis-ssm` ClusterSecretStore installed in staging/platform.
+- **grafana-operator Helm release** — primary cluster only, per ADR-022 §Multi-region. The slave cluster is data-plane-only; running grafana-operator there would race on Grafana Cloud control-plane state.
+- **Platform Grafana CRDs** — `Grafana` (target stack), root `GrafanaNotificationPolicy`, three `GrafanaDashboard` CRDs (Kubernetes overview, Karpenter, grafana-operator meta), and four `PrometheusRule` CRDs (NodeNotReady, DeprecatedAPIUsed, GrafanaOperatorReconcileFailed, GrafanaCloudCardinalityApproaching8k).
+
+## What this layer does NOT own
+
+- **Alloy, prometheus-operator-crds, External Secrets Operator, kube-state-metrics** — installed by staging/platform (PR-1).
+- **The primary-region secrets CMK (`alias/aegis-staging-secrets`)** — created by staging/bootstrap.
+- **Service-team dashboards, contact points, notification-policy leaves** — aegis-core repo per ADR-023 §Domain split.
+- **Slave-cluster control plane** — by design there is no slave observability control plane; Alloy in staging/platform handles slave data-plane.
+
+## Apply order
+
+```
+network → platform → workloads → observability
+```
+
+Observability depends on workloads because the `team-webhooks` ExternalSecret targets the `aegis` namespace owned by workloads. CI enforces the order in `.github/workflows/terraform-apply-workload.yml`.
+
+## First-time operator steps
+
+See [docs/runbooks/006-grafana-cloud-onboarding.md](../../../../docs/runbooks/006-grafana-cloud-onboarding.md) Part 4 for the one-time Grafana Cloud signup + bootstrap token flow. Until the bootstrap token is put in SSM PS, `terraform apply` on this layer exits with `NoSuchKey` on the bootstrap-token data source — that's the intended operator-facing failure mode.
+
+## Slack webhook placeholder
+
+`tokens.tf` creates `/aegis/staging/grafana-cloud/team-webhooks-slack-aegis` with a placeholder value and `lifecycle.ignore_changes = [value]`. Operator overwrites out-of-band:
+
+```bash
+AWS_PROFILE=aegis-staging-admin aws ssm put-parameter \
+  --region eu-central-1 \
+  --name /aegis/staging/grafana-cloud/team-webhooks-slack-aegis \
+  --type SecureString --key-id alias/aegis-staging-secrets \
+  --value 'https://hooks.slack.com/services/T.../B.../...' \
+  --overwrite
+```
+
+External Secrets picks up the real value within its refresh interval (1h default) and populates the `team-webhooks` K8s Secret key `slack-aegis` in the `aegis` namespace, fulfilling the aegis-core GrafanaContactPoint contract (ADR-023 §Secret plumbing model).
+
+## Teardown
+
+**Pre-teardown step** per ADR-022 §Teardown: delete Grafana CRDs before destroying this layer, or Grafana Cloud will carry orphan dashboards and routing. PR-4 wires this into `terraform-teardown-workload.yml` as the first stage. Manual form:
+
+```bash
+kubectl delete grafanadashboards,grafanacontactpoints,grafananotificationpolicies,grafananotificationpolicyroutes --all -A
+# wait ~2 minutes for finalizers
+terraform destroy
+```

--- a/terraform/environments/staging/observability/backend.tf
+++ b/terraform/environments/staging/observability/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "staging/observability/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/terraform/environments/staging/observability/config.tf
+++ b/terraform/environments/staging/observability/config.tf
@@ -1,0 +1,188 @@
+# -----------------------------------------------------------------------------
+# Configuration Contract — ADR-004
+# -----------------------------------------------------------------------------
+# Peer Terraservice layer for Grafana Cloud downstream identities + the
+# primary-only grafana-operator install (ADR-022, ADR-023).
+#
+# Gate: presence of config.grafana_cloud. Without the block, the whole layer
+# plans to zero resources — operator can apply a fresh staging without
+# observability, then enable it later by adding grafana_cloud to config and
+# re-applying. Mirrors staging/platform/config.tf observability_enabled gate.
+#
+# Unlike staging/platform (which is slot-patterned K=2), this layer targets
+# the PRIMARY cluster only — grafana-operator reconciles against a single
+# Grafana Cloud stack; running it in both slots would make the two
+# reconcilers race on identical CRDs (ADR-022 §Multi-region primary-only
+# rationale). There is no slave_1 provider and no slot pattern here.
+# -----------------------------------------------------------------------------
+
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.staging.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+
+  # Grafana Cloud block — gate for the whole layer.
+  grafana_cloud         = try(local.config.grafana_cloud, null)
+  observability_enabled = local.grafana_cloud != null
+
+  # -----------------------------------------------------------------------------
+  # EKS compute footprint — mirrored from staging/platform so the K=2 ceiling
+  # precondition can assert in this layer too. Not used for slot expansion
+  # (grafana-operator is primary-only per ADR-022 §Multi-region); consulted
+  # only for the precondition guard and a clearer error message when a
+  # forker tries to push past K=2.
+  # -----------------------------------------------------------------------------
+  eks_regions = try(
+    local.config.eks.staging.regions,
+    [{
+      region = local.primary_region
+      role   = "primary"
+      mode   = "active"
+    }]
+  )
+
+  primary_eks_region = [for r in local.eks_regions : r if r.role == "primary"][0]
+
+  # Cluster name convention matches staging/platform: "<org>-staging-<slot>".
+  # grafana-operator + CRDs land on the primary cluster only.
+  primary_cluster_name = "${local.config.organization.name}-staging-primary"
+
+  # SSM PS path prefix — ADR-022 §Secret path convention. All Grafana Cloud
+  # secrets live under this prefix so IAM policies can scope to the whole
+  # family with a single wildcard (staging/platform ESO IRSA does this).
+  ssm_path_prefix = "/aegis/staging/grafana-cloud"
+
+  tags = merge(local.config.tags, {
+    Environment = "staging"
+    Component   = "observability"
+  })
+
+  # Per-cluster details read from staging/platform's per-slot clusters map.
+  clusters = try(data.terraform_remote_state.staging_platform.outputs.clusters, {})
+}
+
+# -----------------------------------------------------------------------------
+# Cross-field invariants — ADR-018 §2 (mirror of staging/platform checks)
+# -----------------------------------------------------------------------------
+
+check "exactly_one_primary_region_top_level" {
+  assert {
+    condition     = length([for r in local.config.regions : r if r.role == "primary"]) == 1
+    error_message = "config/landing-zone.yaml regions[] must have exactly one entry with role: primary."
+  }
+}
+
+check "exactly_one_primary_eks_region" {
+  assert {
+    condition     = length([for r in local.eks_regions : r if r.role == "primary"]) == 1
+    error_message = "config/landing-zone.yaml eks.staging.regions[] must have exactly one entry with role: primary."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# K=2 slot ceiling — mirror of the same guard in network/, platform/,
+# workloads/. Observability is primary-only but must still refuse to plan
+# when the top-level config exceeds K=2 — otherwise a forker could drift
+# the sibling layers into K=3 state while observability silently applies.
+# -----------------------------------------------------------------------------
+
+resource "terraform_data" "assert_k2_max" {
+  lifecycle {
+    precondition {
+      condition     = length(local.eks_regions) <= 2
+      error_message = <<-EOT
+        eks.staging.regions[] has ${length(local.eks_regions)} entries, exceeding the slot-pattern K=2 ceiling declared in ADR-018 §3 "Scaling boundary".
+
+        See the detailed unlock procedure in terraform/environments/staging/network/config.tf — single source of truth.
+
+        Note: this layer (staging/observability) is intentionally primary-only per ADR-022 §Multi-region. The K=2 guard exists here because a K=3 top-level config is a repo-wide governance breach; refusing to plan is safer than silently applying one layer past the ceiling.
+      EOT
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cross-layer state read — consume platform's clusters map
+# -----------------------------------------------------------------------------
+# Observability is a peer layer that depends on staging/platform (EKS cluster
+# must exist for the kubernetes/kubectl/helm providers to connect) AND on
+# staging/workloads (the `aegis` namespace must exist for the team-webhooks
+# ExternalSecret to land in that namespace). Apply ordering is enforced by
+# the terraform-apply-workload.yml workflow: network → platform → workloads
+# → observability. This data source is the compile-time check that platform
+# has been applied; workloads dependency is ordering-only (enforced by CI).
+# -----------------------------------------------------------------------------
+
+data "terraform_remote_state" "staging_platform" {
+  backend = "s3"
+  config = {
+    bucket = "${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}"
+    key    = "staging/platform/terraform.tfstate"
+    region = local.primary_region
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+check "expected_account" {
+  assert {
+    condition     = data.aws_caller_identity.current.account_id == local.account_id
+    error_message = "Running against the wrong AWS account (${data.aws_caller_identity.current.account_id}) — staging/observability must be applied with credentials for ${local.account_id} (aegis-staging)."
+  }
+}
+
+check "platform_layer_applied" {
+  assert {
+    condition = (
+      !local.observability_enabled
+      || (
+        data.terraform_remote_state.staging_platform.outputs != null
+        && try(contains(keys(data.terraform_remote_state.staging_platform.outputs.clusters), "primary"), false)
+      )
+    )
+    error_message = "staging/platform has not been applied or its clusters map is missing the primary slot. Apply staging/platform before staging/observability (gh workflow run terraform-apply-workload.yml -f env=staging)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# SSM PS SecureString encryption key — contract with staging/bootstrap
+# -----------------------------------------------------------------------------
+# Alias `alias/aegis-staging-secrets` is owned by staging/bootstrap/kms-secrets.tf
+# (PR-1 contract). Looked up by alias to avoid chaining bootstrap state into
+# this layer. The check below fires a readable error if a forker attempts
+# observability before bootstrap.
+# -----------------------------------------------------------------------------
+
+data "aws_kms_alias" "secrets" {
+  count = local.observability_enabled ? 1 : 0
+
+  name = "alias/aegis-staging-secrets"
+}
+
+check "secrets_kms_key_exists" {
+  assert {
+    condition = (
+      !local.observability_enabled
+      || try(data.aws_kms_alias.secrets[0].target_key_arn, "") != ""
+    )
+    error_message = "config.grafana_cloud is set but KMS alias 'alias/aegis-staging-secrets' is missing. Apply staging/bootstrap first (baseline layer, auto-applied on PR merge — see staging/bootstrap/kms-secrets.tf)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Bootstrap token — Runbook 006 Part 2 (human-provisioned, 30-day expiry)
+# -----------------------------------------------------------------------------
+# Plain `data "aws_ssm_parameter"` returns NoSuchKey when the operator has
+# not run Runbook 006 Part 2 yet. That is the intended operator-facing error
+# — Part 4 of the runbook documents the `terraform apply` command that
+# reaches this data source. Keeping it unconditional (no count) surfaces the
+# missing-bootstrap-token case loudly rather than masking it.
+# -----------------------------------------------------------------------------
+
+data "aws_ssm_parameter" "bootstrap_token" {
+  count = local.observability_enabled ? 1 : 0
+
+  name            = "${local.ssm_path_prefix}/bootstrap-token"
+  with_decryption = true
+}

--- a/terraform/environments/staging/observability/external-secrets.tf
+++ b/terraform/environments/staging/observability/external-secrets.tf
@@ -1,0 +1,165 @@
+# -----------------------------------------------------------------------------
+# ExternalSecrets — pull SSM PS SecureStrings into K8s Secrets (ADR-022)
+# -----------------------------------------------------------------------------
+# Three ExternalSecret manifests, one per downstream token. All three
+# reference the `aegis-ssm` ClusterSecretStore created in staging/platform
+# (PR-1). Naming + key contracts are locked — the consumer side (Alloy
+# extraEnv in staging/platform; grafana-operator Grafana CRD in this layer;
+# aegis-core's GrafanaContactPoint CRDs) hard-codes these exact strings.
+#
+# Refresh interval (1h default) is acceptable for 90-day rotating tokens —
+# External Secrets picks up rotations within the hour without manual
+# intervention. Tightening to 5m would matter only for secrets that rotate
+# on minutes-scale (none here).
+#
+# kubectl_manifest over kubernetes_manifest: ExternalSecret is a CRD shipped
+# by the External Secrets Operator chart. kubernetes_manifest requires the
+# CRD to be reachable at plan time, which fails on cold apply if ESO's helm
+# release has not yet installed its CRDs. kubectl_manifest defers schema
+# validation to apply time — identical pattern to staging/platform's
+# kubectl_manifest usage for CRD-backed resources.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# alloy-token — consumed by Alloy Deployment in `monitoring` ns
+# -----------------------------------------------------------------------------
+# Contract with staging/platform/modules/eks-cluster/alloy.tf:
+#   extraEnv[0] references K8s Secret `alloy-token` key `token` → mounted
+#   as env var GRAFANA_CLOUD_TOKEN → Alloy config env("GRAFANA_CLOUD_TOKEN")
+#   resolves to this secret's value.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "external_secret_alloy_token" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "alloy-token"
+      namespace = "monitoring"
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+        "app.kubernetes.io/part-of"    = "platform"
+      }
+    }
+    spec = {
+      refreshInterval = "1h"
+      secretStoreRef = {
+        name = "aegis-ssm"
+        kind = "ClusterSecretStore"
+      }
+      target = {
+        name           = "alloy-token"
+        creationPolicy = "Owner"
+      }
+      data = [
+        {
+          secretKey = "token"
+          remoteRef = {
+            key = "${local.ssm_path_prefix}/alloy-token"
+          }
+        },
+      ]
+    }
+  })
+
+  depends_on = [aws_ssm_parameter.alloy_token]
+}
+
+# -----------------------------------------------------------------------------
+# grafana-operator-token — consumed by the Grafana CRD (spec.external.apiKey)
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "external_secret_grafana_operator_token" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "grafana-operator-token"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+        "app.kubernetes.io/part-of"    = "platform"
+      }
+    }
+    spec = {
+      refreshInterval = "1h"
+      secretStoreRef = {
+        name = "aegis-ssm"
+        kind = "ClusterSecretStore"
+      }
+      target = {
+        name           = "grafana-operator-token"
+        creationPolicy = "Owner"
+      }
+      data = [
+        {
+          secretKey = "token"
+          remoteRef = {
+            key = "${local.ssm_path_prefix}/grafana-operator-token"
+          }
+        },
+      ]
+    }
+  })
+
+  depends_on = [
+    kubernetes_namespace_v1.observability,
+    aws_ssm_parameter.grafana_operator_token,
+  ]
+}
+
+# -----------------------------------------------------------------------------
+# team-webhooks — consumed by aegis-core's GrafanaContactPoint CRD
+# -----------------------------------------------------------------------------
+# Multi-key secret (ADR-023 §Secret plumbing model). Today only one key
+# (`slack-aegis`) exists; future team onboarding adds keys alongside (e.g.
+# `slack-platform`, `slack-billing`). The ExternalSecret's `data` list is
+# the single source of truth for which keys exist — adding a team = adding
+# an entry here and a matching SSM PS parameter in tokens.tf.
+#
+# Target namespace `aegis` is owned by staging/workloads (via
+# modules/eks-workloads/namespace.tf). Apply order: network → platform →
+# workloads → observability, enforced by terraform-apply-workload.yml.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "external_secret_team_webhooks" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "team-webhooks"
+      namespace = "aegis"
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+        "app.kubernetes.io/part-of"    = "platform"
+      }
+    }
+    spec = {
+      refreshInterval = "1h"
+      secretStoreRef = {
+        name = "aegis-ssm"
+        kind = "ClusterSecretStore"
+      }
+      target = {
+        name           = "team-webhooks"
+        creationPolicy = "Owner"
+      }
+      data = [
+        {
+          secretKey = "slack-aegis"
+          remoteRef = {
+            key = "${local.ssm_path_prefix}/team-webhooks-slack-aegis"
+          }
+        },
+      ]
+    }
+  })
+
+  depends_on = [aws_ssm_parameter.team_webhooks_slack_aegis]
+}

--- a/terraform/environments/staging/observability/grafana-crd.tf
+++ b/terraform/environments/staging/observability/grafana-crd.tf
@@ -35,7 +35,7 @@ resource "kubectl_manifest" "grafana" {
     }
     spec = {
       external = {
-        url = "https://${local.grafana_cloud.org_slug}.grafana.net"
+        url = "https://${try(local.grafana_cloud.org_slug, "")}.grafana.net"
         apiKey = {
           name = "grafana-operator-token"
           key  = "token"

--- a/terraform/environments/staging/observability/grafana-crd.tf
+++ b/terraform/environments/staging/observability/grafana-crd.tf
@@ -1,0 +1,115 @@
+# -----------------------------------------------------------------------------
+# Grafana CRD — target stack for grafana-operator (ADR-022 Layer 3)
+# -----------------------------------------------------------------------------
+# The Grafana CRD tells grafana-operator WHICH Grafana instance to reconcile
+# against. `spec.external` points at a pre-existing external instance (our
+# Grafana Cloud stack) rather than asking the operator to provision a
+# Grafana server in-cluster. Auth is via `spec.external.apiKey`, which
+# references the K8s Secret created by ExternalSecret in external-secrets.tf.
+#
+# Label contract — `dashboards: grafana` (and other selector labels) on
+# this Grafana CRD are what every GrafanaDashboard / GrafanaContactPoint /
+# GrafanaNotificationPolicy CRD targets via its `spec.instanceSelector`.
+# The value `grafana` is arbitrary but forms a cluster-wide singleton
+# contract: aegis-core's CRDs must use the SAME selector to bind to this
+# instance. Changing the value here without coordinating with aegis-core
+# breaks the contract — it's part of the cross-repo platform surface.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "grafana" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "grafana.integreatly.org/v1beta1"
+    kind       = "Grafana"
+    metadata = {
+      name      = "aegis-staging"
+      namespace = "observability"
+      labels = {
+        # Label value — must match the instanceSelector on every
+        # GrafanaDashboard / GrafanaContactPoint / GrafanaNotificationPolicy*
+        # CRD in the cluster. Cluster-wide singleton.
+        dashboards                  = "grafana"
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      external = {
+        url = "https://${local.grafana_cloud.org_slug}.grafana.net"
+        apiKey = {
+          name = "grafana-operator-token"
+          key  = "token"
+        }
+      }
+    }
+  })
+
+  depends_on = [
+    helm_release.grafana_operator,
+    kubectl_manifest.external_secret_grafana_operator_token,
+  ]
+}
+
+# -----------------------------------------------------------------------------
+# Root GrafanaNotificationPolicy — platform-owned (ADR-023 §Notification tree)
+# -----------------------------------------------------------------------------
+# Grafana Cloud's Alertmanager enforces a SINGLE notification policy tree
+# per stack; concurrent writers race, last writer wins. The contract
+# (ADR-023 §Notification policy tree composition):
+#
+#   - Root is platform-owned. Exactly ONE GrafanaNotificationPolicy in the
+#     cluster, and it lives in the platform namespace (`observability`).
+#   - Leaves are service-team-owned via GrafanaNotificationPolicyRoute
+#     CRDs in their own namespaces.
+#
+# The root here defines a catch-all: every alert gets routed via the
+# default receiver unless a leaf route matches first. For the lab tier we
+# define the default receiver name as `platform-default` — aegis-core will
+# ship the actual GrafanaContactPoint (`aegis-oncall-slack` etc.) in its
+# own namespace, and their leaf routes will match-and-divert before this
+# catch-all fires.
+#
+# `routeSelector` on the root matches any leaf labeled `tree=aegis-root`.
+# That label is the contract surface service teams use to attach their
+# leaves — documented in ADR-023.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "notification_policy_root" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "grafana.integreatly.org/v1beta1"
+    kind       = "GrafanaNotificationPolicy"
+    metadata = {
+      name      = "aegis-root"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      instanceSelector = {
+        matchLabels = {
+          dashboards = "grafana"
+        }
+      }
+      route = {
+        # Default receiver name — aegis-core (or platform) will ship a
+        # GrafanaContactPoint with this name as the fallback target. Not
+        # shipping the contact point itself here: platform doesn't pick
+        # service-team targets, it only defines the routing shape.
+        receiver = "platform-default"
+        group_by = ["alertname", "cluster", "namespace"]
+        # Leaf-attach point: any GrafanaNotificationPolicyRoute CRD with
+        # label `tree=aegis-root` will be composed under this root.
+        routeSelector = {
+          matchLabels = {
+            tree = "aegis-root"
+          }
+        }
+      }
+    }
+  })
+
+  depends_on = [kubectl_manifest.grafana]
+}

--- a/terraform/environments/staging/observability/grafana-operator.tf
+++ b/terraform/environments/staging/observability/grafana-operator.tf
@@ -1,0 +1,75 @@
+# -----------------------------------------------------------------------------
+# grafana-operator — PRIMARY CLUSTER ONLY (ADR-022 §Multi-region)
+# -----------------------------------------------------------------------------
+# grafana-operator reconciles Kubernetes CRDs (Grafana, GrafanaDashboard,
+# GrafanaContactPoint, GrafanaNotificationPolicy, GrafanaNotificationPolicyRoute,
+# GrafanaMuteTiming) against a SINGLE Grafana Cloud stack. If both slot
+# clusters ran grafana-operator, they would race on identical Grafana Cloud
+# resources (last-writer-wins thrash, never converges).
+#
+# This layer's providers target the primary cluster only. grafana-operator
+# is therefore installed once, on the primary, regardless of how many EKS
+# slots the config declares. Slave-cluster observability is data-plane
+# (Alloy remote_write in staging/platform) — not control-plane.
+#
+# Chart: grafana/grafana-operator 5.22.2 (current stable at PR time). The
+# operator CRDs ship INSIDE this chart — enabling `installCRDs = true` is
+# how the Grafana* CRDs become available for our own kubectl_manifest
+# resources (the Grafana CRD + root NotificationPolicy below).
+#
+# wait = true so helm_release blocks until the operator Deployment is
+# Ready. Downstream kubectl_manifest resources (Grafana CRD, dashboards,
+# alerts) depend_on this release — wait=true guarantees the CRDs are
+# registered before those manifests apply.
+#
+# Cost: grafana-operator sits at ~50m CPU / 128Mi memory idle. Negligible
+# at lab scale (one operator vs kube-prometheus-stack's full Prometheus +
+# Grafana + Alertmanager footprint this replaces — ADR-022 reversal).
+# -----------------------------------------------------------------------------
+
+resource "helm_release" "grafana_operator" {
+  count = local.observability_enabled ? 1 : 0
+
+  name       = "grafana-operator"
+  namespace  = "observability"
+  repository = "oci://ghcr.io/grafana/helm-charts"
+  chart      = "grafana-operator"
+  version    = "v5.22.2"
+
+  wait = true
+
+  values = [
+    yamlencode({
+      # CRD management: chart installs Grafana, GrafanaDashboard, etc.
+      # into the cluster. Our kubectl_manifest resources below reference
+      # these CRDs — wait=true + CRD install happening in this same
+      # helm_release guarantees the schema is registered before
+      # Terraform attempts to apply any downstream Grafana* manifest.
+      installCRDs = true
+
+      # Resource limits — lab-tier, single operator per stack.
+      resources = {
+        requests = { cpu = "50m", memory = "128Mi" }
+        limits   = { memory = "256Mi" }
+      }
+
+      # ServiceMonitor for self-metrics — platform-owned observability of
+      # the observability stack itself (meta-observability per ADR-023
+      # §Known Limitations). Alloy scrapes this ServiceMonitor via the
+      # wide-open selector in staging/platform/modules/eks-cluster/alloy.tf.
+      serviceMonitor = {
+        enabled = true
+      }
+    }),
+  ]
+
+  depends_on = [
+    kubernetes_namespace_v1.observability,
+    # ExternalSecret must exist before the Grafana CRD tries to reference
+    # its K8s Secret output. The Grafana CRD apply itself is gated
+    # separately in grafana-crd.tf, but installing grafana-operator before
+    # ESO has synced the token avoids a reconcile-loop error spike on
+    # first-apply that we would then have to clear from dashboards.
+    kubectl_manifest.external_secret_grafana_operator_token,
+  ]
+}

--- a/terraform/environments/staging/observability/namespace.tf
+++ b/terraform/environments/staging/observability/namespace.tf
@@ -1,0 +1,37 @@
+# -----------------------------------------------------------------------------
+# observability namespace — home of grafana-operator + the Grafana CRD
+# -----------------------------------------------------------------------------
+# Coordination Point 2 from aegis-core #46: the Grafana CRD lives in
+# `observability/`, and grafana-operator's `instanceSelector` scans
+# cluster-wide for dashboards, contact points, and notification routes.
+# This means aegis-core's per-service CRDs live in the `aegis` namespace
+# and grafana-operator picks them up via label selector without any
+# cross-namespace RBAC gymnastics.
+#
+# Why a dedicated namespace (not `monitoring`): `monitoring` is owned by
+# staging/platform (Alloy, prometheus-operator-crds, kube-state-metrics)
+# and represents the data-plane of the observability stack — what IS
+# scraped and shipped. `observability` owns the control-plane — what
+# configures the dashboards, alerting routes, and the Grafana-side stack
+# identity. Separating the two makes the RBAC + NetworkPolicy story
+# cleaner when/if either namespace needs tightening.
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_namespace_v1" "observability" {
+  count = local.observability_enabled ? 1 : 0
+
+  metadata {
+    name = "observability"
+
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = "platform"
+      # Pod Security Standards — grafana-operator runs as non-root,
+      # read-only root FS, no privileged capabilities. `restricted`
+      # is the tightest PSS tier and is the correct profile.
+      "pod-security.kubernetes.io/enforce" = "restricted"
+      "pod-security.kubernetes.io/audit"   = "restricted"
+      "pod-security.kubernetes.io/warn"    = "restricted"
+    }
+  }
+}

--- a/terraform/environments/staging/observability/outputs.tf
+++ b/terraform/environments/staging/observability/outputs.tf
@@ -9,7 +9,7 @@
 
 output "grafana_stack_url" {
   description = "Browser-facing URL of the Grafana Cloud stack. Human login via Google OAuth (Runbook 006 Part 3). Null when observability_enabled=false."
-  value       = local.observability_enabled ? "https://${local.grafana_cloud.org_slug}.grafana.net" : null
+  value       = local.observability_enabled ? "https://${try(local.grafana_cloud.org_slug, "")}.grafana.net" : null
 }
 
 output "grafana_stack_region_slug" {

--- a/terraform/environments/staging/observability/outputs.tf
+++ b/terraform/environments/staging/observability/outputs.tf
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------------------------
+# Outputs — operator-facing only (no downstream Terraform consumers)
+# -----------------------------------------------------------------------------
+# Observability is a leaf layer. Nothing reads its state. Outputs exist for
+# human use: where to log in, where the secrets live, how to rotate. No
+# sensitive values — tokens are in SSM PS, retrieved via AWS CLI per
+# Runbook 006.
+# -----------------------------------------------------------------------------
+
+output "grafana_stack_url" {
+  description = "Browser-facing URL of the Grafana Cloud stack. Human login via Google OAuth (Runbook 006 Part 3). Null when observability_enabled=false."
+  value       = local.observability_enabled ? "https://${local.grafana_cloud.org_slug}.grafana.net" : null
+}
+
+output "grafana_stack_region_slug" {
+  description = "Grafana Cloud stack region slug (e.g. prod-eu-west-3). Read-only attribute from the stack data source — useful when rotating tokens or adding a secondary Access Policy."
+  value       = try(data.grafana_cloud_stack.this[0].region_slug, null)
+}
+
+output "ssm_paths" {
+  description = "SSM PS parameter paths for the three downstream secrets. Values are NOT output (secure by location, not by masking). Retrieve with: aws ssm get-parameter --name <path> --with-decryption."
+  value = local.observability_enabled ? {
+    bootstrap_token           = "${local.ssm_path_prefix}/bootstrap-token"
+    alloy_token               = "${local.ssm_path_prefix}/alloy-token"
+    grafana_operator_token    = "${local.ssm_path_prefix}/grafana-operator-token"
+    team_webhooks_slack_aegis = "${local.ssm_path_prefix}/team-webhooks-slack-aegis"
+  } : null
+}
+
+output "grafana_admin_login_hint" {
+  description = <<-EOT
+    How to log in to the Grafana Cloud stack as a human admin:
+
+      1. Open the URL from `grafana_stack_url` output
+      2. Click "Sign in with Google"
+      3. Use the Gmail account invited during Runbook 006 Part 3 (Admin role)
+
+    Break-glass service account tokens live in SSM PS — see `ssm_paths` output.
+    Free tier does NOT support SAML; upgrade to Grafana Cloud Pro or migrate
+    to AMG when that becomes a requirement (ADR-022 §Known limitations).
+  EOT
+  value       = "See description above."
+}
+
+output "observability_enabled" {
+  description = "Whether the observability layer provisioned any resources (true when config.grafana_cloud is present, false otherwise)."
+  value       = local.observability_enabled
+}

--- a/terraform/environments/staging/observability/platform-alerts.tf
+++ b/terraform/environments/staging/observability/platform-alerts.tf
@@ -1,0 +1,200 @@
+# -----------------------------------------------------------------------------
+# Platform-owned PrometheusRule CRDs (ADR-023 §Domain split)
+# -----------------------------------------------------------------------------
+# Four alerts ship at this PR:
+#
+#   1. NodeNotReady — moved over from the deleted kube-prometheus-stack
+#      observability.tf (Session D Incident 26 context). Canonical signal
+#      for the FIS DR drill (ADR-020).
+#   2. KubernetesDeprecatedAPIUsed — moved over from the deleted chart.
+#      Change-review-discipline §3.4 requires this one.
+#   3. GrafanaOperatorReconcileFailed — meta-observability. Fires when the
+#      operator cannot reconcile its CRDs. If this alert fires during a
+#      dashboard push, the push is unreliable until the operator recovers.
+#   4. GrafanaCloudCardinalityApproaching8k — capacity guardrail. Grafana
+#      Cloud free tier caps at 10k active series; firing at 8k gives 20%
+#      headroom to diagnose and cut cardinality before ingestion throttle.
+#
+# Annotations preserved verbatim from the old kube-prometheus-stack rules
+# where applicable — operators already familiar with the summary/description
+# text don't need to relearn wording.
+#
+# Server-side evaluation: Alloy's `mimir.rules.kubernetes "default"` block
+# (staging/platform/modules/eks-cluster/alloy.tf) discovers these CRDs and
+# forwards them to Grafana Cloud Mimir ruler. Cluster control-plane loss
+# does NOT silence these alerts for metrics that are already being
+# remote_written (ADR-022 §Rule evaluation location).
+#
+# One PrometheusRule per concern (not a mega-rule with all groups) —
+# keeps diffs surgical when any single rule changes.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# 1. NodeNotReady — FIS drill signal (ADR-020)
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "rule_node_not_ready" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PrometheusRule"
+    metadata = {
+      name      = "node-not-ready"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      groups = [{
+        name = "dr-drill"
+        rules = [{
+          alert = "NodeNotReady"
+          expr  = "kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 0"
+          for   = "1m"
+          labels = {
+            severity = "warning"
+            drill    = "fis-primary-outage"
+          }
+          annotations = {
+            summary     = "Node {{ $labels.node }} is NotReady"
+            description = "Node {{ $labels.node }} has been NotReady for >1 minute. Expected during the FIS primary-outage drill (ADR-020); investigate if no drill is running."
+          }
+        }]
+      }]
+    }
+  })
+
+  depends_on = [helm_release.grafana_operator]
+}
+
+# -----------------------------------------------------------------------------
+# 2. KubernetesDeprecatedAPIUsed — change-review-discipline §3.4
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "rule_deprecated_apis" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PrometheusRule"
+    metadata = {
+      name      = "deprecated-apis"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      groups = [{
+        name = "deprecated-api-detection"
+        rules = [{
+          alert = "KubernetesDeprecatedAPIUsed"
+          expr  = "apiserver_requested_deprecated_apis > 0"
+          for   = "5m"
+          labels = {
+            severity = "warning"
+          }
+          annotations = {
+            summary     = "Deprecated Kubernetes API in use"
+            description = "The API {{ $labels.resource }}.{{ $labels.group }}/{{ $labels.version }} is deprecated. Migrate before the removal version."
+          }
+        }]
+      }]
+    }
+  })
+
+  depends_on = [helm_release.grafana_operator]
+}
+
+# -----------------------------------------------------------------------------
+# 3. GrafanaOperatorReconcileFailed — meta-observability
+# -----------------------------------------------------------------------------
+# If grafana-operator cannot reconcile, every dashboard/alert/route push
+# silently fails (ADR-023 §Known Limitations "Meta-observability"). 10-minute
+# for-duration tolerates transient Grafana Cloud API hiccups without pages.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "rule_grafana_operator_reconcile_failed" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PrometheusRule"
+    metadata = {
+      name      = "grafana-operator-reconcile-failed"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      groups = [{
+        name = "meta-observability"
+        rules = [{
+          alert = "GrafanaOperatorReconcileFailed"
+          expr  = "sum(rate(grafana_operator_reconcile_errors_total[10m])) > 0"
+          for   = "10m"
+          labels = {
+            severity = "warning"
+          }
+          annotations = {
+            summary     = "grafana-operator reconcile failing"
+            description = "grafana-operator has been emitting reconcile errors for >10 minutes. Dashboard / alert / contact point pushes to Grafana Cloud are unreliable until this clears. Check operator logs: kubectl -n observability logs deploy/grafana-operator-controller-manager."
+          }
+        }]
+      }]
+    }
+  })
+
+  depends_on = [helm_release.grafana_operator]
+}
+
+# -----------------------------------------------------------------------------
+# 4. GrafanaCloudCardinalityApproaching8k — capacity guardrail
+# -----------------------------------------------------------------------------
+# Grafana Cloud free tier: 10k active series cap, throttle-on-overage. Alert
+# at 8k (80%) to leave headroom for diagnosis (ADR-022 §Cardinality budget).
+# `grafana_cloud_active_series_total` is exposed by Grafana Cloud's usage
+# endpoint, scraped by Alloy as a self-scrape target — the Alloy config is
+# a follow-up (TODO when the self-scrape target is wired up in PR-3 or a
+# subsequent tightening). Until then this rule is defined but may evaluate
+# to `no data` — that's intentional; the rule being present + named is
+# the change, wiring the metric into scrape is the follow-up.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "rule_grafana_cloud_cardinality" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PrometheusRule"
+    metadata = {
+      name      = "grafana-cloud-cardinality"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      groups = [{
+        name = "cardinality-guardrail"
+        rules = [{
+          alert = "GrafanaCloudCardinalityApproaching8k"
+          expr  = "grafana_cloud_active_series_total > 8000"
+          for   = "10m"
+          labels = {
+            severity = "warning"
+          }
+          annotations = {
+            summary     = "Grafana Cloud active series > 8k (80% of 10k cap)"
+            description = "Grafana Cloud active series has exceeded 8,000 for 10 minutes. Throttle starts at 10k — reduce cardinality before hitting the cap. Run cardinality audit: curl Alloy /debug/prometheus/self. See ADR-022 §Cardinality for the budget allocation."
+          }
+        }]
+      }]
+    }
+  })
+
+  depends_on = [helm_release.grafana_operator]
+}

--- a/terraform/environments/staging/observability/platform-dashboards.tf
+++ b/terraform/environments/staging/observability/platform-dashboards.tf
@@ -1,0 +1,181 @@
+# -----------------------------------------------------------------------------
+# Platform-owned GrafanaDashboard CRDs (ADR-023 §Domain split)
+# -----------------------------------------------------------------------------
+# Three dashboards shipped at this PR. All carry label
+# `app.kubernetes.io/part-of: platform` so they're visually and
+# programmatically distinguishable from aegis-core's service dashboards.
+#
+# Import strategy — `grafanaCom.id` imports the published dashboard by its
+# numeric ID from grafana.com/dashboards. This is the cheapest way to ship
+# well-known dashboards (Kubernetes cluster overview, Karpenter, etc.) that
+# the community has already maintained; we own only the thin CRD wrapper,
+# not the JSON. If a dashboard needs customization, the alternative is
+# `spec.json` (inline JSON) or `spec.configMapRef` — out of scope for this
+# PR; Phase 4c+ can fork any of these dashboards into the repo if needed.
+#
+# instanceSelector matches the Grafana CRD's label contract from
+# grafana-crd.tf (dashboards=grafana). All platform dashboards bind to the
+# singleton Grafana instance in the `observability` namespace.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Kubernetes cluster overview — grafana.com dashboard 15759
+# -----------------------------------------------------------------------------
+# "Kubernetes / Views / Global" by the Grafana team. Covers: node count,
+# pod count, namespace pod breakdown, CPU/memory/network totals, per-node
+# pressure. The canonical first-look dashboard for any cluster.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "dashboard_kubernetes_overview" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "grafana.integreatly.org/v1beta1"
+    kind       = "GrafanaDashboard"
+    metadata = {
+      name      = "kubernetes-cluster-overview"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      instanceSelector = {
+        matchLabels = {
+          dashboards = "grafana"
+        }
+      }
+      # Import the community-maintained dashboard JSON by its grafana.com
+      # numeric ID. Revision pinning avoids silent content drift when the
+      # author publishes a new revision upstream.
+      grafanaCom = {
+        id       = 15759
+        revision = 37
+      }
+      resyncPeriod = "1h"
+    }
+  })
+
+  depends_on = [kubectl_manifest.grafana]
+}
+
+# -----------------------------------------------------------------------------
+# Karpenter provisioning — grafana.com dashboard 20398
+# -----------------------------------------------------------------------------
+# Karpenter's own published dashboard. Covers NodeClaim lifecycle, pending
+# pods, provisioning latency, interruption rate. Essential during the
+# FIS DR drill (ADR-020) — primary-region instances stop; this dashboard
+# shows Karpenter attempting to re-provision until the SCP deny holds.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "dashboard_karpenter" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "grafana.integreatly.org/v1beta1"
+    kind       = "GrafanaDashboard"
+    metadata = {
+      name      = "karpenter-capacity"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      instanceSelector = {
+        matchLabels = {
+          dashboards = "grafana"
+        }
+      }
+      grafanaCom = {
+        id       = 20398
+        revision = 1
+      }
+      resyncPeriod = "1h"
+    }
+  })
+
+  depends_on = [kubectl_manifest.grafana]
+}
+
+# -----------------------------------------------------------------------------
+# grafana-operator meta-observability — inline JSON
+# -----------------------------------------------------------------------------
+# Self-monitoring of the observability stack itself (ADR-023 §Known
+# Limitations: "Meta-observability is platform-owned by definition").
+# Three-panel minimal dashboard — reconcile errors, operator queue depth,
+# pod CPU/memory. No public dashboard ID for grafana-operator; inline JSON
+# is the minimum viable dashboard until the community ships one.
+#
+# The JSON is deliberately minimal. Extending it is easy (copy from the
+# Grafana UI after authoring panels manually); keeping it small here
+# reduces diff noise in this PR.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "dashboard_grafana_operator_meta" {
+  count = local.observability_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "grafana.integreatly.org/v1beta1"
+    kind       = "GrafanaDashboard"
+    metadata = {
+      name      = "grafana-operator-meta"
+      namespace = "observability"
+      labels = {
+        "app.kubernetes.io/part-of" = "platform"
+      }
+    }
+    spec = {
+      instanceSelector = {
+        matchLabels = {
+          dashboards = "grafana"
+        }
+      }
+      resyncPeriod = "1h"
+      json = jsonencode({
+        title         = "grafana-operator meta-observability"
+        schemaVersion = 39
+        refresh       = "30s"
+        time          = { from = "now-6h", to = "now" }
+        tags          = ["platform", "meta"]
+        panels = [
+          {
+            id      = 1
+            type    = "stat"
+            title   = "Reconcile errors (5m rate)"
+            gridPos = { h = 6, w = 8, x = 0, y = 0 }
+            targets = [{
+              expr         = "sum(rate(grafana_operator_reconcile_errors_total[5m]))"
+              refId        = "A"
+              legendFormat = "errors/s"
+            }]
+          },
+          {
+            id      = 2
+            type    = "timeseries"
+            title   = "Controller workqueue depth"
+            gridPos = { h = 8, w = 16, x = 8, y = 0 }
+            targets = [{
+              expr         = "workqueue_depth{job=\"grafana-operator\"}"
+              refId        = "A"
+              legendFormat = "{{name}}"
+            }]
+          },
+          {
+            id      = 3
+            type    = "timeseries"
+            title   = "Operator pod memory"
+            gridPos = { h = 8, w = 24, x = 0, y = 8 }
+            targets = [{
+              expr         = "container_memory_working_set_bytes{namespace=\"observability\",pod=~\"grafana-operator-.*\"}"
+              refId        = "A"
+              legendFormat = "{{pod}}"
+            }]
+          },
+        ]
+      })
+    }
+  })
+
+  depends_on = [kubectl_manifest.grafana]
+}

--- a/terraform/environments/staging/observability/providers.tf
+++ b/terraform/environments/staging/observability/providers.tf
@@ -1,0 +1,95 @@
+# -----------------------------------------------------------------------------
+# Providers — primary-only, no slot pattern (ADR-022 §Multi-region)
+# -----------------------------------------------------------------------------
+# Unlike staging/platform and staging/workloads, this layer targets ONLY the
+# primary cluster. grafana-operator reconciles against a single Grafana Cloud
+# stack; running it in both cluster slots would make the two reconcilers race
+# on identical CRDs. Data-plane scraping (Alloy) is in staging/platform and
+# runs in both slots — see staging/platform/modules/eks-cluster/alloy.tf.
+#
+# The kubernetes/kubectl/helm providers therefore point at the primary
+# cluster only. No `alias = "primary"` — there is no second alias to
+# distinguish from, so the default (unaliased) provider is simpler to read
+# and eliminates the `providers = {}` pass-through boilerplate used in
+# slot-patterned layers.
+#
+# Lazy-evaluation: kubernetes/kubectl/helm provider blocks reference
+# `local.clusters.primary.*` — resolved at apply time after the platform
+# remote_state data source returns. At plan time on a cold apply (platform
+# not yet applied), the check "platform_layer_applied" in config.tf surfaces
+# a readable error; provider blocks themselves do not error at plan time
+# because Terraform defers provider configuration validation until apply.
+# -----------------------------------------------------------------------------
+
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}
+
+provider "kubernetes" {
+  host                   = try(local.clusters.primary.cluster_endpoint, "")
+  cluster_ca_certificate = try(base64decode(local.clusters.primary.cluster_certificate_authority_data), "")
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", try(local.clusters.primary.cluster_name, ""), "--region", local.primary_eks_region.region]
+  }
+}
+
+provider "kubectl" {
+  host                   = try(local.clusters.primary.cluster_endpoint, "")
+  cluster_ca_certificate = try(base64decode(local.clusters.primary.cluster_certificate_authority_data), "")
+  load_config_file       = false
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", try(local.clusters.primary.cluster_name, ""), "--region", local.primary_eks_region.region]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = try(local.clusters.primary.cluster_endpoint, "")
+    cluster_ca_certificate = try(base64decode(local.clusters.primary.cluster_certificate_authority_data), "")
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", try(local.clusters.primary.cluster_name, ""), "--region", local.primary_eks_region.region]
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# grafana/grafana — cloud-level only (ADR-022 §Auth and secret chain)
+# -----------------------------------------------------------------------------
+# Single `cloud` provider instance. Authenticates with the one-time human-
+# provisioned bootstrap token from SSM PS; scope-limited to managing Cloud
+# Access Policies and stack service accounts. Used to provision the Alloy
+# access policy+token and the grafana-operator stack service account+token.
+#
+# A stack-level provider is NOT declared here because grafana-operator
+# (running inside the cluster) is what talks to the stack API day-to-day.
+# If a future use-case needs Terraform-side stack-level provisioning (e.g.
+# pre-creating a Grafana folder structure), declare a `stack` alias then.
+# Declaring it unused today would trigger a validation warning and pin a
+# token reference that may not exist on a fresh apply.
+#
+# Dummy credentials when observability_enabled=false: Terraform evaluates
+# provider config at init. The bootstrap_token data source is count-gated
+# so on a disabled layer Terraform never dereferences the SSM PS value,
+# but the provider block itself must evaluate to something.
+# -----------------------------------------------------------------------------
+
+provider "grafana" {
+  alias = "cloud"
+
+  cloud_access_policy_token = try(data.aws_ssm_parameter.bootstrap_token[0].value, "unset")
+}

--- a/terraform/environments/staging/observability/tokens.tf
+++ b/terraform/environments/staging/observability/tokens.tf
@@ -1,0 +1,195 @@
+# -----------------------------------------------------------------------------
+# Grafana Cloud downstream tokens + SSM PS writeback (ADR-022)
+# -----------------------------------------------------------------------------
+# Three chains in this file:
+#
+#   1. Alloy — Cloud Access Policy (metrics:write, logs:write) scoped to this
+#      stack's realm only, plus a token with 90-day expiry. Token value is
+#      written to SSM PS for External Secrets Operator to sync into K8s.
+#
+#   2. grafana-operator — stack-level Service Account with Admin role, plus
+#      a token with 90-day expiry. Stack Admin is required because
+#      grafana-operator reconciles dashboards, contact points, notification
+#      policies across the stack (ADR-023 §Decision — platform ownership of
+#      the Grafana CRD). Token value written to SSM PS.
+#
+#   3. team-webhooks-slack-aegis — a placeholder SSM PS parameter. Terraform
+#      creates the parameter with a dummy value; the operator fills the real
+#      Slack webhook URL out-of-band via AWS CLI. `lifecycle.ignore_changes`
+#      on `value` prevents Terraform from clobbering the operator-supplied
+#      secret on subsequent applies. This fulfills ldz #126 Coordination
+#      Point 1 for aegis-core (key exists in `team-webhooks` Secret by the
+#      time aegis-core's GrafanaContactPoint CRD arrives).
+#
+# Why two different resource families for the two tokens:
+#   - Alloy needs a stack-realm Cloud Access Policy — metrics/logs push
+#     credentials live at the Cloud (org) API layer, not inside the stack.
+#   - grafana-operator needs a stack Service Account — the Grafana API it
+#     talks to (dashboards, alerting) is per-stack and authenticated by an
+#     SA token minted inside the stack.
+# Both are provisioned via the `cloud`-aliased grafana/grafana provider
+# using the one-time bootstrap token in SSM PS.
+#
+# Token lifecycle: 90-day expiry per Runbook 006 §Token rotation. Rotation
+# is a Terraform operation — edit `seconds_to_live` / `expires_at`, apply,
+# External Secrets picks up the new values within its refresh interval.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Stack lookup — resolves the stack's region_slug for access-policy realm
+# -----------------------------------------------------------------------------
+# grafana_cloud_access_policy.realm needs the stack identifier. We look up
+# the stack by its slug (from config.grafana_cloud.org_slug) so the realm
+# entry is construction-safe against region drift (the stack's region is
+# locked at creation and cannot change, but making the relationship data-
+# sourced keeps the resource schema honest).
+# -----------------------------------------------------------------------------
+
+data "grafana_cloud_stack" "this" {
+  count = local.observability_enabled ? 1 : 0
+
+  provider = grafana.cloud
+
+  slug = local.grafana_cloud.org_slug
+}
+
+# -----------------------------------------------------------------------------
+# Alloy — Cloud Access Policy + token
+# -----------------------------------------------------------------------------
+
+resource "grafana_cloud_access_policy" "alloy" {
+  count = local.observability_enabled ? 1 : 0
+
+  provider = grafana.cloud
+
+  region       = data.grafana_cloud_stack.this[0].region_slug
+  name         = "aegis-staging-alloy"
+  display_name = "Alloy — metrics and logs push from aegis-staging clusters"
+
+  scopes = ["metrics:write", "logs:write"]
+
+  realm {
+    type       = "stack"
+    identifier = data.grafana_cloud_stack.this[0].id
+  }
+}
+
+resource "grafana_cloud_access_policy_token" "alloy" {
+  count = local.observability_enabled ? 1 : 0
+
+  provider = grafana.cloud
+
+  region           = data.grafana_cloud_stack.this[0].region_slug
+  access_policy_id = grafana_cloud_access_policy.alloy[0].policy_id
+  name             = "aegis-staging-alloy"
+  display_name     = "Alloy 90-day rotating token"
+  # 90-day expiry per Runbook 006 §Token rotation. Bump this timestamp on
+  # rotation — new token value materialises and SSM PS updates in-place.
+  expires_at = "2026-07-20T00:00:00Z"
+}
+
+# -----------------------------------------------------------------------------
+# grafana-operator — Stack Service Account + token
+# -----------------------------------------------------------------------------
+
+resource "grafana_cloud_stack_service_account" "grafana_operator" {
+  count = local.observability_enabled ? 1 : 0
+
+  provider = grafana.cloud
+
+  stack_slug = local.grafana_cloud.org_slug
+  name       = "grafana-operator"
+  role       = "Admin"
+}
+
+resource "grafana_cloud_stack_service_account_token" "grafana_operator" {
+  count = local.observability_enabled ? 1 : 0
+
+  provider = grafana.cloud
+
+  stack_slug         = local.grafana_cloud.org_slug
+  service_account_id = grafana_cloud_stack_service_account.grafana_operator[0].id
+  name               = "grafana-operator-terraform"
+  # 90 days = 7,776,000 seconds. Matches Alloy's rotation cadence.
+  seconds_to_live = 7776000
+}
+
+# -----------------------------------------------------------------------------
+# SSM PS writeback — downstream tokens
+# -----------------------------------------------------------------------------
+# Each token is stored as a SecureString encrypted with the shared secrets
+# CMK (alias/aegis-staging-secrets). External Secrets Operator (installed in
+# staging/platform) reads these parameters via the aegis-ssm
+# ClusterSecretStore and reconciles them into K8s Secrets on each cluster.
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "alloy_token" {
+  count = local.observability_enabled ? 1 : 0
+
+  name        = "${local.ssm_path_prefix}/alloy-token"
+  description = "Grafana Cloud Alloy remote_write token. Provisioned by terraform/environments/staging/observability/; consumed by ExternalSecret → K8s Secret `alloy-token` in ns `monitoring`, mounted as env GRAFANA_CLOUD_TOKEN by the Alloy Deployment (staging/platform)."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  value       = grafana_cloud_access_policy_token.alloy[0].token
+
+  tags = merge(local.tags, {
+    Name = "grafana-cloud-alloy-token"
+  })
+}
+
+resource "aws_ssm_parameter" "grafana_operator_token" {
+  count = local.observability_enabled ? 1 : 0
+
+  name        = "${local.ssm_path_prefix}/grafana-operator-token"
+  description = "Grafana Cloud stack Service Account token (Admin role). Provisioned by terraform/environments/staging/observability/; consumed by ExternalSecret → K8s Secret `grafana-operator-token` in ns `observability`, referenced by the Grafana CRD's spec.external.apiKey."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  value       = grafana_cloud_stack_service_account_token.grafana_operator[0].key
+
+  tags = merge(local.tags, {
+    Name = "grafana-cloud-grafana-operator-token"
+  })
+}
+
+# -----------------------------------------------------------------------------
+# team-webhooks-slack-aegis — placeholder for aegis-core (ldz #126 CP1)
+# -----------------------------------------------------------------------------
+# Fulfills the pre-provisioning contract agreed in ldz #126: the SSM PS key
+# `/aegis/staging/grafana-cloud/team-webhooks-slack-aegis` exists with a
+# valid (if placeholder) value by the time aegis-core's ArgoCD app starts
+# reconciling GrafanaContactPoint. Without this key, grafana-operator's
+# Secret-not-found loop stalls silently — exactly the failure mode #126 was
+# opened to prevent.
+#
+# Operator fills the real Slack webhook URL via AWS CLI:
+#
+#   aws ssm put-parameter \
+#     --region eu-central-1 \
+#     --name /aegis/staging/grafana-cloud/team-webhooks-slack-aegis \
+#     --type SecureString --key-id alias/aegis-staging-secrets \
+#     --value 'https://hooks.slack.com/services/T.../B.../...' \
+#     --overwrite
+#
+# lifecycle.ignore_changes = [value] prevents subsequent `terraform apply`
+# from clobbering the operator-supplied value back to the placeholder.
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "team_webhooks_slack_aegis" {
+  count = local.observability_enabled ? 1 : 0
+
+  name        = "${local.ssm_path_prefix}/team-webhooks-slack-aegis"
+  description = "Slack webhook URL for aegis team notifications. Operator-managed value; Terraform creates the SecureString shell only. Consumed by ExternalSecret → K8s Secret `team-webhooks` (key `slack-aegis`) in ns `aegis`, referenced by aegis-core's GrafanaContactPoint CRD (ldz #126)."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  # Placeholder value. The real webhook URL is put-parameter'd by the
+  # operator out-of-band; Terraform never sees or touches it after create.
+  value = "placeholder-operator-must-overwrite"
+
+  tags = merge(local.tags, {
+    Name = "grafana-cloud-team-webhooks-slack-aegis"
+  })
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/environments/staging/observability/tokens.tf
+++ b/terraform/environments/staging/observability/tokens.tf
@@ -50,7 +50,7 @@ data "grafana_cloud_stack" "this" {
 
   provider = grafana.cloud
 
-  slug = local.grafana_cloud.org_slug
+  slug = try(local.grafana_cloud.org_slug, "")
 }
 
 # -----------------------------------------------------------------------------
@@ -97,7 +97,7 @@ resource "grafana_cloud_stack_service_account" "grafana_operator" {
 
   provider = grafana.cloud
 
-  stack_slug = local.grafana_cloud.org_slug
+  stack_slug = try(local.grafana_cloud.org_slug, "")
   name       = "grafana-operator"
   role       = "Admin"
 }
@@ -107,7 +107,7 @@ resource "grafana_cloud_stack_service_account_token" "grafana_operator" {
 
   provider = grafana.cloud
 
-  stack_slug         = local.grafana_cloud.org_slug
+  stack_slug         = try(local.grafana_cloud.org_slug, "")
   service_account_id = grafana_cloud_stack_service_account.grafana_operator[0].id
   name               = "grafana-operator-terraform"
   # 90 days = 7,776,000 seconds. Matches Alloy's rotation cadence.

--- a/terraform/environments/staging/observability/versions.tf
+++ b/terraform/environments/staging/observability/versions.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+    # kubectl provider for Grafana* CRDs + ExternalSecret CRDs — deferred
+    # plan-time schema validation avoids the bootstrap trap where
+    # kubernetes_manifest requires the CRD to be reachable at plan time.
+    # See staging/platform for the same rationale (Incident 10).
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.19"
+    }
+    # helm installs grafana-operator (primary-only, ADR-022 §Multi-region).
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17"
+    }
+    # grafana/grafana provider — ADR-022 §Auth and secret chain. Provisions
+    # the Cloud Access Policy + tokens (for Alloy) and the stack-level
+    # service account + token (for grafana-operator) from the one-time
+    # human-created bootstrap token. v4.x line — pin the minor to catch
+    # obvious resource-schema breakage via Dependabot review.
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 4.31"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Second of 4 PRs implementing ADR-022 observability reversal. Adds a **new peer Terraservice layer** at `terraform/environments/staging/observability/` that provisions Grafana Cloud downstream identities via Terraform, installs `grafana-operator` on the primary cluster only, and ships the platform-owned `Grafana` / `GrafanaNotificationPolicy` / `GrafanaDashboard` / `PrometheusRule` CRDs.

### What lands here

**TF layer** (13 new files in `staging/observability/`):
- `backend.tf` / `versions.tf` / `providers.tf` / `config.tf` — skeleton, `grafana/grafana ~> 4.31` added, primary-only providers (no slot pattern — ADR-022 §Multi-region)
- `tokens.tf` — `grafana_cloud_access_policy` + token for Alloy (scopes: `metrics:write`, `logs:write`) + `grafana_cloud_stack_service_account` + token for grafana-operator (Admin) + 3 `aws_ssm_parameter` SecureString resources + team-webhooks-slack-aegis placeholder with `lifecycle.ignore_changes = [value]`
- `external-secrets.tf` — 3 `ExternalSecret` CRDs (alloy-token, grafana-operator-token, team-webhooks) referencing the `aegis-ssm` ClusterSecretStore from PR-1
- `namespace.tf` — `observability` namespace (PSS restricted)
- `grafana-operator.tf` — helm_release for `ghcr.io/grafana/helm-charts/grafana-operator 5.22.2`, primary-cluster-only, `wait=true` so CRDs register before downstream manifests
- `grafana-crd.tf` — `Grafana` CRD pointing at the GC stack via `spec.external.apiKey` + root `GrafanaNotificationPolicy` (catch-all receiver `platform-default`, leaf-attach via `tree=aegis-root` label selector)
- `platform-dashboards.tf` — 3 `GrafanaDashboard` CRDs (K8s overview 15759, Karpenter 20398, grafana-operator meta inline)
- `platform-alerts.tf` — 4 `PrometheusRule` CRDs: NodeNotReady (Inc 29), KubernetesDeprecatedAPIUsed, GrafanaOperatorReconcileFailed, GrafanaCloudCardinalityApproaching8k

**CI wiring**:
- `.github/workflows/terraform-plan.yml` — `staging/observability` added to Plan matrix
- `.github/workflows/terraform-apply-workload.yml` — new `apply-observability` job ordered AFTER `apply-workloads` (team-webhooks ExternalSecret targets `aegis` ns, created by workloads layer)

### Gating

Everything is behind `local.observability_enabled = try(local.config.grafana_cloud, null) != null`. CI Plan with a config that has no `grafana_cloud:` block shows zero resources. Data sources (`aws_kms_alias.secrets`, `aws_ssm_parameter.bootstrap_token`) are count-gated so they're only evaluated when enabled.

## Closes

- **Closes https://github.com/BinHsu/aegis-aws-landing-zone/issues/126** — Coordination Point 1 (team-webhooks-slack-aegis SSM PS key pre-provisioning) from aegis-core #46 ACK. Placeholder value on create; operator fills real Slack webhook URL via CLI; Terraform ignores subsequent value changes.

## 5-step change-review-discipline checklist

1. **Blast radius**: new peer Terraservice layer, new CI matrix row, new CI apply job. Config-gated — omitting `grafana_cloud` leaves everything at zero resources. Observability layer's own state file in S3; no impact on existing platform/workloads/network state.
2. **Dependency assumptions**: apply order `network → platform → workloads → observability` (see config.tf check blocks). Bootstrap-token in SSM PS must exist (Runbook 006 Part 2, human CLI step) before `terraform apply` in this layer — intended operator-facing error surface if skipped.
3. **Deprecation status** (upstream upgrade guides consulted):
   - `grafana/grafana` provider `~> 4.31` — current v4 line (v4.31.3 released 2026-04-16); v3 deprecated resource renames forced the bump from original `~> 3.x` brief
   - `grafana-operator` chart `v5.22.2` — current stable line, released 2025-03-17 per GH releases
   - Other providers unchanged from staging/platform's versions.tf
4. **Rollback plan**: `git revert`. TF destroy cleanly removes grafana-operator helm_release + all CRDs + SSM PS parameters. Grafana Cloud tokens persist on GC side (manual delete via portal if needed — documented in Runbook 006 §Stack teardown). bootstrap-token SSM PS value untouched (we don't own it, only read it).
5. **2 AM readability**: every file has a preamble explaining *why* that file exists, what cross-layer contracts it satisfies, and what the naming/label values mean. Cross-references to ADR-022 / ADR-023 / Runbook 006 / PR-1 contract points.

## Cross-repo

- **aegis-core #46** — CP1 (secret pre-provisioning) fulfilled via #126 closure above. CP2 (namespace layout) ACK'd earlier today — Grafana CRD lives in `observability` ns with cluster-wide `instanceSelector`. CP3 their side.
- **aegis-core #58** — LAN smoke still outstanding. Not blocking this PR merge; still gates cold-apply.

## Merge ordering

Merge after PR-1 (#127) — this layer's `data.aws_kms_alias.secrets` (count-gated) needs PR-1's bootstrap-layer KMS key to exist in AWS at apply time. CI Plan against current config (no `grafana_cloud` block) shows zero resources either way, so CI passes independently.

## Not in this PR

- **PR-3** — `staging/workloads` removes kube-prometheus-stack + adds explicit ServiceMonitor CRDs for cert-manager + argo-rollouts
- **PR-4** — `terraform-teardown-workload.yml` CRD pre-delete stage + layer teardown order update

## Not applied this session

Per `project_cold_apply_deferred_to_big_bang.md`, no cold-apply until all 3 gates close (ADR-022 impl merged; aegis-core images ready ✅; aegis-core LAN smoke ⏳). This PR is code-only.

## Test plan

- [ ] Checkov passes
- [ ] Plan `staging/observability` passes in CI with current (no-grafana_cloud) config (shows zero resources)
- [ ] Plan other layers unchanged
- [ ] `validate-config.py` continues to accept example.yaml (unchanged in this PR)
- [ ] Cold-apply deferred to future session

🤖 Generated with [Claude Code](https://claude.com/claude-code)