### PR TITLE
docs: post-signup amendments for Qdrant + Grafana Cloud free tier runbooks

### DIFF
--- a/docs/decisions/025-qdrant-backend-cloud-free-tier.md
+++ b/docs/decisions/025-qdrant-backend-cloud-free-tier.md
@@ -59,11 +59,13 @@ The aegis-core issue should arrive as `cross-repo` (non-blocking for now — the
 
 Until the issue arrives, we do not speculate on the Secret shape; this repo has already paid the cost of guessing at cross-repo contracts (see CLAUDE.md "Wait for cross-repo issue before implementing").
 
-### GDPR region caveat is acknowledged, not resolved
+### GDPR region posture
 
-Qdrant Cloud's free tier is effectively US-region-only as of this writing; the paid tier offers AWS `eu-central-1` and `eu-west-1`. Bin is based in Germany and GDPR applies broadly to his professional context — but the lab's corpus is **non-PII Taiwan documentation**, deliberately chosen to avoid PII handling inside the portfolio. For the scope this ADR covers, US residency of vector embeddings of a public document corpus is acceptable.
+Qdrant Cloud free tier **offers AWS `eu-central-1` (Frankfurt)** — confirmed during first-time operator signup on 2026-04-23. This is strictly better than the earlier assumption (baked into the first drafts of this ADR and Runbook 007) that free tier was effectively US-only. Cluster placement in Frankfurt is compatible with GDPR obligations that apply broadly to Bin's professional context.
 
-If scope ever expands — real user queries, user-identifying metadata attached to vectors, or a demo reframed around a European corpus — the migration path is a config change (region selector at Qdrant Cloud level + new API key) plus a paid-tier billing attachment. It is not a re-architecture. This caveat is recorded here so the next operator does not have to rediscover it.
+The lab's corpus remains **non-PII Taiwan documentation** by design, so Frankfurt placement is a better-than-required posture rather than a compliance requirement. The repo retains full flexibility to scale the corpus or re-frame the demo without triggering a region migration.
+
+If scope ever expands beyond portfolio ceilings — real user queries, user-identifying metadata attached to vectors, or data volumes past the free tier's 1 GB / 1 M vector caps — the paid tier is a clean upgrade on the same `eu-central-1` region plus a DPA signature for real user data. It is a config change plus billing attachment, not a re-architecture.
 
 ### No engine refactor burden on aegis-core
 
@@ -80,7 +82,7 @@ The portfolio narrative instead carries "chose a managed backend on cost-discipl
 Revisit this ADR when any of the following fires:
 
 - **Corpus scope changes**: crosses 1 M vectors or 1 GB stored embeddings → Qdrant Cloud paid tier (same client, same contract) or option A if ops budget has expanded.
-- **GDPR scope changes**: real user data enters the vector store → paid tier with `eu-central-1` region selector + DPA signature.
+- **GDPR scope changes**: real user data enters the vector store → paid tier upgrade on the same `eu-central-1` region + DPA signature.
 - **Vendor risk materialises**: Qdrant Labs service deterioration, pricing model change, or acquisition affecting free-tier terms → option A becomes the escape hatch (same client code).
 - **Multi-tenant or per-team vector isolation**: if future workloads need isolated vector namespaces with separate quotas → option A with per-namespace StatefulSets, or paid-tier multi-cluster Qdrant Cloud.
 

--- a/docs/runbooks/006-grafana-cloud-onboarding.md
+++ b/docs/runbooks/006-grafana-cloud-onboarding.md
@@ -28,10 +28,10 @@ Related: [ADR-022](../decisions/022-observability-backend-grafana-cloud.md) (bac
 
 1. Navigate to `https://grafana.com/signup`
 2. Sign up with email. Note: this email is the account root and is difficult to change later. Lab uses `pcpunkhades@gmail.com`.
-3. Create organization — suggested name: `aegis-lab`
-4. Create stack:
-   - Stack URL slug: `aegis-staging` (must match `config/landing-zone.yaml` `grafana_cloud.org_slug`)
-   - Region: `eu-central` (Frankfurt) — **REGION IS LOCKED once set**; changing requires a new stack and full re-ingest
+3. Most Grafana Cloud signup flows auto-create both an organization and a stack matching your account name (the lab's live signup on 2026-04-23 produced org `aegis` + stack slug `aegis`). Skip this step if you are happy with the auto-created org; otherwise manually create one (suggested name: `aegis-lab`).
+4. Create stack — **skip if signup auto-created one you want to keep**. Otherwise:
+   - Stack URL slug: your choice. Update `config/landing-zone.yaml` `grafana_cloud.org_slug` to match your **actual** slug — the `aegis-staging` example appearing elsewhere in this repo is a suggestion, not a contract. If the auto-created slug (typically equal to your org name) is fine, record that value and move on.
+   - Region: `eu-central` (Frankfurt) — **REGION IS LOCKED once set**; changing requires a new stack and full re-ingest. Availability confirmed on free tier 2026-04-23.
 5. Record stack endpoints (needed later). Find them under Portal → Stacks → your stack → Details:
    - Grafana URL: `https://<slug>.grafana.net`
    - Mimir URL: `https://prometheus-prod-<N>-<mimir-region>-<N>.grafana.net/api/prom`
@@ -54,9 +54,9 @@ This is the single manual step. Terraform provisions all downstream tokens after
      - `accesspolicies:read`
      - `accesspolicies:write`
      - `stacks:read`
-     - `stack-service-accounts:read`
      - `stack-service-accounts:write`
      - `stack-api-keys:write`
+   - Note on missing `:read` rows: Grafana Cloud Portal UI (verified 2026-04-23) offers only `:write` for `stack-service-accounts` and `stack-api-keys` — no separate `:read` checkbox exists. This follows Grafana's convention that write-scopes for create-mostly resources implicitly grant the read needed by the Terraform provider to list existing items before create. If a future Terraform apply fails with 403 on SA/API-key list operations, widen the policy with whatever additional scope the error references and amend this runbook.
    - Do NOT grant: `billing:*`, `stacks:write`, `stacks:delete` — these are the "delete the stack" scopes
 3. Click "Add token":
    - Name: `bootstrap-<YYYYMMDD>`
@@ -79,20 +79,20 @@ AWS_PROFILE=aegis-staging-admin aws ssm put-parameter \
 
 Free tier does NOT support SAML. If the `grafana-operator` service account token breaks, a human must recover manually. This admin user is that recovery path.
 
-Auth options on free tier (pick one — Google OAuth recommended):
+The goal is **any human-level OAuth login that is independent of service-account tokens**. Which OAuth provider you use is secondary.
 
-- Google OAuth (recommended — aligns with lab operator's existing Gmail)
-- GitHub OAuth
-- Email + password (last resort; requires password manager)
+- **If you signed up via Google or GitHub OAuth at Part 1**: you already have a human-level OAuth path — your signup identity IS the break-glass. Verify once by opening the workspace URL in a private window and completing the OAuth flow from scratch to confirm it works independently of any in-progress session. Part 3 is effectively complete after this verification (no second user needed for a single-operator lab).
+- **If you signed up via email + password**: add a secondary OAuth identity (Google or GitHub) now — email+password alone is not an acceptable break-glass because it collapses into a single password-manager dependency.
+- **Belt-and-suspenders option (enterprise / multi-operator scope)**: even if signed up via OAuth, invite a second independent OAuth identity so recovery does not depend on a single provider account (e.g. GitHub SSO + Google OAuth as orthogonal recovery paths). Overkill for a single-operator portfolio lab; warranted for production.
 
-Steps (Google OAuth path):
+Steps for adding a secondary OAuth identity (only if the signup path did not cover it):
 
 1. Open the workspace URL: `https://<stack-slug>.grafana.net`
 2. Navigate: Administration → Users and access → Users → Invite new user
 3. Fill in:
-   - Email: operator's Gmail
+   - Email: the operator's Google- or GitHub-linked email
    - Role: Admin
-4. User receives invitation email → accept → "Sign in with Google"
+4. User receives invitation email → accept → "Sign in with Google" (or "Sign in with GitHub")
 5. Verify login works BEFORE proceeding — confirm browser-based admin access, independent of any machine token
 
 If SAML SSO (AWS IAM Identity Center integration) is needed: upgrade to Grafana Cloud Pro. See [ADR-022](../decisions/022-observability-backend-grafana-cloud.md) §Known limitations and [ADR-021](../decisions/021-observability-scaling-path.md) rung transitions.

--- a/docs/runbooks/007-qdrant-cloud-onboarding.md
+++ b/docs/runbooks/007-qdrant-cloud-onboarding.md
@@ -20,7 +20,7 @@ Related: [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) (backend 
 - 20–30 minutes for first-time setup; 10 minutes for rotation
 - No payment method required for free tier
 - Do NOT attach a credit card — keeps overage behavior on ingest-throttle, not auto-upgrade. Same free-tier discipline as Runbook 006.
-- GDPR caveat acknowledged: free tier cluster placement is effectively US-region on Qdrant Cloud today. The lab's corpus is non-PII Taiwan documentation by design (see [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §GDPR region caveat). If your scope ever expands beyond the non-PII corpus, migrate to the paid tier's `eu-central-1` selector before ingesting.
+- GDPR posture: Qdrant Cloud free tier **offers AWS `eu-central-1` (Frankfurt)** — confirmed 2026-04-23. Pick Frankfurt unless operating from a non-EU locale. See [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §GDPR region posture for the full rationale and upgrade path.
 
 ---
 
@@ -33,7 +33,7 @@ Related: [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) (backend 
 5. Create cluster:
    - Tier: **Free**
    - Cloud provider: **AWS** (Qdrant Cloud also offers GCP and Azure; AWS aligns with the lab's existing posture)
-   - Region: the **free tier offers a limited set of regions** (see [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §GDPR region caveat — EU regions may not be offered on free tier; a US region is expected). Pick the closest option available; do NOT upgrade to paid purely for region choice unless the corpus scope has changed to include PII.
+   - Region: **`eu-central-1` (Frankfurt)** — available on free tier as confirmed 2026-04-23. Pick Frankfurt if deploying from Germany / EU; other EU regions may also be available. If Qdrant Cloud ever narrows free-tier region selection in future, re-consult [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §GDPR region posture.
    - Cluster name: `aegis-staging-vectors` (or your preferred name — this is not load-bearing; the engine reads the URL from SSM PS, not the cluster name)
 6. Click **Create**. Cluster provisioning takes ~1–2 minutes.
 7. Once the cluster shows as `Healthy` in the Clusters menu, click into it to see the **Cluster Detail** page.
@@ -65,6 +65,8 @@ Auth header for later verification: Qdrant Cloud accepts **both** `api-key: <key
 ---
 
 ## Part 3 — Stash credentials in SSM Parameter Store (manual, pre-Terraform)
+
+> ⚠️ **Credentials go in SSM Parameter Store — never in `config/landing-zone.yaml`.** The `config.yaml` file holds deployment-shape metadata (account IDs, emails, CIDRs) per CLAUDE.md §Security; API keys and session tokens are categorically distinct and must land in SSM PS SecureString with the KMS alias `alias/aegis-staging-secrets`. This rule applies even though `config.yaml` is gitignored — the repo's "zero static credentials by design" posture draws the line at file type, not at git-tracked vs. local.
 
 **IMPORTANT**: per [ADR-025](../decisions/025-qdrant-backend-cloud-free-tier.md) §"Landing-zone implementation is deferred pending aegis-core Secret-contract issue", this repo has intentionally NOT yet shipped Terraform `aws_ssm_parameter` resources for the Qdrant Cloud credentials. The Secret shape (key names, env-var mappings, extra config like collection name / embedding dimension / distance metric) is aegis-core's call and will arrive as a cross-repo issue.
 


### PR DESCRIPTION
## Summary

Post-live-signup amendments batched from the same operator session on 2026-04-22/23 (Qdrant) and 2026-04-23 (Grafana Cloud). All edits are surgical — no structural reorganization of either runbook or ADR.

## Qdrant side (ADR-025 + Runbook 007)

- **Free tier EU region available** — Live signup confirmed \`eu-central-1\` (Frankfurt) IS offered on Qdrant Cloud free tier. ADR-025 §GDPR renamed (\"is acknowledged, not resolved\" → \"region posture\") and rewritten. Runbook 007 pre-flight + Part 1 step 5 direct operator to Frankfurt outright.
- **Credential-placement guardrail** — Runbook 007 Part 3 now opens with a prominent callout: credentials → SSM PS SecureString + KMS only, never in \`config.yaml\` even though \`config.yaml\` is gitignored. Rule framed by file type, not by git-tracked vs. local. Added after the operator asked during live onboarding to record the API key in \`config.yaml\`.

## Grafana Cloud side (Runbook 006)

- **Slug auto-creation reality** — Part 1 steps 3-4 rewritten. Grafana Cloud signup auto-creates an org + stack matching the account name (lab's run got \`aegis\`, not the runbook's \`aegis-staging\` example). Runbook now makes this the default path and makes the config-alignment direction explicit (update \`config.yaml\` to match your ACTUAL slug).
- **Non-existent scopes removed** — Part 2 step 2 scope list dropped \`stack-service-accounts:read\`. Portal UI (verified on-screen 2026-04-23) exposes only \`:write\` for \`stack-service-accounts\` and \`stack-api-keys\`. Added explanatory note on Grafana's convention that write-scopes for create-mostly resources implicitly grant the list/read required by the Terraform provider. Rollback path documented if a future TF apply 403s on list operations.
- **Break-glass OAuth choice widened** — Part 3 rewritten. The goal is \"any human-level OAuth login independent of service-account tokens\" — which provider is secondary. Three realistic cases enumerated (signed up via OAuth → verify once, signed up via email+password → must add OAuth, enterprise belt-and-suspenders → two providers). Lab operator's GitHub SSO at signup already satisfies the goal — original \"Google OAuth recommended\" framing misled him into thinking a second invite was required.

## Test plan

- [ ] Checkov + Terraform Plan matrix green (docs-only, no TF diff)
- [ ] Runbook 006 + Runbook 007 read consistently end-to-end after the edits
- [ ] ADR-025 §GDPR and §Future switch triggers are internally consistent

No collateral bumps required (amending existing docs; counts unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)