### PR TITLE
ci(baseline): add workflow_dispatch trigger as manual safety valve

### DIFF
--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -23,6 +23,20 @@ on:
       - 'terraform/environments/prod/bootstrap/**'
       - 'config/**'
 
+  # Manual safety valve — mirrors terraform-apply-workload.yml's dispatch
+  # trigger. Use when:
+  #   - A baseline layer was added in a PR that didn't touch any path-filter
+  #     directory (e.g., a CI-only PR adding the layer to the matrix; the
+  #     push trigger won't fire).
+  #   - A previous auto-apply failed mid-matrix and you want to re-run
+  #     without a no-op code commit.
+  #   - First-time apply of a new baseline layer on a cold environment.
+  #
+  # Behavior is identical to push: runs the full matrix serially. No inputs
+  # because baseline is cheap and the matrix is fast; per-layer targeting
+  # would add config surface for marginal benefit.
+  workflow_dispatch:
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
## Summary

Baseline workflow was push-only, which created a gap exposed by PR #143: a CI-only PR that adds a new baseline matrix entry does not match the path filter, so the push trigger never fires and the newly-added layer never materializes.

This PR adds `workflow_dispatch` as a safety valve — mirrors the pattern already in `terraform-apply-workload.yml`. Push trigger behavior is unchanged; dispatch runs the same matrix serially with no inputs.

## Change Review Discipline checklist

### 1. Blast radius
**Low.** New trigger, no behavior change for existing push-triggered runs. Worst case: someone dispatches unnecessarily; matrix is idempotent, effect is 3-minute run with no-op plans.

### 2. Dependency assumptions
- Workflow auth via GitHub OIDC — unchanged.
- Matrix entries and their ordering — unchanged.
- Account-scoped role trust policies — unchanged.

### 3. Deprecation status
- `workflow_dispatch` is a stable GitHub Actions trigger, no deprecation.
- No new actions introduced.

### 4. Rollback plan
- Single-line `workflow_dispatch:` removal, `git revert` + merge. Zero state impact.

### 5. 2 AM readability
- Full comment block explains the 3 legitimate use cases for dispatch (first-apply, recovery, re-run).
- Placed adjacent to `push:` block for trigger-discoverability.

## Related

- PR #143 — added `staging/edge` to baseline matrix (merged); exposed this gap as side effect.
- ldz #101 — ACM cert ask from aegis-core; needs the dispatch post-merge to trigger the first edge apply.

## Test plan

- [ ] Checkov green
- [ ] All Terraform Plan matrix entries green
- [ ] On merge: `gh workflow run terraform-apply-baseline.yml` succeeds and runs the full matrix
- [ ] `staging/edge` matrix entry creates ACM api cert + validation records

🤖 Generated with [Claude Code](https://claude.com/claude-code)