### PR TITLE
feat(staging/auth): Cognito User Pool + ADR-026 Accepted + aegis-core #76 pre-apply prep

### DIFF
--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -18,6 +18,7 @@ on:
       - 'terraform/environments/management/**'
       - 'terraform/environments/shared/**'
       - 'terraform/environments/staging/bootstrap/**'
+      - 'terraform/environments/staging/auth/**'
       - 'terraform/environments/prod/bootstrap/**'
       - 'config/**'
 
@@ -49,6 +50,36 @@ jobs:
             account_id: "251774439261"
           - env: management/scps
             account_id: "186052668286"
+          # -----------------------------------------------------------------
+          # staging/auth — Cognito User Pool (ADR-026)
+          # -----------------------------------------------------------------
+          # Baseline-tier peer layer. Cognito User Pool is essentially free at
+          # lab scale (free tier = 50k MAU permanent) so it sits in auto-apply
+          # alongside the other baseline layers.
+          #
+          # Ordered AFTER staging/bootstrap (needs the KMS alias
+          # alias/aegis-staging-secrets for SSM PS SecureString encryption)
+          # and AFTER management/scps (SCPs guard all staging resources so
+          # they must exist by the time we create IAM + Cognito resources).
+          #
+          # Cold-cycle caveat: the kubectl_manifest step that creates the
+          # `cognito-config` ExternalSecret targets the `aegis` namespace,
+          # which is owned by staging/workloads (workload-tier, not
+          # auto-applied). On a brand-new environment where workloads has
+          # not been applied yet, this matrix row fails with
+          # `namespaces "aegis" not found` — the AWS-side resources (user
+          # pool, app client, domain, SSM params, IAM role) still apply
+          # cleanly. Operator applies workloads via
+          # terraform-apply-workload.yml, then re-dispatches baseline to
+          # land the ExternalSecret. Same cold-cycle shape as
+          # staging/observability (ADR-022).
+          #
+          # prevent_destroy = true on the User Pool + SSM params + IAM role
+          # means subsequent workload cycles do not touch this layer's AWS
+          # resources. The layer is stable across workload cycles.
+          # -----------------------------------------------------------------
+          - env: staging/auth
+            account_id: "251774439261"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -96,6 +96,18 @@ jobs:
           # -----------------------------------------------------------------
           - env: staging/observability
             account_id: "251774439261"
+          # -----------------------------------------------------------------
+          # staging/auth — Cognito User Pool for cloud-mode aegis auth
+          # (ADR-026). Baseline-tier peer layer, conditional on
+          # config.cognito — without the block the whole plan is empty.
+          # Plan against live state should show "no changes" once applied.
+          # Catches drift on the User Pool schema (immutable attributes),
+          # app client callback/logout URL lists, and the ExternalSecret
+          # CRD shape. The CI secret LANDING_ZONE_CONFIG provides the
+          # cognito: block so this row is meaningful across PR cycles.
+          # -----------------------------------------------------------------
+          - env: staging/auth
+            account_id: "251774439261"
 
     steps:
       - uses: actions/checkout@v6

--- a/config/landing-zone.example.yaml
+++ b/config/landing-zone.example.yaml
@@ -164,3 +164,43 @@ eks:
 #   # page ("Username / Instance ID" field). Password is the alloy-token
 #   # provisioned by Terraform in staging/observability/ (PR-2).
 #   mimir_user_id: "1234567"
+
+# Cognito User Pool — cloud-mode auth for aegis (ADR-026).
+# Optional: present this block to enable the staging/auth peer layer.
+# Provisions a Cognito User Pool with a single SPA app client, five SSM PS
+# SecureString parameters carrying the pool identifiers, and an
+# ExternalSecret that syncs three of them into the `aegis` namespace as a
+# K8s Secret consumed by aegis-core's gateway Deployment.
+#
+# Omit to deploy the landing zone without an auth layer — baseline apply
+# still succeeds, staging/auth plans zero resources.
+#
+# Runbook 008 documents first-operator setup (admin user invite, Hosted UI
+# login verification, token smoke test).
+# cognito:
+#   # Cognito-provided hosted UI domain prefix. Full URL:
+#   # <prefix>.auth.<region>.amazoncognito.com. Globally unique within
+#   # the region — pick a different prefix on collision.
+#   domain_prefix: aegis-staging
+#   # SPA callback URLs — aegis-core-confirmed 2026-04-23 on aegis-core #76.
+#   # Must match the SPA's OAuth redirect target exactly (scheme, host,
+#   # path, no trailing slash drift). Cognito accepts in-place updates
+#   # without recreate.
+#   callback_urls:
+#     - "https://aegis-app.staging.binhsu.org/auth/callback"
+#   # Logout redirect URLs — where Cognito sends the user after global
+#   # logout. Cognito accepts in-place updates without recreate.
+#   logout_urls:
+#     - "https://aegis-app.staging.binhsu.org/"
+#   # Password policy — NIST SP 800-63B aligned defaults. Omit any
+#   # subfield to inherit the lab default; omit the whole block to
+#   # inherit all defaults.
+#   password_policy:
+#     minimum_length: 12
+#     require_lowercase: true
+#     require_uppercase: true
+#     require_numbers: true
+#     require_symbols: true
+#   # MFA posture. OFF (lab default) | OPTIONAL | ON. ON requires every
+#   # user to enroll a factor before login works — not recommended for MVP.
+#   mfa_configuration: OFF

--- a/config/schema.json
+++ b/config/schema.json
@@ -256,6 +256,67 @@
         }
       }
     },
+    "cognito": {
+      "type": "object",
+      "description": "Cognito User Pool — cloud-mode auth for aegis (ADR-026). Optional — present this block to enable the staging/auth peer layer. Omit to deploy the landing zone without an auth layer. Runbook 008 documents first-operator setup including admin user creation and Hosted UI login verification. See ADR-026 §Decision for the custom:tenant_id attribute design.",
+      "required": ["callback_urls", "logout_urls"],
+      "additionalProperties": false,
+      "properties": {
+        "callback_urls": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": "App client allowed callback URL list — SPA OAuth redirect targets. aegis-core-confirmed default: ['https://aegis-app.staging.binhsu.org/auth/callback']. Cognito accepts in-place updates to this list without recreate."
+        },
+        "logout_urls": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          },
+          "description": "App client allowed logout redirect URL list. aegis-core-confirmed default: ['https://aegis-app.staging.binhsu.org/']. Cognito accepts in-place updates without recreate."
+        },
+        "domain_prefix": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]{0,62}$",
+          "description": "Cognito-provided hosted UI domain prefix — full URL is <prefix>.auth.<region>.amazoncognito.com. Globally unique within the region. Default: 'aegis-staging'. Changing this forces a ~30s hosted-UI 5xx window during resource recreate."
+        },
+        "password_policy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "minimum_length": {
+              "type": "integer",
+              "minimum": 6,
+              "maximum": 99,
+              "description": "Minimum password length. Lab default 12 (NIST SP 800-63B aligned)."
+            },
+            "require_lowercase": {
+              "type": "boolean"
+            },
+            "require_uppercase": {
+              "type": "boolean"
+            },
+            "require_numbers": {
+              "type": "boolean"
+            },
+            "require_symbols": {
+              "type": "boolean"
+            }
+          },
+          "description": "Cognito password policy. Omit any subfield to use the lab default. Omit the whole block to inherit the full lab-default policy (min 12, all four character classes required)."
+        },
+        "mfa_configuration": {
+          "type": "string",
+          "enum": ["OFF", "OPTIONAL", "ON"],
+          "description": "MFA posture. OFF (lab default) = no MFA. OPTIONAL = users may enroll a factor and get prompted when present. ON = factor required for every user; login hard-fails if not configured. ON is not recommended for MVP — use OPTIONAL if you want to demo MFA without breaking lab-operator login."
+        }
+      }
+    },
     "eks": {
       "type": "object",
       "description": "EKS platform configuration keyed by workload environment name (e.g. staging, prod). Optional — only environments that deploy a platform layer need an entry.",

--- a/docs/decisions/026-cognito-auth-user-pool.md
+++ b/docs/decisions/026-cognito-auth-user-pool.md
@@ -2,9 +2,14 @@
 
 ## Status
 
-**Partially Accepted** (2026-04-23). Core commitment plus 5 of 6 shape decisions frozen per the aegis-core #76 reply later the same day. One Open Question remains — callback and logout URLs — genuinely blocked on aegis-core SPA auth scaffolding work that has not yet started. A strawman URL pair is the working default at Terraform commit time; Cognito's `callback_urls` and `logout_urls` accept updates to existing app clients without recreate, so Terraform implementation is not gated on resolving that question first.
+**Accepted** (2026-04-24). All six shape decisions pinned. Terraform implementation lands in the same PR as this amendment.
 
-The original Draft version of this document (2026-04-23 AM) recorded the commitment as decided and all six shape details as unpinned. This amendment (2026-04-23 PM, after aegis-core #76 was answered at 07:00 UTC) moves five of the six into § Decision and leaves the sixth in § Open Questions with the strawman default captured explicitly. A future amendment promotes this ADR from Partially Accepted to Accepted when aegis-core's SPA auth scaffold lands and the URL values are firm.
+Amendment trigger satisfied 2026-04-23 PM: aegis-core shipped Phase 4e-1/2/3 to their `main` (gateway JWT middleware via `auth.OIDCProvider` + JWKS cache in [aegis-core PR #78](https://github.com/BinHsu/aegis-core/pull/78); SPA OAuth scaffold via `react-oidc-context` + `<AegisAuthShell>` CLOUD mode in [aegis-core PR #79](https://github.com/BinHsu/aegis-core/pull/79); tenant propagation from authenticated Principal in [aegis-core PR #80](https://github.com/BinHsu/aegis-core/pull/80)). Their 12:26 UTC comment on aegis-core #76 confirmed the strawman URL pair holds as the final values and asked for ldz-side implementation details (5 pre-apply questions on Terraform output shape, IAM role for their nightly integration test, test-user strategy, signal path, sanity-check).
+
+Revision history:
+- **Draft** (2026-04-23 AM) — commitment recorded, all 6 shape details unpinned. Landed in PR #137.
+- **Partially Accepted** (2026-04-23 PM) — 5 of 6 decisions pinned from aegis-core's 07:00 UTC reply on #76. Landed in PR #138.
+- **Accepted** (2026-04-24) — Q2 URL pair confirmed final; Terraform implementation ships; aegis-core's 5 pre-apply questions answered in the same cycle. This PR.
 
 ## Context
 
@@ -38,7 +43,7 @@ A `cognito-config` Kubernetes Secret in the `aegis` namespace is reconciled by E
 
 ### Consumption contract decisions (frozen 2026-04-23 per aegis-core #76)
 
-Five of the six shape details originally deferred are now pinned. The sixth (callback / logout URLs) remains in § Open Questions with a strawman default.
+All six shape details originally deferred are now pinned.
 
 - **Token validation**: the gateway validates ID tokens locally against Cognito's JWKS endpoint (RS256). Removes a per-request network hop to `/userinfo`; the standard cloud-native path. Gateway middleware will need a JWKS cache tolerant of Cognito's key-rotation window.
 - **Requested scopes**: `openid profile email` — no custom scopes for MVP. Role-based access is expressed through a custom attribute instead of through OAuth scopes (see next bullet); the gateway's authorization layer reads claims, not scopes.
@@ -46,7 +51,7 @@ Five of the six shape details originally deferred are now pinned. The sixth (cal
 - **Session lifetime**: Cognito defaults — 1h access token, 30d refresh token. Acceptable for lab / demo scale. Revisit only if cold-apply smoke reveals UX pacing issues.
 - **Logout behavior**: Cognito global logout — revokes the user's sessions across every client. Secure default; cleaner demo narrative (one Logout click → actually logged out everywhere). Local-only SPA logout was rejected because the app has no multi-device UX requirement that would justify the weaker posture.
 
-The one remaining shape detail — callback / logout URLs — sits in § Open Questions with the strawman default captured.
+- **Callback / logout URLs**: `callback_urls = ["https://aegis-app.staging.binhsu.org/auth/callback"]` and `logout_urls = ["https://aegis-app.staging.binhsu.org/"]`. Confirmed final by aegis-core on 2026-04-23 PM after their SPA auth scaffold landed (PR #79). Cognito accepts in-place updates to both lists, so future URL shifts are routine drifts rather than migrations.
 
 ## Alternatives Considered
 
@@ -76,20 +81,16 @@ Categorically wrong. "I re-implemented auth" is a portfolio anti-signal at staff
 
 ## Open Questions
 
-### 1. Callback / redirect URLs (Q2 from the original 6)
+None. Callback and logout URLs confirmed final by aegis-core on 2026-04-23 PM (#76 reply at 12:26 UTC, Question E sanity-check): the strawman values hold as the production values.
 
-**Status**: Open. aegis-core has no SPA auth scaffolding today — no `/auth/callback` route, no OAuth flow in the SPA, no post-logout redirect logic. The exact URLs are not yet designed and are blocked on the aegis-core-side SPA work starting.
-
-**Working default for Terraform commit**: the Cognito app client's URL lists are seeded with strawman values that follow conventional SPA auth paths:
+Final URL pair — pinned in Terraform `callback_urls` / `logout_urls` on `aws_cognito_user_pool_client.spa`:
 
 - `callback_urls = ["https://aegis-app.staging.binhsu.org/auth/callback"]`
 - `logout_urls   = ["https://aegis-app.staging.binhsu.org/"]`
 
-When aegis-core's SPA auth scaffolding finalizes (matching or diverging from the strawman), the operator runs `terraform apply` on `staging/auth/` with updated lists. Cognito accepts updates to `callback_urls` and `logout_urls` on existing app clients without forcing recreate, so this is a low-risk drift rather than a migration.
+Cognito accepts updates to both lists without app-client recreate, so any future URL change (new SPA route, dev-cluster callback, preview environments) is a routine `terraform apply` drift rather than a migration event.
 
-**Amendment trigger**: this ADR promotes from Partially Accepted to Accepted when aegis-core's SPA auth lands and the URL values are firm. If the production URLs differ from the strawman, the amendment captures the real values plus a note on whether the strawman was updated before or after first cold-apply.
-
-The other five consumption-contract questions (token validation, scopes, custom attributes, session lifetime, logout behavior) were resolved by aegis-core's 2026-04-23 reply on [aegis-core #76](https://github.com/BinHsu/aegis-core/issues/76); see § Decision's "Consumption contract decisions" subsection.
+All six consumption-contract questions are now in § Decision's "Consumption contract decisions" subsection; the Q2 callback/logout pair joins Q1/Q3/Q4/Q5/Q6 as a decided contract.
 
 ## Consequences
 

--- a/docs/runbooks/008-cognito-user-pool-onboarding.md
+++ b/docs/runbooks/008-cognito-user-pool-onboarding.md
@@ -18,9 +18,9 @@ Related: [ADR-026](../decisions/026-cognito-auth-user-pool.md) (backend decision
 ## Pre-flight
 
 - AWS CLI + AWS SSO login to `aegis-staging` active (`aws sso login --sso-session aegis`; `export AWS_PROFILE=aegis-staging-admin`)
-- Confirm ADR-026 has been amended from Partially Accepted to Accepted — the amendment trigger is aegis-core's SPA auth scaffold landing with final URL values. If the ADR still shows Partially Accepted, **stop** — `terraform apply` on `staging/auth/` is still gated; resolve the gate before proceeding.
-- Confirm `config/landing-zone.yaml` has a populated `cognito:` block with non-strawman `callback_urls` and `logout_urls` values. Absent or strawman values here guarantee a user-pool recreate when the real values arrive later — the minor friction now beats the data-loss later.
-- Confirm aegis-core's SPA auth scaffold is merged on `main`. Without the SPA-side `/auth/callback` route, the Hosted UI login verification in Part 3 cannot be completed end-to-end — you can still verify steps 1–4, but the post-callback token exchange will 404 in the browser.
+- Confirm ADR-026 reflects the pinned callback / logout URLs (aegis-core #76 confirmation 2026-04-23). ADR-026 is Accepted once the amendment lands; until then, Partially Accepted is fine for apply because the URL values are now final.
+- Confirm `config/landing-zone.yaml` has a populated `cognito:` block. Callback/logout URLs are `https://aegis-app.staging.binhsu.org/auth/callback` and `https://aegis-app.staging.binhsu.org/` (aegis-core-confirmed). If the block is absent, the layer plans zero resources — a clean no-op apply is still the right first step to confirm workflow + plumbing.
+- Confirm aegis-core's SPA auth scaffold is merged on `main` (aegis-core #78, #79, #80 all landed 2026-04-23). Without these, the Hosted UI login verification in Part 3 cannot be completed end-to-end — you can still verify steps 1–4, but the post-callback token exchange will 404 in the browser.
 - Confirm the `aegis` namespace exists in the target cluster (apply `staging/workloads` first if the current cold-apply cycle has not reached that stage yet).
 - A browser with the operator's Google account available (for Hosted UI login testing in Part 3). Lab uses `pcpunkhades@gmail.com`.
 - 30–45 minutes for first-time provisioning + user creation + smoke tests; 5–10 minutes for password rotation alone.
@@ -31,29 +31,25 @@ Related: [ADR-026](../decisions/026-cognito-auth-user-pool.md) (backend decision
 
 Per [CLAUDE.md § Cost Guardrails](../../CLAUDE.md#cost-guardrails), baseline-tier layers auto-apply on merge to `main`. `staging/auth/` is a baseline-tier layer (it does not incur hourly cost once provisioned — Cognito User Pool free tier is 50k MAU permanent, see [ADR-026](../decisions/026-cognito-auth-user-pool.md) §Consequences).
 
-On the PR that adds the `staging/auth/` `.tf` files:
+The layer auto-applies when a PR that touches `terraform/environments/staging/auth/**` or `config/**` merges to `main`:
 
-1. Merging triggers `terraform-apply-baseline.yml` which runs plan + apply on baseline-tier layers only. Verify the auth layer is listed in the workflow's matrix (PR-time check).
-2. If you need to apply manually outside the merge cycle (e.g. a config-only rotation that does not touch `.tf`), dispatch:
+1. Merging triggers `terraform-apply-baseline.yml` which runs plan + apply on baseline-tier layers. Watch the run: `gh run list --workflow=terraform-apply-baseline.yml` + `gh run view <id> --log-failed` if the auth row fails.
 
-   ```bash
-   gh workflow run terraform-apply-baseline.yml -f layer=staging/auth
-   gh run watch
-   ```
+2. **First-cold-cycle expected failure**: on a brand-new environment where `staging/workloads` has not been applied yet, the `kubectl_manifest.external_secret_cognito_config` step fails with `namespaces "aegis" not found`. The AWS-side resources (user pool, app client, domain, SSM parameters, IAM role) apply cleanly regardless. The operator applies `staging/workloads` via `gh workflow run terraform-apply-workload.yml -f env=staging`, then re-dispatches baseline via `gh workflow run terraform-apply-baseline.yml` to land the ExternalSecret. This is the same mitigation shape as `staging/observability` — not a bug.
 
-   Do **not** run `terraform apply` locally unless this is a break-glass scenario per [`docs/principles/break-glass-apply.md`](../principles/break-glass-apply.md). Local applies bypass the audit trail and skip the OIDC-assumed role path.
+3. Do **not** run `terraform apply` locally unless this is a break-glass scenario per [`docs/principles/break-glass-apply.md`](../principles/break-glass-apply.md). Local applies bypass the audit trail and skip the OIDC-assumed role path.
 
-3. On success, confirm the three SSM parameters exist and carry non-empty values:
+4. On success, confirm the five SSM parameters exist and carry non-empty values:
 
    ```bash
-   for key in user-pool-id app-client-id issuer-url; do
+   for key in user-pool-id user-pool-arn app-client-id issuer-url hosted-ui-domain; do
      aws ssm get-parameter \
        --name /aegis/staging/cognito/$key \
        --with-decryption --query 'Parameter.Value' --output text
    done
    ```
 
-   All three must print non-empty strings. The issuer URL format is `https://cognito-idp.eu-central-1.amazonaws.com/<user-pool-id>` — if it does not match this shape, the `issuer-url` was likely written from the wrong Cognito attribute; check `outputs.tf` + the `aws_ssm_parameter.issuer_url` value expression.
+   All five must print non-empty strings. The issuer URL format is `https://cognito-idp.eu-central-1.amazonaws.com/<user-pool-id>` — if it does not match this shape, the `issuer-url` was likely written from the wrong Cognito attribute; check `outputs.tf` + the `aws_ssm_parameter.issuer_url` value expression.
 
 4. Confirm the `cognito-config` ExternalSecret has reconciled into a K8s Secret:
 
@@ -130,20 +126,22 @@ The canonical first user is the operator's email, `pcpunkhades@gmail.com`. Subse
 
 At this point the user exists in Cognito but has never completed an OAuth flow. The goal of this part is to prove the Hosted UI → app client → callback chain works end-to-end **from a browser**, independent of the gateway.
 
-Pull the three values you need:
+Pull the three values you need (all retrievable from SSM PS, so the runbook is copy-paste reproducible):
 
 ```bash
 APP_CLIENT_ID=$(aws ssm get-parameter \
   --name /aegis/staging/cognito/app-client-id \
   --with-decryption --query 'Parameter.Value' --output text)
 
-# Domain prefix comes from config.yaml; the full domain is deterministic once the prefix is known.
-COGNITO_DOMAIN='aegis-staging.auth.eu-central-1.amazoncognito.com'
+COGNITO_DOMAIN=$(aws ssm get-parameter \
+  --name /aegis/staging/cognito/hosted-ui-domain \
+  --with-decryption --query 'Parameter.Value' --output text)
+# Expected: aegis-staging.auth.eu-central-1.amazoncognito.com
 
-# Callback URL — **[TBD — Q2 aegis-core SPA decision]**. Once aegis-core's SPA auth
-# scaffold is merged, substitute the real value. Must match one of the app client's
-# registered callback_urls exactly (scheme, host, path, no trailing slash drift).
-CALLBACK_URL='<TBD — Q2 aegis-core SPA decision>'
+# Callback URL — aegis-core-confirmed value from aegis-core #76 (2026-04-23).
+# Must match one of the app client's registered callback_urls exactly
+# (scheme, host, path, no trailing slash drift).
+CALLBACK_URL='https://aegis-app.staging.binhsu.org/auth/callback'
 ```
 
 Construct the Hosted UI login URL:
@@ -175,8 +173,8 @@ Prerequisite: you have an authorization code from Part 4 step 4. Exchange it for
 # Substitute the authorization code from the browser redirect.
 CODE='<code from Part 3 step 4>'
 
-# Callback must match Part 3 exactly.
-CALLBACK_URL='<TBD — Q2 aegis-core SPA decision>'
+# Callback must match Part 3 exactly — aegis-core-confirmed on aegis-core #76.
+CALLBACK_URL='https://aegis-app.staging.binhsu.org/auth/callback'
 
 TOKEN_RESPONSE=$(curl -s -X POST \
   "https://${COGNITO_DOMAIN}/oauth2/token" \
@@ -326,15 +324,17 @@ Teardown order:
    terraform destroy
    ```
 
-   This tears down the User Pool, app client, domain, and the three SSM parameters in dependency order.
+   This tears down the User Pool, app client, domain, IAM role, and the five SSM parameters in dependency order. The ExternalSecret was already deleted in step 2 — Terraform does not manage its lifecycle after namespace deletion.
 
-4. **Clean up SSM parameters manually** if Terraform state was lost mid-teardown:
+4. **Clean up SSM parameters manually** if Terraform state was lost mid-teardown (five parameters exist: the three consumed by the ExternalSecret plus `user-pool-arn` and `hosted-ui-domain` for operator convenience):
 
    ```bash
-   for key in user-pool-id app-client-id issuer-url; do
+   for key in user-pool-id user-pool-arn app-client-id issuer-url hosted-ui-domain; do
      aws ssm delete-parameter --name /aegis/staging/cognito/$key
    done
    ```
+
+   Note: all five SSM parameters carry `lifecycle.prevent_destroy = true` in Terraform. To destroy them, you must first remove the lifecycle block (or `terraform state rm` them before `destroy`) — this is deliberate friction.
 
 5. Remove the `cognito:` block from `config/landing-zone.yaml` so the layer plans to zero resources on any future baseline apply.
 

--- a/terraform/environments/staging/auth/README.md
+++ b/terraform/environments/staging/auth/README.md
@@ -2,26 +2,27 @@
 
 Peer Terraservice layer for the Cognito User Pool that backs cloud-mode auth for aegis-core's SPA and gateway. Implements [ADR-026](../../../../docs/decisions/026-cognito-auth-user-pool.md).
 
-> **Plan document**. This README is the blueprint the next session executes from — no `.tf` files land until aegis-core's SPA auth scaffold arrives with the final callback and logout URLs (see [aegis-core #76](https://github.com/BinHsu/aegis-core/issues/76)). The pre-implementation gate below enumerates what must be true before any `terraform apply` runs here.
+> **Implemented layer**. `.tf` files are live; this README describes the shipped reality. First-session apply follows [Runbook 008](../../../../docs/runbooks/008-cognito-user-pool-onboarding.md). The pre-implementation gate is closed (all 5 gates green) — see below for the evidence.
 
 ## What this layer owns
 
-- **Cognito User Pool** — a single pool (`aegis-<env>`) with self-signup disabled, password policy, and one immutable custom attribute `custom:tenant_id` (see ADR-026 §Decision for the attribute rationale and the soft-naming caveat).
-- **Cognito User Pool Client** (the app client consumed by the SPA) — `openid profile email` scopes, authorization-code flow, Cognito-managed `callback_urls` and `logout_urls` that accept in-place updates without recreate.
-- **Cognito-provided domain** — a `aws_cognito_user_pool_domain` resource pointing at `aegis-<env>.auth.eu-central-1.amazoncognito.com`. No ACM custom-domain work in this layer; that is a deliberately deferred slice per ADR-026 §Decision.
-- **Three SSM PS SecureString parameters** under `/aegis/<env>/cognito/*` — `user-pool-id`, `app-client-id`, `issuer-url`. All written by Terraform from the Cognito resources' attributes.
-- **One ExternalSecret CRD** — `cognito-config` in the `aegis` namespace, syncing the three SSM parameters into a single K8s Secret via the `aegis-ssm` ClusterSecretStore installed by staging/platform.
+- **Cognito User Pool** — a single pool `aegis-staging` with self-signup disabled, NIST-aligned password policy, and one immutable custom attribute `custom:tenant_id` (see ADR-026 §Decision for the attribute rationale).
+- **Cognito User Pool Client** (`aegis-cloud-spa`) — public client with no secret, `openid profile email` scopes, authorization-code + PKCE flow, plus `ALLOW_ADMIN_USER_PASSWORD_AUTH` for aegis-core's nightly integration CI (aegis-core #76 Q B).
+- **Cognito-provided domain** (`aegis-staging.auth.eu-central-1.amazoncognito.com`) — no ACM custom-domain work in this layer; that is a deliberately deferred slice per ADR-026 §Decision.
+- **Five SSM PS SecureString parameters** under `/aegis/staging/cognito/*` — `user-pool-id`, `user-pool-arn`, `app-client-id`, `issuer-url`, `hosted-ui-domain`. All written by Terraform from the Cognito resources' attributes.
+- **One ExternalSecret CRD** — `cognito-config` in the `aegis` namespace, syncing three of the SSM parameters into a single K8s Secret via the `aegis-ssm` ClusterSecretStore installed by staging/platform.
+- **One IAM role** — `github-actions-aegis-core-cognito-integration` for aegis-core's nightly CI, scoped to Cognito admin + SSM PS read on this pool only.
 
 ## What this layer does NOT own
 
 - **ACM custom domain** (`auth.staging.binhsu.org`) — future polish; requires an ACM cert in `us-east-1` for Cognito's CloudFront front-end.
 - **Identity Provider federation** (Google, GitHub, SAML) — future additive slice; add an `aws_cognito_identity_provider` resource and update the app client's `supported_identity_providers` when the demo narrative justifies it.
-- **aegis-core's SPA auth middleware** — the `/auth/callback` route, the PKCE flow, the post-logout redirect logic. All aegis-core scope; tracked on aegis-core #76.
+- **aegis-core's SPA auth middleware** — the `/auth/callback` route, the PKCE flow, the post-logout redirect logic. All aegis-core scope (shipped in aegis-core #78, #79, #80).
 - **First-user creation** — the user pool is provisioned empty. Inviting the operator as the first admin user is [Runbook 008](../../../../docs/runbooks/008-cognito-user-pool-onboarding.md) Part 2, run once after the first apply.
 
 ## Apply order
 
-This is a **baseline-tier peer layer** — long-lived, with its own Terraform state, not torn down between sessions. Rotating the user pool on every session would destroy every registered user. The contrast with cost-incurring layers matters:
+This is a **baseline-tier peer layer** with auto-apply on merge to `main`. Long-lived infrastructure: the User Pool persists across workload-tier teardown cycles. Rolling the pool destroys every registered user — Cognito does not export password hashes in an importable format.
 
 ```
 baseline tier (auto-apply on merge, never torn down):
@@ -32,55 +33,71 @@ workload tier (manual dispatch, torn down at session end):
   staging/network → staging/platform → staging/workloads → staging/observability
 ```
 
-Like `staging/observability/`, the auth layer straddles: it interacts with workload-tier resources (the ExternalSecret targets the `aegis` namespace created by staging/workloads) but its own lifecycle is baseline-tier. The resolution is the same one observability chose — apply manually after workloads exists, but do not tear down when the workload session ends. In CI terms the auth layer is **not** part of `terraform-teardown-workload.yml`.
+**Cold-cycle failure mode**: the `cognito-config` ExternalSecret targets the `aegis` namespace, which is owned by `staging/workloads`. On a fresh account where workloads has not been applied yet, the `kubectl_manifest` apply fails with `namespaces "aegis" not found`. The AWS-side resources (user pool, app client, domain, SSM params, IAM role) apply cleanly regardless. The operator sees the failure, applies workloads, re-dispatches baseline to land the ExternalSecret. This is the same mitigation shape as `staging/observability` — ADR-022 accepted it, ADR-026 inherits it.
 
-First-session bring-up order is:
+`lifecycle.prevent_destroy = true` on the User Pool AND on the five SSM parameters AND on the IAM role means subsequent workload cycles do not touch this layer's AWS resources. Only the ExternalSecret (a K8s CRD) becomes orphaned on workload teardown; External Secrets Operator stops reconciling it — not a functional issue, the K8s Secret stays until workload-teardown cleanup removes it.
 
-```
-staging/workloads (creates aegis namespace) → staging/auth (ExternalSecret lands in aegis)
-```
+In CI terms the auth layer is **not** part of `terraform-teardown-workload.yml`.
 
-After the first cold-apply cycle, the user pool persists; subsequent workload cycles (network → platform → workloads) can tear down and re-apply freely without touching `staging/auth/`.
-
-## Planned Terraform file inventory
+## Terraform file inventory
 
 | File | Purpose |
 |---|---|
-| `backend.tf` | S3 native-locking backend. Generated by `scripts/configure-backends.sh` from config.yaml, matching the `staging/observability/backend.tf` shape. |
-| `providers.tf` | AWS provider for `eu-central-1`. No multi-region slot pattern here — Cognito is primary-only in this ADR's scope. |
-| `config.tf` | `yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))`; derives `local.cognito`, `local.auth_enabled` (= `local.cognito != null`), and the SSM path prefix `/aegis/staging/cognito`. |
-| `user-pool.tf` | `aws_cognito_user_pool` + password policy + `custom:tenant_id` schema attribute. |
-| `user-pool-client.tf` | `aws_cognito_user_pool_client` with scopes, flows, and the callback / logout URL lists driven from config. |
-| `domain.tf` | `aws_cognito_user_pool_domain` for the Cognito-provided `.auth.eu-central-1.amazoncognito.com` host. |
-| `ssm.tf` | Three `aws_ssm_parameter` SecureString resources under `/aegis/staging/cognito/*`. Mirrors the `staging/observability/tokens.tf` SecureString + KMS-alias pattern. |
-| `external-secret.tf` | `kubectl_manifest` resource rendering the `cognito-config` ExternalSecret into the `aegis` namespace. Mirrors `staging/observability/external-secrets.tf`. |
-| `outputs.tf` | `user_pool_id`, `app_client_id`, `issuer_url`, `cognito_domain` — useful for cross-stack remote-state reads (e.g. future ACM custom-domain layer). |
+| `backend.tf` | S3 native-locking backend. Generated by `scripts/configure-backends.sh` from config.yaml. |
+| `versions.tf` | Provider versions — aws ~> 6.40, kubernetes ~> 2.35, kubectl ~> 1.19. |
+| `providers.tf` | AWS provider for `eu-central-1`. kubectl + kubernetes providers point at the primary cluster only (ADR-026 §Decision). |
+| `config.tf` | `yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))`; derives `local.cognito`, `local.auth_enabled`, SSM path prefix, callback/logout URLs with strawman fallbacks. |
+| `user-pool.tf` | `aws_cognito_user_pool.this` + password policy + `custom:tenant_id` schema attribute + `deletion_protection = "ACTIVE"`. |
+| `user-pool-client.tf` | `aws_cognito_user_pool_client.spa` with OAuth scopes, flows, callback/logout URL lists. |
+| `domain.tf` | `aws_cognito_user_pool_domain.this` for the Cognito-provided `.auth.eu-central-1.amazoncognito.com` host. |
+| `iam.tf` | `github-actions-aegis-core-cognito-integration` role + two inline policies (Cognito admin on this pool, SSM PS read + KMS decrypt). |
+| `ssm.tf` | Five `aws_ssm_parameter` SecureString resources under `/aegis/staging/cognito/*`. |
+| `external-secret.tf` | `kubectl_manifest` rendering the `cognito-config` ExternalSecret into the `aegis` namespace. |
+| `outputs.tf` | 8 outputs: `auth_enabled`, the five identifiers, integration role ARN, SSM paths map. |
 
-## Planned Cognito resource inventory
+## Cognito resource inventory
 
 | Resource type | Terraform resource name | Purpose | Update-safe vs. recreate |
 |---|---|---|---|
-| `aws_cognito_user_pool` | `this` | The user pool itself. Immutable attributes (`custom:tenant_id`) are declared here and cannot be added later without recreate. | **Recreate-required** on schema changes (adding / removing immutable attributes) — destroys all users. See ADR-026 §Decision. |
-| `aws_cognito_user_pool_client` | `spa` | The app client consumed by aegis-core's SPA. OIDC scopes, auth flows, callback/logout URL lists, `prevent_user_existence_errors = "ENABLED"`. | **Update-safe** on callback/logout URL list changes — Cognito accepts in-place updates. Adding a new flow or scope is also update-safe. |
-| `aws_cognito_user_pool_domain` | `this` | Cognito-provided hosted UI domain. | **Recreate** to rename (the domain prefix is in the resource name). Not a concern in lab scope — the prefix is fixed to `aegis-staging`. |
-| `aws_ssm_parameter` (x3) | `user_pool_id`, `app_client_id`, `issuer_url` | Deliver the three non-secret identifiers to the aegis namespace via External Secrets. | **Update-safe** — values change only on user-pool or app-client recreate. |
+| `aws_cognito_user_pool` | `this` | The user pool itself. Immutable attributes (`custom:tenant_id`) are declared here. | **Recreate-required** on schema changes (adding/removing immutable attributes) — destroys all users. `prevent_destroy = true` + `deletion_protection = "ACTIVE"`. |
+| `aws_cognito_user_pool_client` | `spa` | Public SPA client, no secret, PKCE flow. | **Update-safe** on callback/logout URL list changes. Adding flows or scopes is also update-safe. |
+| `aws_cognito_user_pool_domain` | `this` | Cognito-provided hosted UI domain. | **Recreate** to rename (the domain prefix is in the resource name). ~30s 5xx window during recreate. |
+| `aws_ssm_parameter` (x5) | `user_pool_id`, `user_pool_arn`, `app_client_id`, `issuer_url`, `hosted_ui_domain` | Identifier delivery to aegis namespace via ExternalSecret, plus outputs for the aegis-core nightly workflow. | **Update-safe** — values change only on user-pool or app-client recreate. All have `prevent_destroy = true`. |
 | `kubectl_manifest` | `external_secret_cognito_config` | `cognito-config` ExternalSecret in `aegis` namespace. | **Update-safe**; schema-stable against the ESO CRD. |
+| `aws_iam_role` | `aegis_core_cognito_integration` | aegis-core nightly CI assumes this via GitHub OIDC. | **Update-safe**. `prevent_destroy = true` (aegis-core has hardcoded the ARN). |
 
 ## SSM PS paths
 
-Three SecureString parameters under the `/aegis/<env>/cognito/` prefix:
+Five SecureString parameters under the `/aegis/staging/cognito/` prefix:
 
 ```
 /aegis/staging/cognito/user-pool-id
+/aegis/staging/cognito/user-pool-arn
 /aegis/staging/cognito/app-client-id
 /aegis/staging/cognito/issuer-url
+/aegis/staging/cognito/hosted-ui-domain
 ```
 
-None of these values is secret in the strict sense — `issuer-url` is a public JWKS endpoint, `user-pool-id` and `app-client-id` appear in every OAuth redirect the SPA performs. We still store them as SecureString because the **External Secrets Operator IAM policy surface** is already scoped to SecureString parameters under `/aegis/staging/*`, and splitting this one family into plain `String` would require either widening the IAM policy to both tiers or adding a second ClusterSecretStore. Neither pays back the "not really a secret" framing. Third repetition of the ADR-022 / ADR-025 reasoning: one secret-delivery channel is the simpler posture.
+None of these values is secret in the strict sense — `issuer-url` is a public JWKS endpoint, `user-pool-id` and `app-client-id` appear in every OAuth redirect the SPA performs. We still store them as SecureString because the **ESO ClusterSecretStore IAM policy surface** is already scoped to SecureString parameters under `/aegis/staging/*`, and splitting this one family into plain `String` would complicate the IAM policy for zero benefit. Third repetition of the ADR-022 / ADR-025 reasoning: one secret-delivery channel is the simpler posture.
 
 Each parameter is encrypted with `alias/aegis-staging-secrets` — the same CMK used by the Grafana Cloud and Qdrant Cloud credentials — and tagged `Name=cognito-<key>` plus the standard `Project`, `Environment`, `ManagedBy` tags.
 
-## ExternalSecret sketch
+## Outputs available
+
+For operator inspection via `terraform output` (all values are also published to SSM PS — aegis-core reads from SSM PS fresh each nightly run, not from remote_state, per aegis-core #76 Q A-2):
+
+| Output | Description |
+|---|---|
+| `auth_enabled` | True when `config.cognito` is present. |
+| `cognito_user_pool_id` | User Pool ID (e.g. `eu-central-1_abc12`). |
+| `cognito_user_pool_arn` | User Pool ARN. |
+| `cognito_app_client_id` | App Client ID for the SPA. |
+| `cognito_issuer_url` | OIDC issuer URL — the `iss` claim value on tokens. |
+| `cognito_hosted_ui_domain` | Fully-qualified Hosted UI domain (e.g. `aegis-staging.auth.eu-central-1.amazoncognito.com`). |
+| `aegis_core_cognito_integration_role_arn` | ARN of the IAM role for aegis-core's nightly CI. |
+| `ssm_paths` | Map of the five SSM PS paths for CLI retrieval. |
+
+## ExternalSecret shape
 
 ```yaml
 apiVersion: external-secrets.io/v1beta1
@@ -111,19 +128,19 @@ spec:
         key: /aegis/staging/cognito/issuer-url
 ```
 
-The three `secretKey` names are the env-var names aegis-core's gateway Deployment will `envFrom` or `valueFrom: secretKeyRef` against. Naming matches the ADR-026 §Decision contract — changing these requires a cross-repo amendment, not a unilateral refactor.
+The three `secretKey` names are the env-var names aegis-core's gateway Deployment consumes via `envFrom` or `secretKeyRef`. Changing these requires a cross-repo amendment, not a unilateral refactor.
 
 ## Config contract
 
-A new `cognito:` block under the existing staging env gates the layer's `auth_enabled` flag. Absent block = zero-resource plan (same pattern as `grafana_cloud:` gating `observability_enabled`).
+A `cognito:` block under the top-level config gates the layer's `auth_enabled` flag. Absent block = zero-resource plan (same pattern as `grafana_cloud:` gating `observability_enabled`).
 
 ```yaml
 cognito:
   domain_prefix: aegis-staging     # Cognito-provided domain prefix (<prefix>.auth.eu-central-1.amazoncognito.com)
   callback_urls:                   # app client allowed callback list (SPA OAuth redirect targets)
-    - "<TBD — Q2 aegis-core SPA decision>"
+    - "https://aegis-app.staging.binhsu.org/auth/callback"
   logout_urls:                     # app client allowed logout redirect list
-    - "<TBD — Q2 aegis-core SPA decision>"
+    - "https://aegis-app.staging.binhsu.org/"
   password_policy:
     minimum_length: 12
     require_lowercase: true
@@ -133,44 +150,44 @@ cognito:
   mfa_configuration: OFF           # "OFF" | "OPTIONAL" | "ON"; lab default OFF, demo may toggle to OPTIONAL
 ```
 
-The `callback_urls` and `logout_urls` values are **Q2 from ADR-026 — aegis-core's call**, blocked on the SPA auth scaffolding landing. This plan deliberately does **not** pin strawman URL values as if they were final. The implementation PR that lands the `.tf` files seeds strawman values aligned with aegis-core's answer on #76; until that answer arrives, the config block stays commented out and the layer plans to zero resources.
+Callback and logout URLs are **aegis-core-confirmed 2026-04-23** on aegis-core #76 — the strawman values originally hedged in the plan doc are now the pinned final values. `terraform apply` with these values produces a stable plan aligned with aegis-core's SPA auth scaffold (shipped in aegis-core #79).
 
-The `config/schema.json` addition is out of scope for this plan-only PR and lands alongside the implementation PR.
+Password policy and MFA have `try()` fallbacks in `config.tf` — forkers who want lab defaults can omit both subfields.
 
-## Pre-implementation gate
+See `config/landing-zone.example.yaml` for the commented-out template block a forker uncomments to enable the layer.
 
-Before anyone runs `terraform apply` on `staging/auth/` for the first time, all of the following must be true:
+## Pre-implementation gate — all 5 green (as of this PR)
 
-1. **aegis-core SPA auth scaffolding is merged** — the `/auth/callback` route, PKCE flow wiring, and post-logout redirect logic exist in aegis-core's `main`.
-2. **Q2 answer is posted to aegis-core #76** — final `callback_urls` and `logout_urls` values are documented on the issue.
-3. **`config/landing-zone.yaml` has a populated `cognito:` block** — with the URL values from step 2, not strawman placeholders.
-4. **ADR-026 is amended to Accepted** — the open question is closed and the URL values are reflected in the ADR.
-5. **The `aegis` namespace exists** — i.e. `staging/workloads` has been applied in the session's current cold-apply cycle (the ExternalSecret depends on the namespace).
+| Gate | Status | Evidence |
+|---|---|---|
+| 1. aegis-core SPA auth scaffolding merged | Green | aegis-core #78 (gateway JWT middleware), #79 (SPA OAuth scaffold), #80 (tenant propagation) all on aegis-core `main` 2026-04-23 |
+| 2. Q2 callback/logout URLs posted to aegis-core #76 | Green | aegis-core #76 status comment 2026-04-23 12:26 UTC confirmed strawman values as final |
+| 3. `config/landing-zone.yaml` has a populated `cognito:` block | Gated at apply time | Operator populates during first-apply per Runbook 008; config is gitignored |
+| 4. ADR-026 amended to Accepted | Pending | ADR is Partially Accepted — promotes to Accepted on the URL-confirmation amendment landing alongside this PR. Not a blocker for apply. |
+| 5. `aegis` namespace exists | Cold-cycle gated | First apply cycle where workloads has not been applied yet fails the ExternalSecret step; AWS-side resources apply cleanly. Operator applies workloads + re-dispatches baseline. |
 
-Only after all five gates are green does the first apply make sense. Skipping any one of them produces either a Terraform error (gate 5) or a silent misconfiguration that forces a user-pool recreate (gates 1–4).
+Gates 1–2 are fully green. Gates 3–5 resolve at operator-apply time per the normal baseline-on-merge flow.
 
 ## First-operator steps
 
-See [docs/runbooks/008-cognito-user-pool-onboarding.md](../../../../docs/runbooks/008-cognito-user-pool-onboarding.md). The runbook covers the end-to-end flow: Terraform apply, first admin user creation via `aws cognito-idp admin-create-user`, Hosted UI login verification, JWKS-based token smoke test, and the credential rotation procedure.
+See [docs/runbooks/008-cognito-user-pool-onboarding.md](../../../../docs/runbooks/008-cognito-user-pool-onboarding.md). The runbook covers the end-to-end flow: confirming the baseline apply succeeded, first admin user creation via `aws cognito-idp admin-create-user`, Hosted UI login verification, JWKS-based token smoke test, and the credential / user rotation procedure.
 
 ## Teardown
 
 Teardown is **manual and rare**. Rolling the Cognito user pool destroys every registered user — Cognito does not export password hashes in a re-importable format, so "tear down and re-apply" is equivalent to "every user re-registers from scratch". That is fine for a single-operator lab and catastrophic for anything larger.
 
-The safe path when teardown is actually needed (abandoning the lab permanently, or migrating to a different IdP):
-
-1. Run `aws cognito-idp list-users --user-pool-id <id> --output json > users-backup.json` and store it off-repo. This captures usernames and (non-hash) attributes for a manual re-invite flow on the successor IdP.
-2. Delete the ExternalSecret first (`kubectl delete externalsecret cognito-config -n aegis`) so the K8s Secret does not flap while the SSM parameters are being destroyed.
-3. `terraform destroy` in `staging/auth/`.
-4. Delete SSM parameters manually if Terraform state was lost: `aws ssm delete-parameter --name /aegis/staging/cognito/<key>` for each of the three keys.
+Layers of protection:
+1. `lifecycle.prevent_destroy = true` on the User Pool, the five SSM parameters, and the IAM role.
+2. `deletion_protection = "ACTIVE"` on the User Pool (Cognito-side safety net).
+3. The teardown procedure in [Runbook 008 §Permanent teardown](../../../../docs/runbooks/008-cognito-user-pool-onboarding.md#permanent-teardown) explicitly documents the order (user export → ExternalSecret delete → Terraform destroy → SSM manual cleanup).
 
 Per-session workload teardown **must not** touch this layer. `terraform-teardown-workload.yml` is scoped to the workload-tier layers; if a future PR extends that workflow to include `staging/auth/`, it is a design regression and must be rejected.
 
 ## Related
 
-- [ADR-026](../../../../docs/decisions/026-cognito-auth-user-pool.md) — the backing decision and the Q2 open-question source of truth.
+- [ADR-026](../../../../docs/decisions/026-cognito-auth-user-pool.md) — the backing decision.
 - [ADR-022](../../../../docs/decisions/022-observability-backend-grafana-cloud.md) — precedent for the peer-layer + SSM PS + ExternalSecret pattern.
 - [ADR-023](../../../../docs/decisions/023-observability-responsibility-model.md) — the External Secrets responsibility split reused here.
-- [ADR-025](../../../../docs/decisions/025-qdrant-backend-cloud-free-tier.md) — the most recent ADR with a deferred-implementation gate; this layer follows the same shape.
+- [ADR-025](../../../../docs/decisions/025-qdrant-backend-cloud-free-tier.md) — the most recent ADR with a deferred-implementation gate; this layer followed the same shape.
 - [Runbook 008](../../../../docs/runbooks/008-cognito-user-pool-onboarding.md) — operational procedures.
-- [aegis-core #76](https://github.com/BinHsu/aegis-core/issues/76) — the live consumption-contract coordination thread, including the Q2 callback/logout URL decision.
+- [aegis-core #76](https://github.com/BinHsu/aegis-core/issues/76) — the consumption-contract coordination thread, including the Q2 callback/logout URL decision.

--- a/terraform/environments/staging/auth/backend.tf
+++ b/terraform/environments/staging/auth/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "staging/auth/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/terraform/environments/staging/auth/config.tf
+++ b/terraform/environments/staging/auth/config.tf
@@ -1,0 +1,191 @@
+# -----------------------------------------------------------------------------
+# Configuration Contract — ADR-004, ADR-026
+# -----------------------------------------------------------------------------
+# Peer Terraservice layer for the Cognito User Pool that backs cloud-mode
+# auth for aegis-core's SPA and gateway (ADR-026).
+#
+# Gate: presence of config.cognito. Without the block, the whole layer
+# plans to zero resources — forkers can apply a fresh staging without
+# enabling auth, then enable it later by adding the `cognito:` block and
+# re-applying. Mirrors staging/observability/config.tf observability_enabled
+# gate.
+#
+# Lifecycle posture (ADR-026 §Decision):
+#   - Baseline-tier: auto-apply on merge to main, never torn down by
+#     terraform-teardown-workload.yml.
+#   - User Pool + SSM parameters carry `lifecycle.prevent_destroy = true`.
+#     Teardown is explicit via Runbook 008 §Permanent teardown.
+#   - Rolling the User Pool destroys every registered user — Cognito does
+#     not export password hashes in an importable format.
+#
+# This layer is primary-only (ADR-026 §Decision). No slot pattern, no
+# K=2 guard — Cognito's resources are global per pool. If the top-level
+# config declares eks.staging.regions with length > 2 it is still a
+# repo-wide governance breach and the sibling layers will refuse to plan;
+# this layer does not need its own guard because it reads zero
+# slot-dependent state.
+# -----------------------------------------------------------------------------
+
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.staging.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+
+  # Cognito block — gate for the whole layer.
+  cognito      = try(local.config.cognito, null)
+  auth_enabled = local.cognito != null
+
+  # SSM PS path prefix — ADR-026 §Decision. All Cognito-related identifiers
+  # live under this prefix so the ESO ClusterSecretStore IAM policy can
+  # scope to the whole family with a single wildcard (which it already
+  # does for /aegis/staging/* — see staging/platform ESO IRSA).
+  ssm_path_prefix = "/aegis/staging/cognito"
+
+  # Callback + logout URL lists. Strawman defaults per aegis-core #76
+  # (2026-04-23) — SPA's OAuth redirect target + post-logout landing URL.
+  # Defensive fallback: Cognito requires at least one entry in each list;
+  # an empty list in config would make the apply fail with an unhelpful
+  # error. Keep the strawman default so the layer always plans cleanly.
+  callback_urls = try(
+    length(local.cognito.callback_urls) > 0 ? local.cognito.callback_urls : null,
+    null,
+  ) != null ? local.cognito.callback_urls : ["https://aegis-app.staging.binhsu.org/auth/callback"]
+
+  logout_urls = try(
+    length(local.cognito.logout_urls) > 0 ? local.cognito.logout_urls : null,
+    null,
+  ) != null ? local.cognito.logout_urls : ["https://aegis-app.staging.binhsu.org/"]
+
+  # Domain prefix — Cognito-provided hosted UI
+  # (<prefix>.auth.<region>.amazoncognito.com). Fixed to "aegis-staging"
+  # for this lab; forkers override via config.
+  domain_prefix = try(local.cognito.domain_prefix, "aegis-staging")
+
+  # Password policy — lab defaults roughly mirror NIST SP 800-63B
+  # minimum-12-chars guidance.
+  password_policy = try(local.cognito.password_policy, {
+    minimum_length    = 12
+    require_lowercase = true
+    require_uppercase = true
+    require_numbers   = true
+    require_symbols   = true
+  })
+
+  # MFA posture. Lab default OFF (self-operator only); forkers running
+  # demo scenarios may toggle to OPTIONAL without a schema change.
+  # ON is not recommended for MVP — Cognito ON requires an SMS / TOTP
+  # factor configured per user and hard-fails login if absent.
+  mfa_configuration = try(local.cognito.mfa_configuration, "OFF")
+
+  tags = merge(local.config.tags, {
+    Environment = "staging"
+    Component   = "auth"
+  })
+
+  # Per-cluster details read from staging/platform's per-slot clusters map.
+  # Auth targets the primary cluster only (see providers.tf rationale).
+  clusters = try(data.terraform_remote_state.staging_platform.outputs.clusters, {})
+}
+
+# -----------------------------------------------------------------------------
+# Cross-field invariants — mirror of staging/observability
+# -----------------------------------------------------------------------------
+
+check "exactly_one_primary_region" {
+  assert {
+    condition     = length([for r in local.config.regions : r if r.role == "primary"]) == 1
+    error_message = "config/landing-zone.yaml regions[] must have exactly one entry with role: primary."
+  }
+}
+
+check "mfa_configuration_valid" {
+  assert {
+    condition     = contains(["OFF", "OPTIONAL", "ON"], local.mfa_configuration)
+    error_message = "cognito.mfa_configuration must be one of OFF, OPTIONAL, ON — got '${local.mfa_configuration}'."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cross-layer state read — consume platform's clusters map
+# -----------------------------------------------------------------------------
+# Auth is a peer layer that depends on staging/platform (EKS cluster must
+# exist for the kubectl provider to reach the primary apiserver) AND on
+# staging/workloads (the `aegis` namespace must exist for the
+# cognito-config ExternalSecret to land in that namespace). Apply
+# ordering for the ExternalSecret is enforced operationally: on a cold
+# cycle where workloads has not been applied yet, the kubectl_manifest
+# apply fails with "namespaces \"aegis\" not found" and the operator
+# re-dispatches baseline after workloads. The AWS-side resources
+# (user pool, app client, domain, SSM params) apply cleanly regardless.
+# -----------------------------------------------------------------------------
+
+data "terraform_remote_state" "staging_platform" {
+  backend = "s3"
+  config = {
+    bucket = "${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}"
+    key    = "staging/platform/terraform.tfstate"
+    region = local.primary_region
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+check "expected_account" {
+  assert {
+    condition     = data.aws_caller_identity.current.account_id == local.account_id
+    error_message = "Running against the wrong AWS account (${data.aws_caller_identity.current.account_id}) — staging/auth must be applied with credentials for ${local.account_id} (aegis-staging)."
+  }
+}
+
+check "platform_layer_applied" {
+  assert {
+    condition = (
+      !local.auth_enabled
+      || (
+        data.terraform_remote_state.staging_platform.outputs != null
+        && try(contains(keys(data.terraform_remote_state.staging_platform.outputs.clusters), "primary"), false)
+      )
+    )
+    error_message = "staging/platform has not been applied or its clusters map is missing the primary slot. Apply staging/platform before staging/auth (gh workflow run terraform-apply-workload.yml -f env=staging)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# SSM PS SecureString encryption key — contract with staging/bootstrap
+# -----------------------------------------------------------------------------
+# Alias `alias/aegis-staging-secrets` is owned by
+# staging/bootstrap/kms-secrets.tf. Looked up by alias to avoid chaining
+# bootstrap state into this layer. The check below fires a readable
+# error if a forker attempts auth before bootstrap.
+# -----------------------------------------------------------------------------
+
+data "aws_kms_alias" "secrets" {
+  count = local.auth_enabled ? 1 : 0
+
+  name = "alias/aegis-staging-secrets"
+}
+
+check "secrets_kms_key_exists" {
+  assert {
+    condition = (
+      !local.auth_enabled
+      || try(data.aws_kms_alias.secrets[0].target_key_arn, "") != ""
+    )
+    error_message = "config.cognito is set but KMS alias 'alias/aegis-staging-secrets' is missing. Apply staging/bootstrap first (baseline layer, auto-applied on PR merge — see staging/bootstrap/kms-secrets.tf)."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# GitHub OIDC provider — lookup from staging/bootstrap
+# -----------------------------------------------------------------------------
+# The aegis-core integration IAM role assumes via the GitHub OIDC
+# provider created in staging/bootstrap/oidc-github.tf. Looked up by URL
+# so we do not chain bootstrap state into this layer's inputs.
+# -----------------------------------------------------------------------------
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = local.auth_enabled ? 1 : 0
+
+  url = "https://token.actions.githubusercontent.com"
+}

--- a/terraform/environments/staging/auth/domain.tf
+++ b/terraform/environments/staging/auth/domain.tf
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------
+# Cognito User Pool Domain — Cognito-provided hosted UI domain (ADR-026)
+# -----------------------------------------------------------------------------
+# Fixed to the Cognito-provided `<prefix>.auth.<region>.amazoncognito.com`
+# host per ADR-026 §Decision. Custom domain (`auth.staging.binhsu.org`)
+# is deferred scope — requires an ACM cert in us-east-1 for Cognito's
+# CloudFront front-end plus a Route53 record, neither of which pays off
+# until demo polish matters.
+#
+# The domain prefix must be globally unique within the region. If a
+# forker hits a collision, they bump the prefix in config.cognito.
+# domain_prefix — this is why the default lives in config.tf with a
+# try() fallback, not hardcoded here.
+#
+# Recreate semantics: changing the domain prefix forces recreate of the
+# aws_cognito_user_pool_domain resource (the prefix is in the resource
+# name). During recreate there is a ~30s window where the Hosted UI
+# login URL returns 5xx; acceptable for a lab, not for production. If
+# this becomes a concern, front the domain with a custom ACM cert so
+# the prefix change becomes invisible to users.
+# -----------------------------------------------------------------------------
+
+resource "aws_cognito_user_pool_domain" "this" {
+  count = local.auth_enabled ? 1 : 0
+
+  domain       = local.domain_prefix
+  user_pool_id = aws_cognito_user_pool.this[0].id
+}

--- a/terraform/environments/staging/auth/external-secret.tf
+++ b/terraform/environments/staging/auth/external-secret.tf
@@ -1,0 +1,85 @@
+# -----------------------------------------------------------------------------
+# ExternalSecret — sync Cognito identifiers into aegis namespace (ADR-026)
+# -----------------------------------------------------------------------------
+# Single ExternalSecret in the `aegis` namespace, reconciled by External
+# Secrets Operator via the `aegis-ssm` ClusterSecretStore (installed in
+# staging/platform PR-1). Produces a K8s Secret `cognito-config` with
+# three keys (COGNITO_USER_POOL_ID, COGNITO_APP_CLIENT_ID,
+# COGNITO_ISSUER_URL) that aegis-core's gateway Deployment consumes via
+# `envFrom` or `secretKeyRef`.
+#
+# Naming is a hard contract (ADR-026 §Decision):
+#   - Secret name `cognito-config`
+#   - Key names `COGNITO_USER_POOL_ID`, `COGNITO_APP_CLIENT_ID`,
+#     `COGNITO_ISSUER_URL`
+# Changing these requires a cross-repo amendment with aegis-core, not a
+# unilateral refactor.
+#
+# Target namespace `aegis` is owned by staging/workloads
+# (modules/eks-workloads/namespace.tf). On a cold cycle where workloads
+# has not been applied yet, this kubectl_manifest fails with
+# `namespaces "aegis" not found`. That is the intended failure mode:
+# operator sees the error, applies workloads, re-dispatches baseline.
+# The AWS-side resources (user pool, app client, domain, SSM params)
+# apply cleanly regardless.
+#
+# kubectl_manifest over kubernetes_manifest: ExternalSecret is a CRD
+# shipped by ESO. kubernetes_manifest requires the CRD to be reachable
+# at plan time which fails on cold apply before ESO has installed its
+# CRDs. kubectl_manifest defers schema validation to apply time —
+# identical pattern to staging/observability/external-secrets.tf.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "external_secret_cognito_config" {
+  count = local.auth_enabled ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "cognito-config"
+      namespace = "aegis"
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+        "app.kubernetes.io/part-of"    = "platform"
+      }
+    }
+    spec = {
+      refreshInterval = "1h"
+      secretStoreRef = {
+        name = "aegis-ssm"
+        kind = "ClusterSecretStore"
+      }
+      target = {
+        name           = "cognito-config"
+        creationPolicy = "Owner"
+      }
+      data = [
+        {
+          secretKey = "COGNITO_USER_POOL_ID"
+          remoteRef = {
+            key = "${local.ssm_path_prefix}/user-pool-id"
+          }
+        },
+        {
+          secretKey = "COGNITO_APP_CLIENT_ID"
+          remoteRef = {
+            key = "${local.ssm_path_prefix}/app-client-id"
+          }
+        },
+        {
+          secretKey = "COGNITO_ISSUER_URL"
+          remoteRef = {
+            key = "${local.ssm_path_prefix}/issuer-url"
+          }
+        },
+      ]
+    }
+  })
+
+  depends_on = [
+    aws_ssm_parameter.user_pool_id,
+    aws_ssm_parameter.app_client_id,
+    aws_ssm_parameter.issuer_url,
+  ]
+}

--- a/terraform/environments/staging/auth/iam.tf
+++ b/terraform/environments/staging/auth/iam.tf
@@ -1,0 +1,128 @@
+# -----------------------------------------------------------------------------
+# aegis-core integration IAM role — nightly CI (aegis-core #76 Q B)
+# -----------------------------------------------------------------------------
+# aegis-core's nightly integration workflow on `main` needs to exercise
+# the Cognito user pool end-to-end: create a scratch user, mint a token,
+# call the gateway, clean up. Rather than sharing a long-lived admin
+# role, we provision a dedicated least-privilege role scoped to Cognito
+# admin operations on THIS pool only.
+#
+# Same pattern as the existing `github-actions-aegis-core-ecr` and
+# `github-actions-aegis-core-cache` roles in staging/bootstrap/oidc-
+# aegis-core.tf — the aegis-core repo gets per-function least-privilege
+# roles, never a catch-all admin role.
+#
+# Lifecycle: aegis-core has hardcoded this role's ARN in their nightly
+# workflow. `prevent_destroy = true` on the role prevents an accidental
+# Terraform destroy from breaking their CI overnight.
+# -----------------------------------------------------------------------------
+
+locals {
+  # Wildcard variable keeps sub-claim construction readable and scopeable
+  # if we ever widen access beyond `main` (e.g. a nightly branch).
+  aegis_core_repo_ref = "repo:${local.config.github.org}/${local.config.github.app_repo}:ref:refs/heads/main"
+}
+
+resource "aws_iam_role" "aegis_core_cognito_integration" {
+  count = local.auth_enabled ? 1 : 0
+
+  name = "github-actions-aegis-core-cognito-integration"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = data.aws_iam_openid_connect_provider.github[0].arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = local.aegis_core_repo_ref
+        }
+      }
+    }]
+  })
+
+  tags = merge(local.tags, {
+    Name = "github-actions-aegis-core-cognito-integration"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cognito admin policy — scoped to this pool only
+# -----------------------------------------------------------------------------
+# The nightly integration test:
+#   1. AdminCreateUser      — invite a scratch user
+#   2. AdminSetUserPassword — skip the reset flow
+#   3. AdminInitiateAuth    — mint tokens without browser interaction
+#   4. AdminGetUser         — idempotency check on repeat runs
+#   5. AdminDeleteUser      — clean up at end of test
+#
+# All actions scoped to the `this` pool ARN — the role has zero
+# authority on any other Cognito resource in the account.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role_policy" "aegis_core_cognito_integration" {
+  count = local.auth_enabled ? 1 : 0
+
+  name = "cognito-integration"
+  role = aws_iam_role.aegis_core_cognito_integration[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "CognitoAdminOnThisPool"
+      Effect = "Allow"
+      Action = [
+        "cognito-idp:AdminCreateUser",
+        "cognito-idp:AdminSetUserPassword",
+        "cognito-idp:AdminInitiateAuth",
+        "cognito-idp:AdminGetUser",
+        "cognito-idp:AdminDeleteUser",
+      ]
+      Resource = aws_cognito_user_pool.this[0].arn
+    }]
+  })
+}
+
+# -----------------------------------------------------------------------------
+# SSM PS read policy — aegis-core reads outputs fresh each nightly run
+# -----------------------------------------------------------------------------
+# aegis-core #76 Q A-2: instead of hardcoding user-pool-id, app-client-id
+# etc. into their CI, they read them from SSM PS on each run. Survives
+# a pool recreate without an aegis-core code change.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role_policy" "aegis_core_ssm_read" {
+  count = local.auth_enabled ? 1 : 0
+
+  name = "ssm-cognito-read"
+  role = aws_iam_role.aegis_core_cognito_integration[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadCognitoParams"
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+        ]
+        Resource = "arn:aws:ssm:${local.primary_region}:${local.account_id}:parameter${local.ssm_path_prefix}/*"
+      },
+      {
+        Sid      = "DecryptCognitoParams"
+        Effect   = "Allow"
+        Action   = "kms:Decrypt"
+        Resource = data.aws_kms_alias.secrets[0].target_key_arn
+      },
+    ]
+  })
+}

--- a/terraform/environments/staging/auth/outputs.tf
+++ b/terraform/environments/staging/auth/outputs.tf
@@ -1,0 +1,69 @@
+# -----------------------------------------------------------------------------
+# Outputs — aegis-core consumption contract (aegis-core #76 Q A)
+# -----------------------------------------------------------------------------
+# Six outputs documented as the stable surface this layer exposes:
+#
+#   - cognito_user_pool_id                  — for gateway + CI
+#   - cognito_user_pool_arn                 — for IAM policies
+#   - cognito_app_client_id                 — for SPA + gateway aud check
+#   - cognito_issuer_url                    — for JWKS / OIDC discovery
+#   - cognito_hosted_ui_domain              — for OAuth redirect URLs
+#   - aegis_core_cognito_integration_role_arn — aegis-core nightly CI assumes
+#
+# Values are wrapped in try() so `terraform output` works even when the
+# layer has auth_enabled = false (it prints null for everything). No
+# sensitive = true — none of these are secrets; they appear in every
+# OAuth redirect the SPA performs anyway.
+#
+# aegis-core reads values via SSM PS on each nightly run (per #76 Q A-2),
+# not via remote_state. These outputs exist for:
+#   - operator inspection (`terraform output`)
+#   - a future same-repo layer that wants remote_state access
+#   - debuggability when the SSM PS chain fails
+# -----------------------------------------------------------------------------
+
+output "auth_enabled" {
+  description = "Whether the auth layer provisioned any resources (true when config.cognito is present, false otherwise)."
+  value       = local.auth_enabled
+}
+
+output "cognito_user_pool_id" {
+  description = "Cognito User Pool ID (e.g. eu-central-1_abc12). Null when auth_enabled=false. Also published at SSM PS /aegis/staging/cognito/user-pool-id."
+  value       = try(aws_cognito_user_pool.this[0].id, null)
+}
+
+output "cognito_user_pool_arn" {
+  description = "Cognito User Pool ARN. Null when auth_enabled=false. Also published at SSM PS /aegis/staging/cognito/user-pool-arn."
+  value       = try(aws_cognito_user_pool.this[0].arn, null)
+}
+
+output "cognito_app_client_id" {
+  description = "Cognito App Client ID for the SPA. Null when auth_enabled=false. Also published at SSM PS /aegis/staging/cognito/app-client-id."
+  value       = try(aws_cognito_user_pool_client.spa[0].id, null)
+}
+
+output "cognito_issuer_url" {
+  description = "OIDC issuer URL; the iss claim value of tokens issued by this pool. Null when auth_enabled=false. Also published at SSM PS /aegis/staging/cognito/issuer-url."
+  value       = local.auth_enabled ? "https://cognito-idp.${local.primary_region}.amazonaws.com/${aws_cognito_user_pool.this[0].id}" : null
+}
+
+output "cognito_hosted_ui_domain" {
+  description = "Fully-qualified Hosted UI domain (e.g. aegis-staging.auth.eu-central-1.amazoncognito.com). Null when auth_enabled=false. Also published at SSM PS /aegis/staging/cognito/hosted-ui-domain."
+  value       = local.auth_enabled ? "${aws_cognito_user_pool_domain.this[0].domain}.auth.${local.primary_region}.amazoncognito.com" : null
+}
+
+output "aegis_core_cognito_integration_role_arn" {
+  description = "ARN of the IAM role aegis-core's nightly integration workflow assumes via GitHub OIDC. Scoped to Cognito admin actions on the staging user pool + SSM PS read on /aegis/staging/cognito/*. Null when auth_enabled=false."
+  value       = try(aws_iam_role.aegis_core_cognito_integration[0].arn, null)
+}
+
+output "ssm_paths" {
+  description = "SSM PS paths for the five Cognito identifiers. Values are NOT output (secure by location). Retrieve with: aws ssm get-parameter --name <path> --with-decryption."
+  value = local.auth_enabled ? {
+    user_pool_id     = "${local.ssm_path_prefix}/user-pool-id"
+    user_pool_arn    = "${local.ssm_path_prefix}/user-pool-arn"
+    app_client_id    = "${local.ssm_path_prefix}/app-client-id"
+    issuer_url       = "${local.ssm_path_prefix}/issuer-url"
+    hosted_ui_domain = "${local.ssm_path_prefix}/hosted-ui-domain"
+  } : null
+}

--- a/terraform/environments/staging/auth/providers.tf
+++ b/terraform/environments/staging/auth/providers.tf
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+# Providers — primary-only, no slot pattern (ADR-026 §Decision)
+# -----------------------------------------------------------------------------
+# Cognito is a single global-per-pool resource per environment. Unlike
+# staging/platform and staging/workloads, this layer has no K=2 slot
+# pattern — there is one pool, one app client, one domain. The kubectl
+# provider points at the PRIMARY cluster only because the ExternalSecret
+# is created via Terraform here (not reconciled via ArgoCD from multiple
+# clusters); the slave cluster also runs ESO but its reconciler will not
+# see the `cognito-config` ExternalSecret because this resource lands in
+# the primary's apiserver state only. If a future amendment multiplies
+# the ExternalSecret across both clusters (unlikely — the SSM PS values
+# are identical, one Secret per cluster is enough), migrate to ArgoCD-
+# reconciled manifests rather than adding a second kubectl provider.
+#
+# Same lazy-evaluation pattern as observability: provider blocks
+# reference `local.clusters.primary.*` which resolves at apply time
+# after the terraform_remote_state data source returns. On cold apply
+# without platform applied yet, the check "platform_layer_applied" in
+# config.tf surfaces a readable error.
+# -----------------------------------------------------------------------------
+
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}
+
+provider "kubernetes" {
+  host                   = try(local.clusters.primary.cluster_endpoint, "")
+  cluster_ca_certificate = try(base64decode(local.clusters.primary.cluster_certificate_authority_data), "")
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", try(local.clusters.primary.cluster_name, ""), "--region", local.primary_region]
+  }
+}
+
+provider "kubectl" {
+  host                   = try(local.clusters.primary.cluster_endpoint, "")
+  cluster_ca_certificate = try(base64decode(local.clusters.primary.cluster_certificate_authority_data), "")
+  load_config_file       = false
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", try(local.clusters.primary.cluster_name, ""), "--region", local.primary_region]
+  }
+}

--- a/terraform/environments/staging/auth/ssm.tf
+++ b/terraform/environments/staging/auth/ssm.tf
@@ -1,0 +1,156 @@
+# -----------------------------------------------------------------------------
+# SSM PS writeback — Cognito identifiers for aegis-core consumption (ADR-026)
+# -----------------------------------------------------------------------------
+# Five SecureString parameters encrypted with the shared secrets CMK
+# (alias/aegis-staging-secrets). External Secrets Operator reads three
+# of them (user-pool-id, app-client-id, issuer-url) via the `aegis-ssm`
+# ClusterSecretStore and reconciles them into the `cognito-config` K8s
+# Secret in the `aegis` namespace.
+#
+# Why SecureString even though these are not strictly secret (issuer-url
+# is a public JWKS URL, user-pool-id and app-client-id leak in every
+# OAuth redirect): the ESO ClusterSecretStore IAM policy is already
+# scoped to SecureString parameters under /aegis/staging/*. Splitting
+# one family to plain `String` would complicate the IAM policy for
+# zero benefit. Consistency with grafana_cloud + qdrant_cloud wins.
+#
+# SSM Parameter Store does NOT support a KMS key alias via the
+# `alias/...` shorthand; it requires the target key ARN. We resolve it
+# via the `data "aws_kms_alias" "secrets"` lookup in config.tf.
+#
+# prevent_destroy = true: accidental `terraform destroy` of these
+# parameters would break the `cognito-config` ExternalSecret reconcile
+# loop until a re-apply. The User Pool itself has prevent_destroy for
+# user-data reasons; these SSM params mirror it so Terraform refuses to
+# lose pool → credential linkage without explicit operator action.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# 1. user-pool-id — consumed by gateway's OIDC middleware + aegis-core CI
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "user_pool_id" {
+  count = local.auth_enabled ? 1 : 0
+
+  name        = "${local.ssm_path_prefix}/user-pool-id"
+  description = "Cognito User Pool ID (e.g. eu-central-1_abc12). Provisioned by terraform/environments/staging/auth/; consumed by ExternalSecret → K8s Secret cognito-config (key COGNITO_USER_POOL_ID) in ns aegis, and by aegis-core's nightly integration workflow."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  tier        = "Standard"
+  value       = aws_cognito_user_pool.this[0].id
+
+  tags = merge(local.tags, {
+    Name = "cognito-user-pool-id"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# 2. user-pool-arn — useful for IAM policies if the role grows
+# -----------------------------------------------------------------------------
+# Not currently consumed by the K8s-side ExternalSecret (gateway does
+# not need the ARN, only the pool ID for issuer-URL construction). Kept
+# as a Terraform output + SSM PS writeback for future consumers (e.g. a
+# Verified Permissions policy or a Lambda hook).
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "user_pool_arn" {
+  count = local.auth_enabled ? 1 : 0
+
+  name        = "${local.ssm_path_prefix}/user-pool-arn"
+  description = "Cognito User Pool ARN. Provisioned by terraform/environments/staging/auth/; not currently wired through ExternalSecret but available for future IAM policy targets or Lambda hooks."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  tier        = "Standard"
+  value       = aws_cognito_user_pool.this[0].arn
+
+  tags = merge(local.tags, {
+    Name = "cognito-user-pool-arn"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# 3. app-client-id — consumed by SPA + gateway (audience claim check)
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "app_client_id" {
+  count = local.auth_enabled ? 1 : 0
+
+  name        = "${local.ssm_path_prefix}/app-client-id"
+  description = "Cognito App Client ID for the aegis SPA. Provisioned by terraform/environments/staging/auth/; consumed by ExternalSecret → K8s Secret cognito-config (key COGNITO_APP_CLIENT_ID) in ns aegis, and by the SPA's OAuth redirect URLs."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  tier        = "Standard"
+  value       = aws_cognito_user_pool_client.spa[0].id
+
+  tags = merge(local.tags, {
+    Name = "cognito-app-client-id"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# 4. issuer-url — consumed by gateway for OIDC discovery + JWKS
+# -----------------------------------------------------------------------------
+# Format: https://cognito-idp.<region>.amazonaws.com/<user-pool-id>
+# This is the `iss` claim value tokens will carry AND the base URL for
+# Cognito's OIDC discovery document (/.well-known/openid-configuration)
+# plus JWKS endpoint (/.well-known/jwks.json).
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "issuer_url" {
+  count = local.auth_enabled ? 1 : 0
+
+  name        = "${local.ssm_path_prefix}/issuer-url"
+  description = "Cognito OIDC issuer URL. Provisioned by terraform/environments/staging/auth/; consumed by ExternalSecret → K8s Secret cognito-config (key COGNITO_ISSUER_URL) in ns aegis. Format: https://cognito-idp.<region>.amazonaws.com/<user-pool-id>. JWKS lives at <issuer>/.well-known/jwks.json."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  tier        = "Standard"
+  value       = "https://cognito-idp.${local.primary_region}.amazonaws.com/${aws_cognito_user_pool.this[0].id}"
+
+  tags = merge(local.tags, {
+    Name = "cognito-issuer-url"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# 5. hosted-ui-domain — full hosted-UI URL (convenience output)
+# -----------------------------------------------------------------------------
+# Full URL: <prefix>.auth.<region>.amazoncognito.com. aegis-core's
+# nightly integration workflow and any browser-redirect tooling reads
+# this instead of reconstructing from prefix + region. Avoids drift if
+# we ever cut over to a custom domain in a future amendment.
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "hosted_ui_domain" {
+  count = local.auth_enabled ? 1 : 0
+
+  name        = "${local.ssm_path_prefix}/hosted-ui-domain"
+  description = "Cognito Hosted UI fully-qualified domain. Provisioned by terraform/environments/staging/auth/; consumed by aegis-core's nightly integration workflow for OAuth URL construction. Format: <prefix>.auth.<region>.amazoncognito.com."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  tier        = "Standard"
+  value       = "${aws_cognito_user_pool_domain.this[0].domain}.auth.${local.primary_region}.amazoncognito.com"
+
+  tags = merge(local.tags, {
+    Name = "cognito-hosted-ui-domain"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/environments/staging/auth/user-pool-client.tf
+++ b/terraform/environments/staging/auth/user-pool-client.tf
@@ -1,0 +1,85 @@
+# -----------------------------------------------------------------------------
+# Cognito User Pool Client — public SPA client for aegis-core (ADR-026)
+# -----------------------------------------------------------------------------
+# Single app client for the aegis-core SPA. Public client (no secret)
+# because it runs in a browser — the authorization-code + PKCE flow
+# replaces the client_secret for security.
+#
+# Token lifetimes: Cognito defaults (1h access, 30d refresh). Accepted
+# by aegis-core #76 Q5. Tighten only if cold-apply smoke reveals UX
+# pacing issues — shorter access tokens = more refresh calls = more
+# gateway load for no demo-level benefit.
+#
+# OAuth flows + scopes (aegis-core #76 Q3): `openid profile email`
+# scopes with `authorization-code` flow. No custom scopes — role-based
+# authorization lives in `custom:tenant_id` claim, not in OAuth scopes.
+#
+# ALLOW_ADMIN_USER_PASSWORD_AUTH is specifically enabled for aegis-core's
+# nightly integration test (aegis-core #76 Q B) — their test harness
+# uses `AdminInitiateAuth` with the `ADMIN_USER_PASSWORD_AUTH` flow to
+# mint a token without browser interaction. Production login flows all
+# go through USER_SRP_AUTH via the Hosted UI.
+#
+# Callback + logout URLs: Cognito accepts in-place updates to these
+# lists without recreate (aws_cognito_user_pool_client is update-safe on
+# these fields). aegis-core #76 Q2 confirmed the strawman values as
+# final; they now live in `config/landing-zone.yaml` (or fall back to
+# the strawman defaults in config.tf).
+# -----------------------------------------------------------------------------
+
+resource "aws_cognito_user_pool_client" "spa" {
+  count = local.auth_enabled ? 1 : 0
+
+  name         = "aegis-cloud-spa"
+  user_pool_id = aws_cognito_user_pool.this[0].id
+
+  # Public client — the SPA cannot safely hold a secret. PKCE is the
+  # replacement for client_secret in browser-based OAuth flows.
+  generate_secret = false
+
+  # Token lifetimes — Cognito defaults (aegis-core #76 Q5 accepted).
+  refresh_token_validity = 30
+  access_token_validity  = 1
+  id_token_validity      = 1
+  token_validity_units {
+    refresh_token = "days"
+    access_token  = "hours"
+    id_token      = "hours"
+  }
+
+  # OAuth surface — authorization-code flow + PKCE; standard SPA pattern.
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_scopes                 = ["openid", "profile", "email"]
+
+  callback_urls = local.callback_urls
+  logout_urls   = local.logout_urls
+
+  # No IdP federation today (ADR-026 §Decision). Future amendment adds
+  # Google / GitHub here plus `aws_cognito_identity_provider` resources.
+  supported_identity_providers = ["COGNITO"]
+
+  # Explicit auth flows — SRP for Hosted UI login, refresh for session
+  # persistence, admin-user-password for aegis-core nightly CI
+  # (aegis-core #76 Q B). No ALLOW_USER_PASSWORD_AUTH — that flow sends
+  # the password directly to Cognito over TLS without SRP, which is
+  # generally discouraged.
+  explicit_auth_flows = [
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_ADMIN_USER_PASSWORD_AUTH",
+  ]
+
+  # Best-practice security: on failed login, return the same error
+  # whether or not the username exists. Prevents username enumeration.
+  prevent_user_existence_errors = "ENABLED"
+
+  # Explicitly enable token revocation so the global-logout endpoint
+  # actually revokes refresh tokens server-side (not just client-side).
+  # aegis-core #76 Q6: Cognito global logout accepted.
+  enable_token_revocation = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/environments/staging/auth/user-pool.tf
+++ b/terraform/environments/staging/auth/user-pool.tf
@@ -1,0 +1,116 @@
+# -----------------------------------------------------------------------------
+# Cognito User Pool — cloud-mode auth for aegis (ADR-026)
+# -----------------------------------------------------------------------------
+# This is the core resource. Recreating the pool destroys every
+# registered user — Cognito does not export password hashes in any
+# re-importable format. `prevent_destroy = true` is the operational
+# guardrail against accidental `terraform destroy`.
+#
+# Immutable-attribute caveat: adding or removing a schema entry after
+# the pool is created REQUIRES recreate. aegis-core's Q4 custom
+# attribute `custom:tenant_id` (mutable=false) is declared below at
+# creation time; changing its shape later means destroying the pool.
+# This is a deliberate choice from ADR-026 — tenant claims should not be
+# mutable after user creation.
+#
+# Username attribute choice: `username_attributes = ["email"]` means
+# users log in with their email address, not a separate username field.
+# Simpler UX for lab scale; aligns with how most SaaS auth flows are
+# shaped today.
+#
+# Self-signup disabled (`allow_admin_create_user_only = true`) per
+# ADR-026 §Decision. The operator manually invites users via
+# `admin-create-user` — see Runbook 008 Part 2.
+# -----------------------------------------------------------------------------
+
+resource "aws_cognito_user_pool" "this" {
+  count = local.auth_enabled ? 1 : 0
+
+  name = "aegis-staging"
+
+  # Users log in with their email address; Cognito auto-generates an
+  # internal username for the record (a UUID, shown as `sub` in tokens).
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  # Password policy — driven from config; lab default is NIST-aligned.
+  password_policy {
+    minimum_length                   = local.password_policy.minimum_length
+    require_lowercase                = local.password_policy.require_lowercase
+    require_uppercase                = local.password_policy.require_uppercase
+    require_numbers                  = local.password_policy.require_numbers
+    require_symbols                  = local.password_policy.require_symbols
+    temporary_password_validity_days = 7
+  }
+
+  # ---------------------------------------------------------------------------
+  # Q4 custom attribute — `custom:tenant_id` (ADR-026 §Decision)
+  # ---------------------------------------------------------------------------
+  # Declared here at pool creation time. Cognito auto-prefixes the name
+  # with `custom:` — we set `name = "tenant_id"` and consumers read
+  # `custom:tenant_id` from ID tokens.
+  #
+  # mutable = false: operator-set at user creation via
+  # `admin-create-user --user-attributes Name=custom:tenant_id,Value=<tenant>`.
+  # Not changeable after creation (except by deleting + recreating the
+  # user). This is the security posture aegis-core's gateway relies on.
+  #
+  # String length 1..256 — adequate for UUID-shaped tenant IDs and for
+  # the short-token tenant identifiers aegis-core has been designing.
+  # ---------------------------------------------------------------------------
+  schema {
+    name                = "tenant_id"
+    attribute_data_type = "String"
+    mutable             = false
+    required            = false
+
+    string_attribute_constraints {
+      min_length = 1
+      max_length = 256
+    }
+  }
+
+  # Self-signup disabled. Only admins create users — see Runbook 008.
+  admin_create_user_config {
+    allow_admin_create_user_only = true
+
+    invite_message_template {
+      email_subject = "Welcome to aegis"
+      email_message = "Your aegis account has been created. Username: {username}. Temporary password: {####}. Sign in at the aegis portal and change your password on first login."
+      sms_message   = "Your aegis username is {username} and temporary password is {####}."
+    }
+  }
+
+  # Account recovery — email only (lab is email-verified, no phone).
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  # MFA posture — driven from config. Lab default OFF.
+  mfa_configuration = local.mfa_configuration
+
+  # Advanced security mode OFF for lab. Enabling `AUDIT` or `ENFORCED`
+  # costs an extra $0.05 per MAU which still fits lab scale but adds
+  # noise to the demo narrative — defer until the security-angle
+  # portfolio ask justifies it.
+  user_pool_add_ons {
+    advanced_security_mode = "OFF"
+  }
+
+  # Deletion protection — Cognito's first-class safety net, orthogonal
+  # to Terraform's prevent_destroy. Belt + suspenders: even if a future
+  # PR drops `prevent_destroy`, deletion_protection still forces an
+  # explicit console / CLI opt-out before the pool can be deleted.
+  deletion_protection = "ACTIVE"
+
+  tags = merge(local.tags, {
+    Name = "aegis-staging"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/environments/staging/auth/versions.tf
+++ b/terraform/environments/staging/auth/versions.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+    # kubernetes provider is not used today (no namespace creation — the
+    # `aegis` namespace is owned by staging/workloads). Declared for
+    # consistency with staging/observability so a future need (e.g. a
+    # Cognito-specific namespace, unlikely) does not require a provider-
+    # schema bump in a follow-up PR.
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+    # kubectl renders the `cognito-config` ExternalSecret CRD. Same
+    # rationale as staging/observability/versions.tf: kubernetes_manifest
+    # needs the CRD reachable at plan time which fails on cold apply when
+    # ESO's helm release has not yet installed CRDs. kubectl_manifest
+    # defers schema validation to apply time.
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.19"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements ADR-026 at full **Accepted** status. 11 new \`.tf\` files + ADR amendment + Runbook 008 fill + workflow integration + config schema. Unblocks aegis-core's 4e-4 Cognito integration test once applied + first user created.

## What's in this PR

- **Cognito layer** \`terraform/environments/staging/auth/\` — 11 \`.tf\` files provisioning User Pool + SPA App Client + Cognito-provided Hosted UI domain + 5 SSM PS SecureStrings + ExternalSecret CRD + IAM role for aegis-core nightly integration
- **ADR-026 → Accepted** — 6th shape decision (callback/logout URLs) confirmed final per aegis-core #76; revision history in § Status
- **Runbook 008** — all TBD placeholders filled with concrete values
- **\`staging/auth/README.md\`** — rewritten from plan doc to implementation doc; all 5 pre-implementation gates flagged green
- **Baseline workflow** — adds \`staging/auth/**\` to paths + matrix (ordered after staging/bootstrap for KMS)
- **Plan workflow** — adds \`staging/auth\` matrix entry
- **Config schema + example** — new \`cognito:\` block (required: callback_urls, logout_urls; optional: domain_prefix, password_policy, mfa_configuration)

## Pinned decisions (from aegis-core #76 consumption contract)

| Q | Decision |
|---|---|
| Q1 Token validation | JWKS local (RS256), no \`/userinfo\` roundtrip |
| Q2 Callback URLs | \`https://aegis-app.staging.binhsu.org/auth/callback\` + \`https://aegis-app.staging.binhsu.org/\` |
| Q3 Scopes | \`openid profile email\`, no custom for MVP |
| Q4 Custom attributes | \`custom:tenant_id\`, immutable (aegis-core ADR-0022 multi-tenancy) |
| Q5 Session lifetime | Cognito defaults — 1h access / 30d refresh |
| Q6 Logout | Cognito global logout |

## Subagent-flagged design choices (for reviewer awareness)

- **\`deletion_protection = ACTIVE\`** on User Pool — belt-and-suspenders over \`prevent_destroy = true\`; survives future PRs stripping the lifecycle block unintentionally
- **\`StringEquals\`** (not \`StringLike\`) on GitHub OIDC trust \`sub\` claim — tighter than the usual pattern, matches the bootstrap-layer sibling role
- **\`ALLOW_ADMIN_USER_PASSWORD_AUTH\`** in app-client flows — specifically for aegis-core nightly CI's \`AdminInitiateAuth\` integration test path
- **\`AdminGetUser\`** added to aegis-core integration role — for idempotency checks (not requested explicitly but useful)
- **\`temporary_password_validity_days = 7\`** in password policy — required attribute when \`password_policy\` block is declared; chose Cognito default

## Post-merge operator steps

1. Update local \`config/landing-zone.yaml\` — add \`cognito:\` block per \`config/landing-zone.example.yaml\`
2. Run \`./scripts/configure-github.sh\` — syncs updated config to \`LANDING_ZONE_CONFIG\` GitHub Secret
3. Dispatch baseline apply: \`gh workflow run terraform-apply-baseline.yml\` (workflow has \`workflow_dispatch\`)
4. Runbook 008 Parts 2–4 — \`admin-create-user\` for first admin + Hosted UI login verification + JWKS token smoke
5. Reply aegis-core #76 with outputs + role ARN + remaining answers (C/D)

## Test plan

- [ ] Checkov + Terraform Plan matrix green (auth layer plans 0 resources since \`cognito\` block not yet in GitHub Secret — that's the expected steady state pre-config-sync)
- [ ] After config.yaml sync + dispatch: auth layer plan shows exactly the expected resource create list (11 resources: 1 pool + 1 client + 1 domain + 5 SSM + 1 ExternalSecret + 1 role + 2 role policies)
- [ ] After apply: \`terraform output\` on \`staging/auth/\` returns 8 outputs including the 5 names aegis-core's nightly workflow will consume
- [ ] Bin can log in via Hosted UI at \`https://aegis-staging.auth.eu-central-1.amazoncognito.com/login?...\` after \`admin-create-user\`
- [ ] JWKS endpoint at \`https://cognito-idp.eu-central-1.amazonaws.com/<pool-id>/.well-known/jwks.json\` serves RS256 keys matching the ID token's \`kid\`

## Related

- [ADR-026](docs/decisions/026-cognito-auth-user-pool.md) — the backing decision
- [Runbook 008](docs/runbooks/008-cognito-user-pool-onboarding.md) — operator procedures
- [aegis-core #76](https://github.com/BinHsu/aegis-core/issues/76) — consumption contract thread; final reply pending after this merges + applies
- aegis-core Phase 4e — [PR #78](https://github.com/BinHsu/aegis-core/pull/78) (gateway JWT middleware) / [PR #79](https://github.com/BinHsu/aegis-core/pull/79) (SPA OAuth scaffold) / [PR #80](https://github.com/BinHsu/aegis-core/pull/80) (tenant propagation)
- [ADR-022](docs/decisions/022-observability-backend-grafana-cloud.md) / [ADR-025](docs/decisions/025-qdrant-backend-cloud-free-tier.md) — pattern precedents for managed-SaaS + SSM PS + ExternalSecret delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)