### PR TITLE
docs(runbooks): add Runbook 007 Qdrant Cloud + fix Runbook 006 break-glass trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ Some Terraservices layers have their own operational contracts — pre-flight ch
   - `docs/runbooks/003-platform-first-verification.md` — end-to-end checklist after `staging/platform` applies; links to Incidents 10–17 for cold-apply gotchas (MUST follow for any fresh apply of the platform layer)
   - `docs/runbooks/004-dns-delegation-cloudflare-to-route53.md` — Cloudflare-side subdomain NS delegation to a Route53 hosted zone; one-time setup + rollback + troubleshooting (MUST read when provisioning `staging/edge/` or any future env's edge Terraservice)
   - `docs/runbooks/005-fis-dr-drill.md` — FIS DR drill execution (ADR-020); pre-flight checks, experiment start/observe/recover, troubleshooting (MUST read before `aws fis start-experiment` against any env)
+  - `docs/runbooks/006-grafana-cloud-onboarding.md` — Grafana Cloud free tier signup, bootstrap/downstream token rotation, scope-isolation verification (MUST read when provisioning a fresh stack, rotating any token, or migrating regions)
+  - `docs/runbooks/007-qdrant-cloud-onboarding.md` — Qdrant Cloud free tier signup, API key rotation, manual SSM PS credential stash ahead of TF scaffolding per ADR-025 (MUST read when provisioning a fresh cluster or rotating the API key)
 
 - **Rule: When adding a new layer whose operations require their own diagnostic order (e.g., observability, service mesh), add a runbook under `docs/runbooks/` rather than extending this file.** Keeping CLAUDE.md small preserves its discoverability; layer-specific details belong with the layer.
 

--- a/docs/interview-notes.md
+++ b/docs/interview-notes.md
@@ -95,13 +95,13 @@ Each entry: what was built → where to look in the repo → the kind of questio
 **Built**: three layers of operational writing with explicit rules in [`CLAUDE.md`](../CLAUDE.md):
 - **ADRs** — 25 in [`docs/decisions/`](decisions/), supersede-in-place style ("Design iteration" sections note evolution; ADR-018 §3 has an in-place amendment demonstrating the pattern; ADR-015 superseded by ADR-022 demonstrates the supersede-with-history pattern)
 - **Incidents** — 32 in [`docs/incidents.md`](incidents.md), append-only, standard format
-- **Runbooks** — 6 in [`docs/runbooks/`](runbooks/); CLAUDE.md rule requires AI agents to read the layer's runbook before operating on it
+- **Runbooks** — 7 in [`docs/runbooks/`](runbooks/); CLAUDE.md rule requires AI agents to read the layer's runbook before operating on it
 
 **Where to look**:
 - [`CLAUDE.md`](../CLAUDE.md) — 6 explicit "Rule: AI must..." clauses
 - [`docs/decisions/`](decisions/) — 25 ADRs
 - [`docs/incidents.md`](incidents.md) — 32 postmortems
-- [`docs/runbooks/`](runbooks/) — 6 runbooks
+- [`docs/runbooks/`](runbooks/) — 7 runbooks
 - [`docs/principles/`](principles/) — 2 cross-cutting discipline docs (change-review, break-glass-apply)
 
 **Likely questions**: show me a real incident (pick from the 32 in `docs/incidents.md` — Incidents 6, 7, 12, 18, 22, 24, 25, 26 cover the widest angle: CMK recovery, hidden cross-account prerequisites, honest design reversal, asymmetric IAM policy, belt-and-suspenders teardown architecture, Terraform concurrency edge cases, service-specific resource-policy quirks, and ArgoCD-managed-CRD bootstrap race); what does the ADR format give you that code comments don't (ADRs preserve *why* even when *what* is obvious from code); how do you keep this discipline consistent (CLAUDE.md rules + pre-commit hooks + AI reminders — not willpower).

--- a/docs/runbooks/006-grafana-cloud-onboarding.md
+++ b/docs/runbooks/006-grafana-cloud-onboarding.md
@@ -32,10 +32,12 @@ Related: [ADR-022](../decisions/022-observability-backend-grafana-cloud.md) (bac
 4. Create stack:
    - Stack URL slug: `aegis-staging` (must match `config/landing-zone.yaml` `grafana_cloud.org_slug`)
    - Region: `eu-central` (Frankfurt) — **REGION IS LOCKED once set**; changing requires a new stack and full re-ingest
-5. Record stack endpoints (needed later):
+5. Record stack endpoints (needed later). Find them under Portal → Stacks → your stack → Details:
    - Grafana URL: `https://<slug>.grafana.net`
-   - Mimir URL: `https://prometheus-prod-<N>-eu-west-<N>.grafana.net/api/prom`
+   - Mimir URL: `https://prometheus-prod-<N>-<mimir-region>-<N>.grafana.net/api/prom`
    - Loki URL: (informational; not yet used)
+
+   Note: the Mimir backend region (`<mimir-region>`, e.g. `eu-west`) can differ from the stack region (`eu-central`) selected in step 4 — this is historical Grafana Cloud behavior where Mimir/Loki/Tempo backends are provisioned on their own regional fleets and are not strictly co-located with the Grafana front-end. Both `<N>` placeholders are auto-assigned during stack creation and are visible in the Details page. Do NOT guess these — copy them verbatim.
 
 ---
 
@@ -97,32 +99,37 @@ If SAML SSO (AWS IAM Identity Center integration) is needed: upgrade to Grafana 
 
 ---
 
-## Part 4 — Terraform provisions downstream tokens
+## Part 4 — Terraform provisions downstream tokens (via CI)
 
-Once the bootstrap token is in SSM PS, Terraform takes over. No further manual token creation.
+Once the bootstrap token is in SSM PS, Terraform takes over. No further manual token creation. Apply goes through the CI workflow — **do NOT run `terraform apply` locally**. Local apply is break-glass only (see [`docs/principles/break-glass-apply.md`](../principles/break-glass-apply.md)); the standard path is the dispatched workflow, which assumes the GitHub OIDC role and records an audit trail.
+
+Per PR #128, the `apply-observability` job in `.github/workflows/terraform-apply-workload.yml` applies the observability layer as the last stage of the standard cold-apply pipeline:
 
 ```bash
-cd terraform/environments/staging/observability
-terraform init
-terraform apply
+gh workflow run terraform-apply-workload.yml -f env=staging
+gh run watch   # approve when GitHub prompts
 ```
 
-This creates (via the `grafana/grafana` Terraform provider):
+If you want to smoke the observability layer in isolation (e.g. right after creating the bootstrap token, before a full workload cycle), re-run the same command — the earlier layers (`apply-network`, `apply-platform`, `apply-workloads`) are idempotent and the observability layer is gated on `observability_enabled` in config, so applying with no `grafana_cloud` block in `config/landing-zone.yaml` plans to zero resources.
+
+On success, the `apply-observability` job creates (via the `grafana/grafana` Terraform provider):
 
 - Cloud Access Policy `aegis-staging-alloy` (scopes: `metrics:write`, `logs:write`) → token stored at `/aegis/staging/grafana-cloud/alloy-token`
 - Grafana Service Account `grafana-operator` (role: Admin) → token stored at `/aegis/staging/grafana-cloud/grafana-operator-token`
 
-If Terraform fails at the `grafana_*` resources:
+If the `apply-observability` job fails at the `grafana_*` resources:
 
 - Check the bootstrap token has not expired (30-day limit)
 - Check scope completeness (see Part 2 step 2)
-- Re-run after fixing
+- Re-dispatch the workflow after fixing
 
 ---
 
 ## Part 5 — Verify scope isolation
 
 One-time sanity check that tokens are scope-limited as intended.
+
+**Before running the curl commands below**, find your stack slug and Mimir URL from Grafana Cloud Portal → Stacks → your stack → Details. Substitute them into the `<stack-slug>` and `<N>` placeholders (the two `<N>` values in the Mimir URL are both auto-assigned by Grafana Cloud and differ from the stack region; see Part 1 step 5).
 
 Alloy token should NOT work on Grafana admin API:
 

--- a/docs/runbooks/007-qdrant-cloud-onboarding.md
+++ b/docs/runbooks/007-qdrant-cloud-onboarding.md
@@ -1,0 +1,218 @@
+<!-- session-close-review: when lab operator needs a fresh Qdrant Cloud cluster, rotates the API key, or the aegis-core Secret-contract cross-repo issue arrives and platform wiring moves from manual SSM PS puts to Terraform-managed resources -->
+# 007. Qdrant Cloud free tier — onboarding and credential rotation
+
+> **When to read this**: you are doing a first-time Qdrant Cloud signup for this lab, rotating the cluster's API key, or migrating to a new Qdrant Cloud cluster. This is NOT a per-session runbook — the Qdrant Cloud cluster is a persistent SaaS resource, not a per-session workload. Reading in full takes <5 minutes.
+
+## When to use
+
+- First-time signup for this lab (Bin or any forker)
+- API key rotation (every 90 days, mirroring Grafana Cloud downstream token cadence)
+- Migrating to a new Qdrant Cloud cluster (region change, account change, corpus re-ingest)
+
+Related: [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) (backend decision), [ADR-023](../decisions/023-observability-responsibility-model.md) (External Secrets + SSM PS pattern reused here), [Runbook 006](006-grafana-cloud-onboarding.md) (sibling SaaS onboarding — Grafana Cloud uses the same credential-plumbing shape).
+
+---
+
+## Pre-flight
+
+- AWS CLI + AWS SSO login to `aegis-staging` active (`aws sso login --sso-session aegis`; `export AWS_PROFILE=aegis-staging-admin`)
+- Browser with Gmail / GitHub available (account root will be bound to one of these)
+- 20–30 minutes for first-time setup; 10 minutes for rotation
+- No payment method required for free tier
+- Do NOT attach a credit card — keeps overage behavior on ingest-throttle, not auto-upgrade. Same free-tier discipline as Runbook 006.
+- GDPR caveat acknowledged: free tier cluster placement is effectively US-region on Qdrant Cloud today. The lab's corpus is non-PII Taiwan documentation by design (see [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §GDPR region caveat). If your scope ever expands beyond the non-PII corpus, migrate to the paid tier's `eu-central-1` selector before ingesting.
+
+---
+
+## Part 1 — Sign up and create cluster
+
+1. Navigate to `https://cloud.qdrant.io/signup`
+2. Sign up with Gmail or GitHub OAuth. Note: this account is the org root and is difficult to change later. Lab uses `pcpunkhades@gmail.com`.
+3. Accept any Terms / DPA prompts — free tier runs on Qdrant Labs' managed infrastructure; no additional contract is required.
+4. Navigate to the Cloud Dashboard → **Clusters** → click **+ Create**
+5. Create cluster:
+   - Tier: **Free**
+   - Cloud provider: **AWS** (Qdrant Cloud also offers GCP and Azure; AWS aligns with the lab's existing posture)
+   - Region: the **free tier offers a limited set of regions** (see [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §GDPR region caveat — EU regions may not be offered on free tier; a US region is expected). Pick the closest option available; do NOT upgrade to paid purely for region choice unless the corpus scope has changed to include PII.
+   - Cluster name: `aegis-staging-vectors` (or your preferred name — this is not load-bearing; the engine reads the URL from SSM PS, not the cluster name)
+6. Click **Create**. Cluster provisioning takes ~1–2 minutes.
+7. Once the cluster shows as `Healthy` in the Clusters menu, click into it to see the **Cluster Detail** page.
+
+**Free tier resource envelope** (confirm on the Qdrant Cloud pricing page at onboarding time — terms are subject to change): 0.5 vCPU, 1 GB RAM, 4 GB disk, single-node cluster. Sufficient for the lab's bounded Taiwan corpus per ADR-025.
+
+---
+
+## Part 2 — Capture credentials
+
+From the **Cluster Detail** page, record two pieces of information:
+
+1. **Cluster endpoint URL** — shown as a hostname like `<cluster-id>.<region>.<provider>.cloud.qdrant.io`. The cluster speaks REST on port **6333** and gRPC on port **6334** (both reachable on the same hostname). The engine (`engine_cpp/src/vectordb/qdrant_client.cc`) uses **gRPC on 6334** — confirm this in the engine's `ConfigFromEnv()` path before committing the URL to SSM PS.
+
+2. **API key** — Qdrant Cloud does not auto-generate a key on cluster creation; you must create one explicitly.
+
+   Navigation: **Cluster Detail page → API Keys tab → + Create** (exact path confirmed against the current Qdrant Cloud docs; UI may minor-version drift).
+
+   Settings:
+   - Name: `engine-<YYYYMMDD>`
+   - Expiration: **90 days** (mirrors the Grafana Cloud downstream token rotation cadence in Runbook 006)
+   - Permission level: **manage/write** (default). The engine needs write permission to ingest via `engine seed --target=cloud`; read-only would block ingestion.
+   - Collections scope: leave unrestricted for now (single-workload cluster). If multi-collection isolation becomes a requirement, scope per-collection later.
+
+3. Click **Create**. **COPY THE API KEY** — shown only once. Qdrant Cloud does not let you retrieve it later; a lost key means creating a new one and re-puttting to SSM PS.
+
+Auth header for later verification: Qdrant Cloud accepts **both** `api-key: <key>` header and `Authorization: Bearer <key>` header. The engine uses whichever its client library defaults to; for the curl test in Part 4, either format works.
+
+---
+
+## Part 3 — Stash credentials in SSM Parameter Store (manual, pre-Terraform)
+
+**IMPORTANT**: per [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §"Landing-zone implementation is deferred pending aegis-core Secret-contract issue", this repo has intentionally NOT yet shipped Terraform `aws_ssm_parameter` resources for the Qdrant Cloud credentials. The Secret shape (key names, env-var mappings, extra config like collection name / embedding dimension / distance metric) is aegis-core's call and will arrive as a cross-repo issue.
+
+Until that issue lands and the corresponding platform PR merges, you must manually put the two parameters to SSM PS. Both parameters live under the `/aegis/staging/qdrant-cloud/` prefix (the `qdrant-cloud` prefix names the managed product, matching the `grafana-cloud` convention in Runbook 006).
+
+```bash
+# Cluster URL (not a secret in the strictest sense, but kept as SecureString
+# to avoid mixing parameter tiers in the same namespace)
+AWS_PROFILE=aegis-staging-admin aws ssm put-parameter \
+  --region eu-central-1 \
+  --name /aegis/staging/qdrant-cloud/cluster-url \
+  --type SecureString \
+  --key-id alias/aegis-staging-secrets \
+  --value '<cluster URL from Part 2 step 1, including scheme + port, e.g. https://xyz.us-east-1.aws.cloud.qdrant.io:6334>'
+
+# API key
+AWS_PROFILE=aegis-staging-admin aws ssm put-parameter \
+  --region eu-central-1 \
+  --name /aegis/staging/qdrant-cloud/api-key \
+  --type SecureString \
+  --key-id alias/aegis-staging-secrets \
+  --value '<API key from Part 2 step 3>'
+```
+
+Both parameters use the same CMK alias (`alias/aegis-staging-secrets`) as the Grafana Cloud secrets, for consistency with the existing External Secrets Operator IAM policy pattern.
+
+Verify both parameters are readable:
+
+```bash
+aws ssm get-parameter \
+  --name /aegis/staging/qdrant-cloud/cluster-url \
+  --with-decryption --query 'Parameter.Value' --output text
+```
+
+---
+
+## Part 4 — Verify credential reachability
+
+Before considering the onboarding done, prove the cluster is reachable with the API key. Use the REST endpoint on port 6333 for a simple health check (gRPC on 6334 is what the engine actually uses, but REST is easier for a shell-based smoke test — if REST auth works, gRPC auth with the same key will also work).
+
+```bash
+# Pull the URL from SSM PS, then curl /collections
+CLUSTER_URL=$(aws ssm get-parameter \
+  --name /aegis/staging/qdrant-cloud/cluster-url \
+  --with-decryption --query 'Parameter.Value' --output text)
+API_KEY=$(aws ssm get-parameter \
+  --name /aegis/staging/qdrant-cloud/api-key \
+  --with-decryption --query 'Parameter.Value' --output text)
+
+# Replace the port with 6333 for REST if cluster-url is the :6334 gRPC form
+REST_URL="${CLUSTER_URL/:6334/:6333}"
+
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -H "api-key: ${API_KEY}" \
+  "${REST_URL}/collections"
+# Expected: 200 (empty collections list is fine — cluster is reachable and authz passed)
+```
+
+If 200, the credential chain is sound end-to-end. If not, see Troubleshooting.
+
+---
+
+## Part 5 — Future state: when TF scaffolding lands
+
+When aegis-core files the cross-repo Secret-contract issue and the corresponding platform PR merges, three things change:
+
+1. **Terraform takes over the SSM PS parameters**. Two `aws_ssm_parameter` SecureString resources (at `/aegis/<env>/qdrant-cloud/cluster-url` and `/aegis/<env>/qdrant-cloud/api-key`) land in either `staging/observability/tokens.tf` (extension) or a new `staging/workloads/qdrant.tf`, matching the placeholder-value + `lifecycle.ignore_changes = [value]` pattern already used for `team-webhooks-slack-aegis`. This means the operator-created values **persist** — Terraform will not overwrite them on first plan, because the `ignore_changes` block treats the live value as authoritative.
+
+   On the first apply after the TF resources land, double-check `terraform plan` output shows **no destructive change** to the parameter's value. If it does, stop and investigate — the `lifecycle.ignore_changes` block is likely missing or misconfigured.
+
+2. **ExternalSecret manifest is added** to the `aegis` namespace. It reconciles `qdrant-credentials` K8s Secret from the two SSM PS parameters on the External Secrets refresh interval (default 1 hour).
+
+3. **Engine Deployment env-vars are wired** (in aegis-core, not here). `QDRANT_URL` and `QDRANT_API_KEY` become `envFrom` / `valueFrom: secretKeyRef` pulls of the reconciled Secret. Pod restart (or a `kubectl rollout restart deployment engine`) is what picks up a rotated key — until the Deployment wiring exists, rotation is purely a manual SSM re-put.
+
+See [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §"Platform work triggered on its arrival" for the full trigger list.
+
+---
+
+## Credential rotation
+
+### API key — every 90 days
+
+Until the TF scaffolding in Part 5 lands, rotation is manual:
+
+1. Qdrant Cloud Portal → Cluster Detail → API Keys → **+ Create** a new key (name `engine-<YYYYMMDD>`, expiration 90 days, manage/write)
+2. **COPY the new key** — shown only once
+3. Overwrite the SSM parameter:
+
+```bash
+AWS_PROFILE=aegis-staging-admin aws ssm put-parameter \
+  --region eu-central-1 \
+  --name /aegis/staging/qdrant-cloud/api-key \
+  --type SecureString \
+  --key-id alias/aegis-staging-secrets \
+  --overwrite \
+  --value '<new key>'
+```
+
+4. **If the engine Deployment is running**: trigger a reload — either wait for External Secrets' refresh interval (≤1 hour) and then `kubectl rollout restart deployment engine -n aegis`, or force-refresh the ExternalSecret with `kubectl annotate externalsecret qdrant-credentials -n aegis force-sync=$(date +%s) --overwrite` and then restart the Deployment.
+
+   Note: before the TF scaffolding and ExternalSecret land, there is no reload path — there is no live engine pod consuming the key yet. Rotation stops at the SSM PS overwrite.
+
+5. Qdrant Cloud Portal → Cluster Detail → API Keys → delete the **old** key. Confirm traffic has not degraded (pull a fresh `curl /collections` with the new key via Part 4).
+
+6. Reset calendar reminder for 90 days.
+
+### Cluster URL — rotates only on cluster re-creation
+
+The URL is stable for the lifetime of a cluster. It changes only on cluster recreation (region migration, account migration). Treat cluster recreation as a full onboarding — return to Part 1.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `curl /collections` returns `401 Unauthorized` | API key wrong, expired, or sent under the wrong header | Confirm key matches what's in SSM PS (`aws ssm get-parameter ... --with-decryption`); confirm header is `api-key: <key>` or `Authorization: Bearer <key>`; if key recently rotated, confirm old key was not re-put by mistake |
+| `curl /collections` returns `404 Not Found` | Wrong port (6333 vs 6334) or URL missing scheme | The REST endpoint is 6333, gRPC is 6334. curl over HTTPS needs an explicit `https://`. Check `$REST_URL` expansion |
+| `curl /collections` returns `403 Forbidden` | API key permission level is read-only, but route requires manage | Create a new key with manage/write permission (Part 2 step 2); delete the over-restricted key |
+| `aws ssm put-parameter` returns `AccessDenied` on `kms:Decrypt` or `ssm:PutParameter` | AWS_PROFILE not assumed the admin role, or CMK alias does not exist in this account/region | Re-run `aws sso login --sso-session aegis`; confirm `aws sts get-caller-identity` shows `aegis-staging-admin`; confirm `alias/aegis-staging-secrets` exists in `eu-central-1` via `aws kms describe-key --key-id alias/aegis-staging-secrets` |
+| Free tier cluster creation offers only US regions | Free tier is region-restricted on Qdrant Cloud (ADR-025 §GDPR caveat) | Accept US residency for the non-PII lab corpus, or upgrade to paid tier + attach payment method and select `eu-central-1` |
+| After cluster recreation, engine cannot connect | Old cluster URL still in SSM PS | `aws ssm put-parameter --overwrite` with the new URL; re-run Part 4 verify; if engine pod is running, restart it |
+
+---
+
+## Account / cluster teardown (permanent — not per-session)
+
+Qdrant Cloud clusters are NOT torn down between sessions — the free tier costs $0 to keep idle, and the Taiwan corpus re-ingest cost (time, not dollars) is non-trivial. Tear down only when abandoning the lab permanently or when migrating to a new cluster.
+
+Teardown order:
+
+1. If the platform-side Terraform scaffolding in Part 5 has landed, first `terraform state rm` or destroy the `aws_ssm_parameter.qdrant_cloud_*` resources (check the exact path after PR lands). Do this BEFORE deleting the cluster, so the downstream ExternalSecret does not flap on missing parameters.
+2. Delete the Qdrant Cloud cluster: Portal → Clusters → your cluster → **Delete cluster**. Historical vector data is lost — export collections to local files first if you need to preserve them.
+3. Delete SSM parameters:
+
+```bash
+for param in cluster-url api-key; do
+  aws ssm delete-parameter --name /aegis/staging/qdrant-cloud/$param
+done
+```
+
+4. If the ADR-025 implementation PR has landed, remove the `qdrant_cloud` block from `config/landing-zone.yaml` (if one exists) so the TF layer plans to zero resources on next apply.
+5. **WARNING**: all ingested vectors are lost on cluster deletion. For the Taiwan corpus, re-ingest is a re-run of `engine seed --target=cloud` — non-trivial but not catastrophic.
+
+---
+
+## Related
+
+- [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) — Qdrant backend decision (Cloud free tier)
+- [ADR-023](../decisions/023-observability-responsibility-model.md) — External Secrets + SSM PS pattern reused here
+- [Runbook 006](006-grafana-cloud-onboarding.md) — sibling SaaS onboarding for Grafana Cloud; same credential-plumbing shape


### PR DESCRIPTION
## Summary

- **Runbook 007 (new, 218 lines)** — first-reader-follows-from-zero Qdrant Cloud free tier onboarding. Signup → cluster create → API key capture → manual SSM PS put-parameter (ADR-025's deferred-implementation discipline) → curl smoke → rotation cadence → future-state note for when aegis-core files the Secret-contract cross-repo issue and TF adopts the manually-created params.
- **Runbook 006 surgical fixes** — Part 4 rewritten from local `terraform apply` (a silent break-glass trap after PR #128 wired `apply-observability` into the workload workflow) to `gh workflow run terraform-apply-workload.yml`. Part 5 gained placeholder-substitution guidance. Part 1 step 5 gained Mimir-region-vs-stack-region clarification.
- **Collateral** — CLAUDE.md runbook list gained 006 + 007 (006's entry had been omitted when PR #123 merged); interview-notes.md runbook count 6 → 7 (two locations).

## Why 006 needed fixing

As of PR #128, the `apply-observability` job in `terraform-apply-workload.yml` auto-applies the observability layer when a `grafana_cloud` block exists in config. Runbook 006 Part 4 still told the operator to run `terraform init && terraform apply` locally — a silent break-glass (per `docs/principles/break-glass-apply.md`, local applies are counted per session). First reader following the old text would accrue a break-glass count without realizing it. Fixed.

## Unverified claims flagged for live-signup confirmation

1. **Grafana Cloud free tier region availability (eu-central)** — could not web-confirm whether Frankfurt is selectable on free tier. ADR-022 + Runbook 006 already assume yes. If live signup reveals US-only, a follow-up amendment to Runbook 006 Part 1 step 4 + ADR-022 §Known limitations is needed.
2. **Qdrant Cloud free tier EU region** — likely US-only per ADR-025; Runbook 007 Part 1 surfaces the GDPR caveat inline. If Frankfurt is offered on free tier, Runbook 007 wording can be tightened post-commit.
3. **`stack-service-accounts:read` scope** — Grafana docs page did not enumerate this scope, but the Portal UI exposes it. No edit made; flagged for in-session sanity check during Part 2 step 2.
4. **Engine `qdrant_client.cc` header preference (`api-key` vs `Authorization: Bearer`)** — Runbook 007 says both work; did not open aegis-core source to confirm which the engine client defaults to. Low-impact because both headers are accepted.

## Test plan

- [ ] Checkov + Terraform Plan matrix green (docs-only PR; plans should show zero diff)
- [ ] Runbook 007 reads top-to-bottom executable with no forward-references
- [ ] Runbook 006 Part 4 no longer requires local `terraform apply`
- [ ] CLAUDE.md runbook list now contains 001–007
- [ ] interview-notes.md both count references show 7

## Related

- [ADR-025](docs/decisions/025-qdrant-backend-cloud-free-tier.md) — backend decision record; Runbook 007 is its operational sibling
- [ADR-022](docs/decisions/022-observability-backend-grafana-cloud.md) — Grafana Cloud backend; Runbook 006 is its operational sibling
- [docs/principles/break-glass-apply.md](docs/principles/break-glass-apply.md) — the discipline Runbook 006 Part 4 had been silently violating

🤖 Generated with [Claude Code](https://claude.com/claude-code)