### PR TITLE
fix(staging/auth): gate ExternalSecret on platform_applied — unblock cold-cycle first apply

### DIFF
--- a/terraform/environments/staging/auth/config.tf
+++ b/terraform/environments/staging/auth/config.tf
@@ -86,6 +86,20 @@ locals {
   # Per-cluster details read from staging/platform's per-slot clusters map.
   # Auth targets the primary cluster only (see providers.tf rationale).
   clusters = try(data.terraform_remote_state.staging_platform.outputs.clusters, {})
+
+  # platform_applied — derived from whether staging/platform has
+  # produced a `primary` cluster in its outputs. Gates the kubectl-
+  # backed ExternalSecret resource: when platform has not been applied
+  # in this cold cycle yet, the kubectl provider's host resolves to
+  # empty string and apply fails with `dial tcp [::1]:80: connect: connection refused`.
+  # The AWS-side resources (User Pool, App Client, Domain, IAM, SSM
+  # parameters) do not depend on cluster reachability and apply cleanly
+  # regardless. On first cold-apply the operator sees "ExternalSecret
+  # skipped, apply this layer again after workloads"; the re-dispatch
+  # then reconciles the ExternalSecret once the cluster exists.
+  # Verified 2026-04-24 — first rerun against real AWS failed exactly
+  # on this gate before it existed.
+  platform_applied = local.auth_enabled && try(contains(keys(local.clusters), "primary"), false)
 }
 
 # -----------------------------------------------------------------------------

--- a/terraform/environments/staging/auth/external-secret.tf
+++ b/terraform/environments/staging/auth/external-secret.tf
@@ -31,7 +31,15 @@
 # -----------------------------------------------------------------------------
 
 resource "kubectl_manifest" "external_secret_cognito_config" {
-  count = local.auth_enabled ? 1 : 0
+  # Gate: both auth_enabled (cognito block in config) AND platform_applied
+  # (staging/platform has produced a cluster output). Without the second
+  # clause the kubectl provider tries to dial an unresolvable host and
+  # fails the whole apply even though AWS-side resources created cleanly.
+  # On cold-cycle first apply the operator sees this ExternalSecret
+  # skipped, applies staging/platform (via workloads), and re-dispatches
+  # baseline — the second pass picks up platform_applied=true and
+  # reconciles the ExternalSecret.
+  count = local.platform_applied ? 1 : 0
 
   yaml_body = yamlencode({
     apiVersion = "external-secrets.io/v1beta1"


### PR DESCRIPTION
## Summary

The \`kubectl_manifest\` for \`cognito-config\` was gated only on \`auth_enabled\`. When staging/platform has not been applied (no cluster outputs in remote state), the kubectl provider's \`host\` resolves to empty string and apply fails with:

\`\`\`
Error: aegis/cognito-config failed to create kubernetes rest client for update of resource:
  Get "http://localhost/api?timeout=32s": dial tcp [::1]:80: connect: connection refused
\`\`\`

Even though the AWS-side resources (User Pool \`eu-central-1_0gdyxKxOB\`, App Client \`1e7i376p7bitfup27gsqklg2hu\`, Cognito domain \`aegis-staging.auth.eu-central-1.amazoncognito.com\`, IAM role \`github-actions-aegis-core-cognito-integration\`, 5 SSM parameters under \`/aegis/staging/cognito/*\`) all created cleanly.

Verified live 2026-04-24 — the first rerun of PR #140's merge-triggered baseline hit this exact failure mode.

## Fix

- New \`local.platform_applied\` in \`config.tf\` — true iff \`auth_enabled\` AND staging/platform's clusters map has a \`primary\` key.
- \`kubectl_manifest.external_secret_cognito_config.count\` gated on \`local.platform_applied\` instead of \`local.auth_enabled\`.

## Net effect

On cold-cycle first baseline apply where platform has not yet been deployed:
- AWS resources apply normally
- ExternalSecret skipped (count = 0)
- Apply succeeds

Operator subsequently applies workloads (stands up the cluster), re-dispatches baseline → \`platform_applied = true\` → ExternalSecret reconciles.

Steady-state case (platform live): \`platform_applied = true\` → ExternalSecret applies as before. No behavior change.

## Test plan

- [ ] Checkov + Plan matrix green (plan for staging/auth now shows ExternalSecret as \`count = 0\` since platform remote state has no \`primary\` cluster in CI)
- [ ] After merge + baseline rerun: \`Apply staging/auth\` reports \`success\` (was \`failure\` before)
- [ ] Future cold-apply with workloads applied first: ExternalSecret applies normally

## Related

- [ADR-026](docs/decisions/026-cognito-auth-user-pool.md) — the backing decision; this fix aligns the implementation with the ADR's "baseline-tier but depends on workload-tier for k8s CRD" stance
- [PR #140](https://github.com/BinHsu/aegis-aws-landing-zone/pull/140) — the original implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)