### PR TITLE
ci(baseline): add staging/edge to apply matrix

### DIFF
--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -19,6 +19,7 @@ on:
       - 'terraform/environments/shared/**'
       - 'terraform/environments/staging/bootstrap/**'
       - 'terraform/environments/staging/auth/**'
+      - 'terraform/environments/staging/edge/**'
       - 'terraform/environments/prod/bootstrap/**'
       - 'config/**'
 
@@ -79,6 +80,34 @@ jobs:
           # resources. The layer is stable across workload cycles.
           # -----------------------------------------------------------------
           - env: staging/auth
+            account_id: "251774439261"
+          # -----------------------------------------------------------------
+          # staging/edge — CloudFront + S3 (frontend) + ALB ACM (api) + Route53
+          # delegated zone + OIDC role (ADR-019)
+          # -----------------------------------------------------------------
+          # Baseline-tier peer layer. All resources are either free tier
+          # (ACM cert, Route53 zone $0.50/mo, IAM) or bill-on-use with ~$0
+          # idle (CloudFront, S3). Safe for auto-apply.
+          #
+          # Ordered AFTER staging/bootstrap (needs the GitHub OIDC provider
+          # created there for `oidc-aegis-core-frontend` role's trust policy)
+          # and AFTER management/scps (SCPs guard all staging resources).
+          #
+          # Unlike staging/auth, this layer has NO kubectl_manifest step and
+          # NO dependency on the workloads namespace — all resources are
+          # account-level AWS primitives. It applies cleanly on a cold
+          # environment without the "apply workloads, then re-dispatch
+          # baseline" dance.
+          #
+          # Route53 ALIAS record for `aegis-api.staging.<domain>` is
+          # intentionally NOT created by this layer — the ALB DNS does not
+          # exist at apply time (LBC provisions it only after aegis-core's
+          # Ingress syncs post-cold-apply). Operator runs the copy-pasteable
+          # command printed by `terraform output -raw api_route53_creation_hint`
+          # after the cluster is live. external-dns automation is a future
+          # follow-up.
+          # -----------------------------------------------------------------
+          - env: staging/edge
             account_id: "251774439261"
 
     steps:


### PR DESCRIPTION
## Summary

Close the CI apply gap for `staging/edge` — the layer has been shipping code (PR #94 frontend, PR #108 api ACM cert) without a materialization path. It was plan-only in CI, and `docs/principles/break-glass-apply.md` forbids local apply by default — so the ACM cert for `aegis-api.staging.binhsu.org` has been code-in-repo-only since 2026-04-20.

This PR adds `staging/edge` to `terraform-apply-baseline.yml` alongside `staging/auth` (precedent: PR #140, same tier — persistent, $0-idle, no cluster dep). Merge triggers auto-apply; ACM cert materializes; ldz #101 closes.

## Change Review Discipline checklist (per `docs/principles/change-review-discipline.md`)

### 1. Blast radius
**Low.** One CI job added to the baseline matrix, `max-parallel: 1` so it runs serially after `staging/auth`. Worst case: the edge `terraform apply` fails, leaving the matrix job red — no cross-layer contamination because state isolation is per-directory. Other baseline layers already applied before this one are unaffected.

### 2. Dependency assumptions
- Needs: GitHub OIDC provider from `staging/bootstrap` (for the `oidc-aegis-core-frontend` role's trust policy) — applied earlier in the same matrix, no issue.
- Needs: Cloudflare NS delegation to be live for `staging.binhsu.org` — operator-managed (runbook 004); unchanged by this PR.
- Does NOT need: EKS cluster (no `kubectl_manifest`), `staging/workloads` namespace (unlike `staging/auth`), or any workload-tier layer. Cold-cycle-safe.

### 3. Deprecation status
- `aws-actions/configure-aws-credentials@v6` — current (already in use across all baseline matrix entries).
- `actions/checkout@v6`, `hashicorp/setup-terraform@v4` — current, shared with the rest of the workflow.
- No new actions introduced.
- Terraform AWS provider handled v5→v6 in incident 24 aftermath; edge already tracks that lock file.

### 4. Rollback plan
- **Fastest**: `git revert` + merge. Removes edge from the auto-apply matrix; existing live resources (if any) stay untouched because this PR only adds a CI matrix entry, not Terraform code. State is not perturbed by a revert.
- If the apply itself fails: read the job log, fix the underlying Terraform issue in a follow-up PR, re-merge. Matrix `fail-fast: false` is already set — one red entry doesn't block other baseline re-apply attempts.

### 5. 2 AM readability
- Matrix entry carries a full comment block (tier rationale, ordering rationale, cold-cycle-safety note, ALIAS-record caveat) — matches `staging/auth`'s precedent.
- Path filter addition is adjacent to the existing entries in obvious alphabetical proximity.

## Related

- ldz #101 — ACM cert ask from aegis-core; this PR is the materialization path.
- aegis-core #50 — will self-close when they replace the placeholder ARN in their gateway Ingress.
- ADR-019 — introduced `staging/edge/` as a dedicated Terraservice.
- ADR-024 — repo topology; this PR reinforces the "logical isolation via CI + state" posture (single repo, per-layer apply via workflow).
- PR #140 — sibling precedent; `staging/auth` added to baseline on 2026-04-24.

## Test plan

- [ ] Checkov green
- [ ] All `terraform-plan.yml` matrix entries green (including the new path-filter trigger recognition)
- [ ] On merge: `terraform-apply-baseline.yml` dispatches; `staging/edge` matrix entry runs
- [ ] On success: `terraform -chdir=terraform/environments/staging/edge output -raw api_acm_certificate_arn` returns a valid ARN
- [ ] Post ARN to aegis-core #50 + close ldz #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)