### PR TITLE
ci(terraform-plan): fix Comment-on-PR JS template-literal quoting (unblocks observability plans)

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -197,22 +197,44 @@ jobs:
         uses: actions/github-script@v9
         if: github.event_name == 'pull_request'
         env:
+          # Pass user-controlled strings through env rather than direct
+          # template interpolation — the previous pattern stuffed
+          # steps.plan.outputs.stdout straight into a JS template literal,
+          # which breaks the instant plan output contains a backtick (`) or
+          # `${` sequence. Alloy Helm values + kubectl_manifest YAML in the
+          # staging/observability layer exposed this (SyntaxError "Unexpected
+          # identifier 'alloy'" on 2026-04-23). Reading via process.env gives
+          # us a plain JS string — no re-parsing of its contents.
+          PLAN_STDOUT: ${{ steps.plan.outputs.stdout }}
+          PLAN_ICON: ${{ steps.status.outputs.icon }}
+          PLAN_SUMMARY: ${{ steps.status.outputs.summary }}
+          MATRIX_ENV: ${{ matrix.env }}
           VARIANT_SUFFIX: ${{ matrix.variant && format(' ({0})', matrix.variant) || '' }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          ACTOR: ${{ github.actor }}
         with:
           script: |
-            const output = `### ${{ steps.status.outputs.icon }} Terraform Plan: \`${{ matrix.env }}\`${process.env.VARIANT_SUFFIX}
+            const planStdout = process.env.PLAN_STDOUT || '(no plan output)';
+            const icon       = process.env.PLAN_ICON       || '';
+            const summary    = process.env.PLAN_SUMMARY    || '';
+            const matrixEnv  = process.env.MATRIX_ENV      || '';
+            const variant    = process.env.VARIANT_SUFFIX  || '';
+            const headRef    = process.env.HEAD_REF        || '';
+            const actor      = process.env.ACTOR           || '';
 
-            **Result:** ${{ steps.status.outputs.summary }}
+            const output = `### ${icon} Terraform Plan: \`${matrixEnv}\`${variant}
+
+            **Result:** ${summary}
 
             <details><summary>Plan Output</summary>
 
             \`\`\`
-            ${{ steps.plan.outputs.stdout }}
+            ${planStdout}
             \`\`\`
 
             </details>
 
-            *Triggered by @${{ github.actor }} on \`${{ github.event.pull_request.head.ref }}\`*`;
+            *Triggered by @${actor} on \`${headRef}\`*`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
## Summary

- The \`Comment Plan on PR\` step in \`terraform-plan.yml\` embeds \`\${{ steps.plan.outputs.stdout }}\` directly inside a JavaScript template literal. Any backtick or \`\${\` in plan output closes the literal early, and the remainder is parsed as JavaScript → uncatchable SyntaxErrors.
- Exposed on 2026-04-23 by PR #135's \`Plan staging/observability\` job failing with \`SyntaxError: Unexpected identifier 'alloy'\`. Root trigger: Alloy Helm values content in the new observability layer (PR #128). Plan itself succeeded; the post-step failed. **Without this fix every subsequent PR would fail the observability plan-comment step.**
- Fix: pass all user-controlled strings through \`env:\` and read via \`process.env.*\` in the script. Template literal now only contains well-formed \`\${var}\` placeholders over plain JS string variables.

## Why this needs its own PR

Observability layer on main → plan output now reliably contains reserved chars → every PR's observability comment step will fail → blocks PR #135 (docs) from passing CI. Fixing the docs PR by adding a workflow change would scope-creep it. Separate fix PR lets #135 rebase onto this once merged.

## Test plan

- [ ] This PR's own CI (\`pull_request\` uses head-branch workflow → fix applies to self) passes all matrix legs including \`Plan staging/observability\`
- [ ] After merge: rebase PR #135 onto main, push, re-verify \`Plan staging/observability\` comment step no longer SyntaxErrors

## Related

- [PR #135](https://github.com/BinHsu/aegis-aws-landing-zone/pull/135) — blocked until this merges
- [PR #128](https://github.com/BinHsu/aegis-aws-landing-zone/pull/128) — observability layer whose plan output exposed the latent bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)