### PR TITLE
feat(observability): Qdrant Cloud scaffold — SSM + ExternalSecret (ldz #141)

### DIFF
--- a/config/landing-zone.example.yaml
+++ b/config/landing-zone.example.yaml
@@ -204,3 +204,23 @@ eks:
 #   # MFA posture. OFF (lab default) | OPTIONAL | ON. ON requires every
 #   # user to enroll a factor before login works — not recommended for MVP.
 #   mfa_configuration: OFF
+
+# Qdrant Cloud vector-DB scaffold (ADR-025, cross-repo ldz #141).
+# Optional: present with `enabled: true` to provision the Qdrant SSM PS
+# placeholders (/aegis/staging/qdrant-cloud/{cluster-url,api-key}) and the
+# ExternalSecret that reconciles them into K8s Secret `qdrant-credentials`
+# in ns `aegis` for the aegis-engine Deployment.
+#
+# Values are operator-managed — Terraform only creates the SecureString
+# shells. After the first apply, fill the real cluster URL + API key via:
+#
+#   aws ssm put-parameter --region eu-central-1 \
+#     --name /aegis/staging/qdrant-cloud/cluster-url \
+#     --type SecureString --key-id alias/aegis-staging-secrets \
+#     --value 'https://<cluster-uuid>.eu-central-1-0.aws.cloud.qdrant.io:6334' \
+#     --overwrite
+#
+# Runbook 007 documents first-time Qdrant Cloud signup + the API key
+# rotation cadence (90 days).
+# qdrant_cloud:
+#   enabled: true

--- a/config/schema.json
+++ b/config/schema.json
@@ -317,6 +317,18 @@
         }
       }
     },
+    "qdrant_cloud": {
+      "type": "object",
+      "description": "Qdrant Cloud vector-DB scaffold (ADR-025, ldz #141). Optional — present with `enabled: true` to provision 2 operator-managed SSM PS placeholders (/aegis/staging/qdrant-cloud/{cluster-url,api-key}) plus an ExternalSecret that reconciles them into K8s Secret `qdrant-credentials` in ns `aegis`. Values are filled operator-side via `aws ssm put-parameter` per Runbook 007; Terraform never sees the real credentials. Omit the block to skip Qdrant entirely.",
+      "required": ["enabled"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Set true to provision the Qdrant SSM PS + ExternalSecret scaffold. False (or omit the block) skips all Qdrant resources."
+        }
+      }
+    },
     "eks": {
       "type": "object",
       "description": "EKS platform configuration keyed by workload environment name (e.g. staging, prod). Optional — only environments that deploy a platform layer need an entry.",

--- a/terraform/environments/staging/observability/config.tf
+++ b/terraform/environments/staging/observability/config.tf
@@ -53,6 +53,20 @@ locals {
   # family with a single wildcard (staging/platform ESO IRSA does this).
   ssm_path_prefix = "/aegis/staging/grafana-cloud"
 
+  # Qdrant Cloud block — independent gate (ADR-025, ldz #141). Enables the
+  # Qdrant scaffold (2 operator-managed SSM PS placeholders + 1 ExternalSecret
+  # reconciling into K8s Secret `qdrant-credentials` in ns `aegis`). Lives in
+  # this layer by precedent (team-webhooks ExternalSecret pattern), not
+  # because Qdrant is an observability concern — see ADR-027 for the layer-
+  # sharding discipline that justifies the current placement + enumerates
+  # triggers for future extraction to `staging/data-secrets/`.
+  qdrant_cloud   = try(local.config.qdrant_cloud, null)
+  qdrant_enabled = try(local.qdrant_cloud.enabled, false)
+
+  # Qdrant SSM PS path prefix — parallel structure to grafana-cloud. IAM wildcard
+  # /aegis/staging/* on ESO IRSA already covers this path, no new IAM needed.
+  qdrant_ssm_path_prefix = "/aegis/staging/qdrant-cloud"
+
   tags = merge(local.config.tags, {
     Environment = "staging"
     Component   = "observability"
@@ -60,6 +74,15 @@ locals {
 
   # Per-cluster details read from staging/platform's per-slot clusters map.
   clusters = try(data.terraform_remote_state.staging_platform.outputs.clusters, {})
+
+  # platform_applied — derived from whether staging/platform has produced a
+  # `primary` cluster in its outputs. Gates the Qdrant ExternalSecret
+  # kubectl_manifest: without a live cluster the kubectl provider dials an
+  # empty host and fails the whole apply. On cold-cycle first apply the
+  # operator sees the ExternalSecret skipped, applies staging/platform (via
+  # workloads), and re-applies this layer — the second pass reconciles it.
+  # Identical pattern to staging/auth/config.tf (PR #142).
+  platform_applied = try(contains(keys(local.clusters), "primary"), false)
 }
 
 # -----------------------------------------------------------------------------
@@ -155,7 +178,10 @@ check "platform_layer_applied" {
 # -----------------------------------------------------------------------------
 
 data "aws_kms_alias" "secrets" {
-  count = local.observability_enabled ? 1 : 0
+  # Shared by grafana-cloud tokens (observability_enabled) and qdrant-cloud
+  # SSM placeholders (qdrant_enabled). Any enabled feature in this layer
+  # needs the KMS alias; gate accordingly.
+  count = (local.observability_enabled || local.qdrant_enabled) ? 1 : 0
 
   name = "alias/aegis-staging-secrets"
 }
@@ -163,10 +189,10 @@ data "aws_kms_alias" "secrets" {
 check "secrets_kms_key_exists" {
   assert {
     condition = (
-      !local.observability_enabled
+      !(local.observability_enabled || local.qdrant_enabled)
       || try(data.aws_kms_alias.secrets[0].target_key_arn, "") != ""
     )
-    error_message = "config.grafana_cloud is set but KMS alias 'alias/aegis-staging-secrets' is missing. Apply staging/bootstrap first (baseline layer, auto-applied on PR merge — see staging/bootstrap/kms-secrets.tf)."
+    error_message = "config.grafana_cloud or config.qdrant_cloud is set but KMS alias 'alias/aegis-staging-secrets' is missing. Apply staging/bootstrap first (baseline layer, auto-applied on PR merge — see staging/bootstrap/kms-secrets.tf)."
   }
 }
 

--- a/terraform/environments/staging/observability/outputs.tf
+++ b/terraform/environments/staging/observability/outputs.tf
@@ -27,6 +27,14 @@ output "ssm_paths" {
   } : null
 }
 
+output "qdrant_ssm_paths" {
+  description = "SSM PS parameter paths for Qdrant Cloud credentials (ADR-025, ldz #141). Values are operator-managed; null when qdrant_cloud is not enabled."
+  value = local.qdrant_enabled ? {
+    cluster_url = "${local.qdrant_ssm_path_prefix}/cluster-url"
+    api_key     = "${local.qdrant_ssm_path_prefix}/api-key"
+  } : null
+}
+
 output "grafana_admin_login_hint" {
   description = <<-EOT
     How to log in to the Grafana Cloud stack as a human admin:

--- a/terraform/environments/staging/observability/qdrant-scaffold.tf
+++ b/terraform/environments/staging/observability/qdrant-scaffold.tf
@@ -1,0 +1,143 @@
+# -----------------------------------------------------------------------------
+# Qdrant Cloud scaffold — ADR-025, cross-repo ldz #141
+# -----------------------------------------------------------------------------
+# Two SSM PS placeholders + one ExternalSecret, mirroring the team-webhooks
+# pattern (tokens.tf §team-webhooks + external-secrets.tf §team_webhooks).
+# The SSM PS values are operator-managed (runbook 007 §API key rotation):
+# Terraform creates the SecureString shells with a placeholder; the operator
+# `put-parameter`s the real `cluster-url` and `api-key` out-of-band. The
+# `lifecycle.ignore_changes = [value]` block prevents subsequent `apply`
+# from clobbering the operator-supplied values back to the placeholder.
+#
+# Layer placement: Qdrant is a vectordb for aegis-engine, not an
+# observability concern. Scaffolded here by precedent (team-webhooks
+# ExternalSecret in ns `aegis` from this layer) rather than category.
+# ADR-027 enumerates the triggers that would justify extracting this block
+# into a new `staging/data-secrets/` layer — none fire today.
+#
+# Contract with aegis-core (ldz #141):
+#   - K8s Secret: `qdrant-credentials` in ns `aegis`
+#   - Keys: `QDRANT_URL`, `QDRANT_API_KEY` (uppercase, env-var convention)
+#   - URL shape: `https://<cluster-host>:6334` (gRPC port, TLS on — the
+#     engine's qdrant_client infers TLS from the scheme; bare host means
+#     plaintext). See engine_cpp/src/vectordb/qdrant_client.cc:132.
+# Changing names requires cross-repo coordination; do not unilaterally rename.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# SSM PS — Qdrant Cloud cluster URL (operator-filled)
+# -----------------------------------------------------------------------------
+# Operator fills the real gRPC endpoint via AWS CLI:
+#
+#   aws ssm put-parameter \
+#     --region eu-central-1 \
+#     --name /aegis/staging/qdrant-cloud/cluster-url \
+#     --type SecureString --key-id alias/aegis-staging-secrets \
+#     --value 'https://<cluster-uuid>.eu-central-1-0.aws.cloud.qdrant.io:6334' \
+#     --overwrite
+#
+# As of 2026-04-23 the live value is already in SSM PS from the pre-Terraform
+# manual bootstrap (Runbook 007). Terraform's create picks up the placeholder
+# on first apply; the `lifecycle.ignore_changes` block leaves the operator
+# value in place on subsequent applies.
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "qdrant_cluster_url" {
+  count = local.qdrant_enabled ? 1 : 0
+
+  name        = "${local.qdrant_ssm_path_prefix}/cluster-url"
+  description = "Qdrant Cloud cluster gRPC endpoint (https://<host>:6334, TLS on via scheme). Operator-managed value; Terraform creates the SecureString shell only. Consumed by ExternalSecret → K8s Secret `qdrant-credentials` key `QDRANT_URL` in ns `aegis`, referenced by aegis-engine's env mapping (ldz #141 + aegis-core engine_cpp/src/vectordb/qdrant_client.cc)."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  value       = "placeholder-operator-must-overwrite"
+
+  tags = merge(local.tags, {
+    Name = "qdrant-cloud-cluster-url"
+  })
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# SSM PS — Qdrant Cloud API key (operator-filled)
+# -----------------------------------------------------------------------------
+# Rotation cadence: Qdrant Cloud free tier issues 90-day keys per Runbook 007.
+# Rotation is an out-of-band `put-parameter`; the ExternalSecret's 1h refresh
+# interval picks up the new value within the hour.
+# -----------------------------------------------------------------------------
+
+resource "aws_ssm_parameter" "qdrant_api_key" {
+  count = local.qdrant_enabled ? 1 : 0
+
+  name        = "${local.qdrant_ssm_path_prefix}/api-key"
+  description = "Qdrant Cloud API key — sent as `api-key` gRPC metadata header on every engine request. Operator-managed value; Terraform creates the SecureString shell only. Consumed by ExternalSecret → K8s Secret `qdrant-credentials` key `QDRANT_API_KEY` in ns `aegis`. Rotation per Runbook 007 §API key rotation."
+  type        = "SecureString"
+  key_id      = data.aws_kms_alias.secrets[0].target_key_arn
+  value       = "placeholder-operator-must-overwrite"
+
+  tags = merge(local.tags, {
+    Name = "qdrant-cloud-api-key"
+  })
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# -----------------------------------------------------------------------------
+# ExternalSecret — reconcile Qdrant credentials into ns aegis
+# -----------------------------------------------------------------------------
+# Dual-gate: qdrant_enabled (feature on) AND platform_applied (cluster exists).
+# On cold cycle the ExternalSecret is skipped — AWS SSM resources still
+# create cleanly. After `staging/platform` applies (via workload workflow),
+# a re-apply of this layer reconciles the ExternalSecret.
+# -----------------------------------------------------------------------------
+
+resource "kubectl_manifest" "external_secret_qdrant_credentials" {
+  count = (local.qdrant_enabled && local.platform_applied) ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "qdrant-credentials"
+      namespace = "aegis"
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+        "app.kubernetes.io/part-of"    = "platform"
+      }
+    }
+    spec = {
+      refreshInterval = "1h"
+      secretStoreRef = {
+        name = "aegis-ssm"
+        kind = "ClusterSecretStore"
+      }
+      target = {
+        name           = "qdrant-credentials"
+        creationPolicy = "Owner"
+      }
+      data = [
+        {
+          secretKey = "QDRANT_URL"
+          remoteRef = {
+            key = "${local.qdrant_ssm_path_prefix}/cluster-url"
+          }
+        },
+        {
+          secretKey = "QDRANT_API_KEY"
+          remoteRef = {
+            key = "${local.qdrant_ssm_path_prefix}/api-key"
+          }
+        },
+      ]
+    }
+  })
+
+  depends_on = [
+    aws_ssm_parameter.qdrant_cluster_url,
+    aws_ssm_parameter.qdrant_api_key,
+  ]
+}

--- a/terraform/environments/staging/observability/qdrant-scaffold.tf
+++ b/terraform/environments/staging/observability/qdrant-scaffold.tf
@@ -36,10 +36,30 @@
 #     --value 'https://<cluster-uuid>.eu-central-1-0.aws.cloud.qdrant.io:6334' \
 #     --overwrite
 #
-# As of 2026-04-23 the live value is already in SSM PS from the pre-Terraform
-# manual bootstrap (Runbook 007). Terraform's create picks up the placeholder
-# on first apply; the `lifecycle.ignore_changes` block leaves the operator
-# value in place on subsequent applies.
+# ⚠️  First-apply migration step — existing operator-managed SSM params
+#
+# As of 2026-04-23 the live values are already in SSM PS from the
+# pre-Terraform manual bootstrap (Runbook 007). Terraform does NOT auto-
+# adopt pre-existing AWS resources; a bare `apply` will fail with
+# `ParameterAlreadyExists`. First-apply operator must import them:
+#
+#   terraform -chdir=terraform/environments/staging/observability import \
+#     'aws_ssm_parameter.qdrant_cluster_url[0]' \
+#     /aegis/staging/qdrant-cloud/cluster-url
+#
+#   terraform -chdir=terraform/environments/staging/observability import \
+#     'aws_ssm_parameter.qdrant_api_key[0]' \
+#     /aegis/staging/qdrant-cloud/api-key
+#
+# After import, the `lifecycle.ignore_changes = [value]` block guarantees
+# the operator-supplied values survive subsequent applies. On a fresh
+# environment (no pre-existing params), skip the imports — Terraform
+# creates placeholders and the operator `put-parameter`s real values
+# out-of-band per Runbook 007 §API key rotation.
+#
+# `import` blocks in HCL are not used here because the count-gated
+# resource address is awkward to import declaratively; the one-time
+# manual import is simpler and clearer to an operator.
 # -----------------------------------------------------------------------------
 
 resource "aws_ssm_parameter" "qdrant_cluster_url" {


### PR DESCRIPTION
## Summary

Mirrors the team-webhooks pattern (PR #128) against aegis-core's cross-repo [#141](https://github.com/BinHsu/aegis-aws-landing-zone/issues/141) Secret-shape spec. Scaffolds Qdrant Cloud credential delivery into the `aegis` namespace.

- `aws_ssm_parameter.qdrant_cluster_url` + `aws_ssm_parameter.qdrant_api_key` — SecureString placeholders at `/aegis/staging/qdrant-cloud/{cluster-url,api-key}` with `lifecycle.ignore_changes = [value]` so operator values survive apply cycles. Real values already live there from 2026-04-23 (Runbook 007 manual bootstrap); this PR retroactively brings them under Terraform management without overwriting.
- `kubectl_manifest.external_secret_qdrant_credentials` — reconciles both params into K8s Secret `qdrant-credentials` in ns `aegis`, keys `QDRANT_URL` + `QDRANT_API_KEY` (uppercase env-var convention, matches aegis-engine's env mapping per `engine_cpp/src/vectordb/qdrant_client.cc`).

## Gates

- **`qdrant_enabled`** — independent config flag, not coupled to `observability_enabled`. Enabling Qdrant without Grafana Cloud is a valid config.
- **`platform_applied`** (ExternalSecret only) — derived from `terraform_remote_state.staging_platform.outputs.clusters.primary` presence. On cold-cycle first apply the ExternalSecret skips cleanly; AWS-side SSM resources still create. Operator re-applies this layer after workloads provisions the cluster — same pattern as Cognito's ExternalSecret in `staging/auth` (PR #142).

## Layer placement

Extends `staging/observability/` by precedent (team-webhooks ExternalSecret targets ns `aegis` from here). Qdrant is **not** an observability concern semantically — the co-location is mechanical, not categorical. ADR-027 §"four triggers" documents when a future `staging/data-secrets/` extraction would fire; none today.

## Change Review Discipline checklist

### 1. Blast radius
**Low.** Two new SSM SecureStrings + one kubectl_manifest, all count-gated on `qdrant_enabled`. With `enabled: false` (or block absent), zero resources. Worst case with enabled: ExternalSecret fails to reconcile → K8s Secret `qdrant-credentials` missing → aegis-engine pod can't start (intentional fail-closed on missing credential). No cross-layer impact.

### 2. Dependency assumptions
- KMS alias `alias/aegis-staging-secrets` from `staging/bootstrap` — existing dep, gate widened from `observability_enabled` to `observability_enabled || qdrant_enabled`.
- ESO `aegis-ssm` ClusterSecretStore from `staging/platform` — same assumption as existing team-webhooks ExternalSecret.
- Namespace `aegis` from `staging/workloads` — same assumption.
- Qdrant Cloud cluster itself — operator-provisioned (Runbook 007); Terraform does not provision the cluster, only the credential delivery scaffold.

### 3. Deprecation status
- `kubectl_manifest` resource from `gavinbunney/kubectl` provider — already used throughout this layer, no deprecation in scope.
- `external-secrets.io/v1beta1` — current; v1 is available but v1beta1 is the pattern used by every other ExternalSecret in this repo, no reason to drift.
- No new providers or actions.

### 4. Rollback plan
- `git revert` + merge. The ExternalSecret teardown triggers the K8s Secret deletion (creationPolicy: Owner) → aegis-engine pods CrashLoopBackOff. If that is the desired rollback (e.g., breaking the Qdrant dep intentionally), revert is clean.
- If only the ExternalSecret is problematic but SSM values should stay: set `qdrant_cloud.enabled: false` in config — Terraform destroys all three Qdrant resources but the operator-supplied SSM values (stored externally) are the lost state. Safer rollback: leave SSM params, remove only the ExternalSecret by commenting out the `kubectl_manifest` block — 1-line change.

### 5. 2 AM readability
- Prominent file-level comment explains layer-placement rationale (not-observability-semantically; future-extraction trigger in ADR-027).
- Per-resource comments cover: operator put-parameter recipe, why lifecycle.ignore_changes, cold-cycle gate rationale.
- Bridge to aegis-core: explicit citation of `engine_cpp/src/vectordb/qdrant_client.cc:132` for the URL-scheme TLS inference contract.

## Related

- Cross-repo: [ldz #141](https://github.com/BinHsu/aegis-aws-landing-zone/issues/141) — the spec this PR implements.
- [ADR-025](../blob/main/docs/decisions/025-qdrant-backend-cloud-free-tier.md) — Qdrant backend decision.
- ADR-027 (PR #144, pending merge) — layer-sharding discipline that justifies the current observability-layer placement.
- PR #128 — team-webhooks pattern this mirrors.
- PR #142 — Cognito ExternalSecret platform_applied gate precedent.

## Test plan

- [ ] Checkov green
- [ ] All Terraform Plan matrix entries green (especially `staging/observability`)
- [ ] `Plan staging/observability` diff shows +2 `aws_ssm_parameter` + 0 or +1 `kubectl_manifest` (depends on whether platform is currently applied) when `qdrant_cloud.enabled: true` is added to config
- [ ] On merge + config update + baseline apply: K8s Secret `qdrant-credentials` materializes in ns `aegis` (`kubectl -n aegis get secret qdrant-credentials`) with `QDRANT_URL` + `QDRANT_API_KEY` keys
- [ ] aegis-core confirms contract fulfillment → closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)