### PR TITLE
fix(eks-cluster): propagate Incident 17's LBC webhook depends_on (Incident 33)

### DIFF
--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -2545,6 +2545,142 @@ Process (this is the bigger win):
 
 ---
 
+## Incident 33 — LBC webhook race recurrence: Incident 17 prevention never propagated to 5 later helm_releases; Kyverno finalizer cascade turned a first-apply retry into manual K8s cleanup
+
+**Date**: 2026-04-24 (Phase 4c+ first real end-to-end cold-apply attempting to land Qdrant + aegis-core rollout wiring together)
+**Severity**: S2 (blocked full-session cold-apply; blocked teardown retry; forced break-glass kubectl cleanup + ad-hoc SSO EKS Access Entry provisioning to recover)
+**Duration**: ~90 minutes from first apply failure to clean teardown completion — 2 failed apply attempts + 2 failed teardown attempts + manual K8s cleanup session
+
+### Symptom
+
+Fresh cold-apply (`gh workflow run terraform-apply-workload.yml -f env=staging`) on an empty state, after the pre-flight prep described in PR #148 (Runbook 007 unfreeze, Qdrant SSM PS imported, etc.). `apply-network` passed in ~3-5min. `apply-platform` failed ~10min later with the signature of Incident 17 but fanned across **five independent helm_releases × two clusters**:
+
+```
+Error: Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws":
+failed to call webhook: Post
+"https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s":
+no endpoints available for service "aws-load-balancer-webhook-service"
+
+(and 7 more similar warnings elsewhere)
+
+Error: 3 errors occurred:
+  (cert_manager × 2 clusters)
+Error: 1 error occurred:
+  (external_secrets × 2 clusters)
+Error: 1 error occurred:
+  (kube_state_metrics × 2 clusters)
+Error: 6 errors occurred:
+  (kyverno × 2 clusters)
+```
+
+Per-resource summary from the failed plan log: cert-manager, external-secrets, kyverno, kube-state-metrics, on both the `primary` and `slave_1` EKS clusters. Total ~22 individual Service-admission failures (multiple Services per chart × 2 clusters). ArgoCD (which HAD `depends_on = [helm_release.aws_lb_controller]` from Incident 17's original fix) succeeded cleanly; that was the single chart that followed the rule.
+
+Naive retry (`gh workflow run terraform-apply-workload.yml -f env=staging` immediately) made the situation worse: cert-manager + ESO + KSM + node-exporter retried fine (LBC pod Ready by then), but Terraform's second-run plan saw the Kyverno helm_release in `failed` state and attempted to **destroy-then-recreate**. `helm uninstall kyverno` then hung for 5 minutes with `timed out waiting for the condition`, producing a second workflow failure with cluster now in a partially-torn-down state (Kyverno pods re-created by ReplicaSet controller while Helm tried to delete them, Kyverno CRDs with finalizers blocking CR cleanup, admission webhooks still registered).
+
+Teardown workflow (`gh workflow run terraform-teardown-workload.yml -f env=staging`) then failed at `destroy-platform` with a **mirror-image webhook race**: ESO's `helm_release` destroyed before `ClusterSecretStore aegis-ssm` could be deleted, because the ClusterSecretStore delete requires validation via `validate.clustersecretstore.external-secrets.io` — whose backing service (`external-secrets-webhook`) is gone after the helm_release destroy. Same Kyverno timeout surfaced on the destroy path.
+
+Result: 2 EKS control planes + NAT + Karpenter EC2 burning ~\$0.30/hr with no clean path forward via CI.
+
+### Root cause
+
+**Incident 17's prescription was written and never applied to the helm_releases added after 2026-04-14.**
+
+Incident 17 (2026-04-14) identified that LBC's MutatingWebhookConfiguration `mservice.elbv2.k8s.aws` intercepts **every** `Service` creation cluster-wide, not just `type=LoadBalancer`. The fix was a one-line `depends_on = [helm_release.aws_lb_controller]` on `helm_release.argocd`. The Prevention section explicitly generalized the rule: *"If a Helm chart installs a cluster-wide admission webhook, every subsequent Helm chart that creates resources the webhook intercepts must `depends_on` the webhook's chart."* That generalization was accurate and complete — but was expressed only in prose, with no enforcement mechanism and no reminder baked into `lb-controller.tf` itself.
+
+Five subsequent helm_releases were added to `modules/eks-cluster/` (cert-manager, external-secrets, kyverno, kube-state-metrics, plus implicitly downstream charts like alloy) and NONE of them added the prescribed `depends_on`. Terraform's resource graph gave no signal — these resources are not attribute-referenced by `aws_lb_controller`, so Terraform schedules them in parallel. When Karpenter hadn't yet provisioned an EC2 node for the LBC pod (cold-cluster case), the webhook service had zero endpoints at the moment these helm charts created their Services.
+
+The Kyverno-destroy-hang was a second-order effect: Kyverno's first-apply created CRDs with finalizers but hadn't fully installed its own admission controller, leaving the cluster in a state where Kyverno's uninstall requires Kyverno's own webhooks to validate CR deletions — but those webhooks can't fire because the controller never reached Ready. Terraform saw `helm uninstall` timeout and gave up. Retrying without manual cleanup perpetuated the loop.
+
+The teardown-path webhook race (ClusterSecretStore blocking on ESO's own validation webhook after ESO is destroyed) is **structurally identical** to the apply-path race but flows in the opposite direction. Same missing-depends_on class; Incident 17's Prevention rule would have caught both if applied.
+
+### Detection
+
+First-run failure was unambiguous from CI logs — error text explicitly named `aws-load-balancer-webhook-service` across 22 failures. Pattern-matched Incident 17 instantly. The misdiagnosis of naïve retry as "webhook race self-resolves once LBC is Ready" was partially correct (4 of 5 charts recovered) but missed that Kyverno specifically poisons its own retry path.
+
+Teardown failure detected via workflow job log: `aegis-ssm failed to delete kubernetes resource: Internal error occurred: failed calling webhook "validate.clustersecretstore.external-secrets.io"` — same admission-webhook-with-no-endpoints signature, different chart.
+
+Operator lockout detection during manual recovery: `kubectl auth whoami` returned `Unauthorized` despite valid SSO credentials. `aws eks list-access-entries` showed only `github-actions-terraform`, `AWSServiceRoleForAmazonEKS`, and the Fargate pod-execution-role — no entry for the human SSO role `AWSReservedSSO_PlatformAdmin_*`. This gap was independent of Incident 33 (a pre-existing deficiency the incident exposed) but materially blocked recovery.
+
+### Resolution
+
+Full manual cleanup + teardown retry sequence (executed with operator SSO after ad-hoc Access Entry creation):
+
+1. **Grant SSO role temporary EKS access on both clusters** (required because the platform layer's Terraform never provisioned an Access Entry for the SSO admin role — pre-existing gap, flagged as follow-up below):
+
+   ```bash
+   SSO_ROLE="arn:aws:iam::251774439261:role/aws-reserved/sso.amazonaws.com/eu-central-1/AWSReservedSSO_PlatformAdmin_5f5772e2bfd724a3"
+   for region_cluster in "eu-central-1 aegis-staging-primary" "eu-west-1 aegis-staging-slave-1"; do
+     region=$(echo $region_cluster | awk '{print $1}')
+     cluster=$(echo $region_cluster | awk '{print $2}')
+     aws eks create-access-entry --cluster-name $cluster --region $region \
+       --principal-arn "$SSO_ROLE" --type STANDARD
+     aws eks associate-access-policy --cluster-name $cluster --region $region \
+       --principal-arn "$SSO_ROLE" \
+       --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy \
+       --access-scope type=cluster
+   done
+   ```
+
+2. **Delete ESO ValidatingWebhookConfiguration** (the one blocking ClusterSecretStore deletion) on both clusters:
+
+   ```bash
+   kubectl --context $ctx delete validatingwebhookconfiguration secretstore-validate
+   ```
+
+3. **Patch + delete `ClusterSecretStore/aegis-ssm`** (finalizer was empty but the webhook rejection was the block — step 2 was required first):
+
+   ```bash
+   kubectl --context $ctx patch clustersecretstore aegis-ssm -p '{"metadata":{"finalizers":null}}' --type=merge
+   kubectl --context $ctx delete clustersecretstore aegis-ssm
+   ```
+
+4. **Delete Kyverno admission webhook configs** (remove the stuck validation that would block CRD deletes):
+
+   ```bash
+   kubectl --context $ctx get mutatingwebhookconfiguration,validatingwebhookconfiguration -o name \
+     | grep -i kyverno | xargs -r kubectl --context $ctx delete
+   ```
+
+5. **Patch finalizers off + delete all 12 Kyverno CRDs** (cascades to any remaining CRs; CRDs themselves had finalizers):
+
+   ```bash
+   for crd in $(kubectl --context $ctx get crd -o name | grep kyverno); do
+     kubectl --context $ctx patch $crd -p '{"metadata":{"finalizers":null}}' --type=merge
+   done
+   kubectl --context $ctx get crd -o name | grep kyverno \
+     | xargs -r kubectl --context $ctx delete --timeout=30s
+   ```
+
+6. **Re-trigger teardown workflow** — completed cleanly on this retry because the cluster-side blockers were gone.
+
+7. **Fix PR** follows: 4 files × `depends_on = [helm_release.aws_lb_controller]` + a prominent policy comment at the top of `lb-controller.tf` enumerating compliance and the rule for future authors.
+
+### Prevention
+
+1. **Structural fix** (this incident's fix PR): explicit `depends_on = [helm_release.aws_lb_controller]` added to `cert-manager-helm.tf`, `external-secrets-helm.tf`, `kyverno-helm.tf`, `kube-state-metrics.tf`. These are the 4 charts that demonstrably failed; `alloy.tf` transitively waits via `external_secrets` and is not load-bearing today (flag for follow-up audit).
+
+2. **Documentation fix**: prominent policy comment at the top of `lb-controller.tf` (not buried in a separate doc) enumerates the rule and current compliance status. Future helm_release additions reviewing the file at PR time will see the rule inline. This is the weakest part of the fix — relies on author compliance — but is the cheapest to ship. Long-term a pre-commit / Checkov custom rule checking `helm_release` → `depends_on` → `helm_release.aws_lb_controller` for charts that create Services would be stronger; out of scope for this PR.
+
+3. **Kyverno-specific hardening**: consider `atomic = true` on `helm_release.kyverno` so a failed first-apply auto-cleans (rolls back) rather than leaving broken state that poisons retry. Not in this PR (one change per PR principle); flagged for the next Kyverno-touching PR.
+
+4. **EKS Access Entry for SSO admin role**: separate from Incident 33's root cause, but exposed by the recovery path. Platform layer should provision an Access Entry for the SSO admin role (likely derived from `data.aws_iam_policy.sso_administrators` or passed as a config value). Until then, operators needing kubectl access during teardown-recovery will need to create Access Entries ad-hoc via AWS CLI. Follow-up issue to track.
+
+### Lessons
+
+- **"Incidents' Prevention sections must live where the code lives, not in a separate doc."** Incident 17's Prevention rule was correct and comprehensive, but it sat in `docs/incidents.md` and nobody reading the next helm_release PR had it in their working memory. The fix here bakes the rule into `lb-controller.tf` as a prominent top-of-file comment with compliance checklist — future PRs touching that module will see it. Generalizable: every "class-of-bug" prevention rule should have a co-located comment at the natural load-bearing location, not only in the incident log.
+
+- **"Prevention that relies on author compliance without enforcement is technical debt."** The depends_on rule is a code-review convention, not a check. Checkov doesn't catch it; terraform validate doesn't; tflint doesn't. Each new helm_release that misses it is an incident-in-waiting. A custom policy (Checkov/OPA/CEL on the plan) would be stronger. Not a 5-minute fix, but worth scheduling.
+
+- **"Second-order effects from admission webhooks are an order of magnitude worse than the first-order failure."** LBC webhook race on apply is annoying but cleanly recoverable (add depends_on, retry). LBC webhook race **combined with** Kyverno's self-finalizer trap on retry was un-recoverable via CI alone — required 90 minutes of manual kubectl work. The compound failure mode wasn't obvious from Incident 17's write-up. Moral: admission webhooks + finalizers + failed helm_release retry is a three-way deadlock surface that deserves dedicated guard rails (atomic=true, separate namespace lifecycle for CRDs, pre-Ready health checks, etc.).
+
+- **"Break-glass discipline must acknowledge that teardown recovery is structurally different from apply break-glass."** The break-glass-apply principle doc (PR #121) correctly flags unauthorized forward-progress mutations. But teardown recovery — where the goal is to return to clean state — often requires K8s-side intervention (finalizer patching, webhook deletion) that's operationally necessary and not the class of concern the principle addresses. The principle doc should carve out "teardown recovery" as an explicit exception category, or a sibling document should codify the teardown-recovery ritual as a named runbook. Right now the ritual exists only as tribal knowledge that each incident must rediscover.
+
+- **"EKS Access Entry provisioning for human SSO roles is a hidden single-point-of-failure for teardown recovery."** The platform layer cleanly provisions Access Entries for the CI role and the Fargate pod-execution-role, but not for the human SSO admin role. This worked "by accident" in normal flow because the operator never needs kubectl in green-path cold-apply + teardown. The moment the green path deviates and operator intervention is required, the operator is locked out. Fix: provision the SSO Access Entry in the platform layer; until then, document the ad-hoc creation as a known teardown-recovery step.
+
+- **"4 + 1 failures is a pattern, not bad luck."** Incident 17 + Incident 33 + (future): if this same class of bug surfaces a third time, the fix is not another depends_on — it's a structural change to how `helm_release`s declare their admission-webhook dependencies (e.g., a module-level map of "admission-owning helm_releases" that `null_resource`s encode as cluster-wide serialization gates). Flag the structural refactor as a pre-emptive ADR draft if the issue recurs.
+
+---
+
 ## Incident 34 — `lifecycle.ignore_changes` does not protect against destroy (2026-04-25)
 
 **Date**: 2026-04-25 (Phase 4c+ post-Incident-33 teardown forensics)

--- a/terraform/environments/staging/observability/.terraform.lock.hcl
+++ b/terraform/environments/staging/observability/.terraform.lock.hcl
@@ -1,0 +1,115 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.19.0"
+  constraints = "~> 1.19"
+  hashes = [
+    "h1:quymfa/OKEfWI5JXFEwGbUY2aAy0vet3rA9JWJam+3k=",
+    "zh:1dec8766336ac5b00b3d8f62e3fff6390f5f60699c9299920fc9861a76f00c71",
+    "zh:43f101b56b58d7fead6a511728b4e09f7c41dc2e3963f59cf1c146c4767c6cb7",
+    "zh:4c4fbaa44f60e722f25cc05ee11dfaec282893c5c0ffa27bc88c382dbfbaa35c",
+    "zh:51dd23238b7b677b8a1abbfcc7deec53ffa5ec79e58e3b54d6be334d3d01bc0e",
+    "zh:5afc2ebc75b9d708730dbabdc8f94dd559d7f2fc5a31c5101358bd8d016916ba",
+    "zh:6be6e72d4663776390a82a37e34f7359f726d0120df622f4a2b46619338a168e",
+    "zh:72642d5fcf1e3febb6e5d4ae7b592bb9ff3cb220af041dbda893588e4bf30c0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1da03e3239867b35812ee031a1060fed6e8d8e458e2eaca48b5dd51b35f56f7",
+    "zh:b98b6a6728fe277fcd133bdfa7237bd733eae233f09653523f14460f608f8ba2",
+    "zh:bb8b071d0437f4767695c6158a3cb70df9f52e377c67019971d888b99147511f",
+    "zh:dc89ce4b63bfef708ec29c17e85ad0232a1794336dc54dd88c3ba0b77e764f71",
+    "zh:dd7dd18f1f8218c6cd19592288fde32dccc743cde05b9feeb2883f37c2ff4b4e",
+    "zh:ec4bd5ab3872dedb39fe528319b4bba609306e12ee90971495f109e142d66310",
+    "zh:f610ead42f724c82f5463e0e71fa735a11ffb6101880665d93f48b4a67b9ad82",
+  ]
+}
+
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "4.33.0"
+  constraints = "~> 4.31"
+  hashes = [
+    "h1:ZH3ni51Pe8JrF5hIfAfu6rNt3P4ZC2YdZoQdRRp/V5Y=",
+    "zh:052fd093bc06ec26bf1cf068ee38a8520f2327e71fba167decb263af1d72c6c2",
+    "zh:1149b04f9adaaf5d94cc29355b389a386a627274e60cfdcbaee7446b2844500c",
+    "zh:1cf02f14a0952861ce566d5f8af7b612187702a8cb1dc990fda91e4cbc5a423e",
+    "zh:2dc0a0651bc8a34f453a152c47311ce4e5da94a1847182711bcb602a9c83f8fa",
+    "zh:334c70c9f4315903b156f4fcf9cbb6b91168c7920889df78ca425644e554c38f",
+    "zh:67de5522c97aeeea2decd021ae014f53ddbd42859477a9963d3396d51b84bf39",
+    "zh:691e6db06bba141883ce7be94022ef3194d4b02be4a9ec7a26a3730f6d5b69bf",
+    "zh:7a6f7d048e0a71b993e2d885fa81bafecd89f932f1ccbaee57916753ed45273d",
+    "zh:9442597c01261d796f5709f6308f653c932c341c98e3908e39494501a10136a5",
+    "zh:97660b697466daa1b12e9cdb860c41ce6d551b30a8df9af8ae6043d8d6f8c2c4",
+    "zh:9ee0cf1276ecd103f051fab65c6e77168db2fcfa4c75d42f1b860b8634279e56",
+    "zh:b044577e5fd3ace9c867dd181004b9a3e27a113573eb235f63ef76ac34ccc9af",
+    "zh:b5174cde297213a27a1d9bdb6ed980d26fa28ec6598933f7e1e1261ea4db7f39",
+    "zh:b6e49a0e93179ebe2193bfdece7920f5b3d7a46627edb06725153f8505a87da1",
+    "zh:ba419a70b3090bf069e7dec0eeb81007601598b811555517f5d9132432e64e1f",
+    "zh:ce7c71e55781223fb753d9ebc74d70f646e6c622c8218bdd06e421df3f2f9b2d",
+    "zh:cf747b021535b9a073577b6fd16a9a417444a5c24c2f6626a17492e00c1bb34a",
+    "zh:e049cd8af1867b642fc26dc230b40d87c03e9eab05da120109acd00e3327b207",
+    "zh:e744602afd2a56561c27fe887e4d4eb21ee9992581205fb1a0c396b84afedd52",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.42.0"
+  constraints = "~> 6.40"
+  hashes = [
+    "h1:B00CO2gJ6fSyfUGhi+siRqNoUG9jI7PD+3r1dHWv3OI=",
+    "zh:0dd774a97eaa4371a60e13b5dc56800d4fb1c48d50e79049f75fc4fe26705ff5",
+    "zh:237d652d8ec028f7bedce1ce056ffe42e2e120d2a4a47fe45b97263cc5948e7e",
+    "zh:367d9e4b816e5f857956887b8f0770aaa5bec47c4b1e2c7bf924e39192d580d6",
+    "zh:4194addb5b34bb803fab031a80d84e9d16cac2308df9a498d51e2214c7893900",
+    "zh:5bcc36226fa5d8a3c37e41ac8cfd2b1eb73e7ae96f8418f6776dcaa16a987198",
+    "zh:61d0632d4cc7973b779b90c1d3bb2d05a1cd4d7030bb4645831e67cf735ecaa0",
+    "zh:7c7efaf9e4bb662ba3e8a714abafe7107bdcd1bf2cd0867510ea32762debc11d",
+    "zh:7d7f8ffe00d4a90184efa454a107bcc46d81f21245baea9678dcfa2fa77ac1be",
+    "zh:7e534c454cdeafe9cc225bea53397883bb96c54da6ea3421fd53dbc9dfc1bb90",
+    "zh:99564c99a0672b2a8b666ab2040f36a7c6f372fa79ac43a6657a54734e46fff8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6b1bb6178798882508f5512222a9433fc21e63cdae83a755650c938e6141d32",
+    "zh:a87592d6ff3d46ee83756f4f84503b2fe4ffc9c1d5dc9f8d4afccb5e126ae538",
+    "zh:daa56fb74c5c9d26b327c40b486beac71cdb9a932c7c4e4561f4401cd0d16a4a",
+    "zh:f35ab043d7121f3a194f42f5b0e0d59fe62d94488acea07e3783405fa5838785",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.17"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.35"
+  hashes = [
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}

--- a/terraform/environments/staging/platform/modules/eks-cluster/cert-manager-helm.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/cert-manager-helm.tf
@@ -73,6 +73,10 @@ resource "helm_release" "cert_manager" {
   depends_on = [
     aws_eks_cluster.main,
     helm_release.karpenter,
+    # LB Controller webhook must be ready before this chart's Services hit
+    # admission (cert-manager, cert-manager-webhook, cert-manager-cainjector).
+    # See Incident 17 (ArgoCD fix) + Incident 33 (this race recurrence).
+    helm_release.aws_lb_controller,
     kubectl_manifest.aegis_cluster_admin_binding,
   ]
 }

--- a/terraform/environments/staging/platform/modules/eks-cluster/external-secrets-helm.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/external-secrets-helm.tf
@@ -75,6 +75,10 @@ resource "helm_release" "external_secrets" {
   depends_on = [
     aws_eks_cluster.main,
     helm_release.karpenter,
+    # LB Controller webhook must be ready before this chart's Services hit
+    # admission (external-secrets, external-secrets-webhook, external-secrets-cert-controller).
+    # See Incident 17 (ArgoCD fix) + Incident 33 (this race recurrence).
+    helm_release.aws_lb_controller,
     kubectl_manifest.aegis_cluster_admin_binding,
   ]
 }

--- a/terraform/environments/staging/platform/modules/eks-cluster/kube-state-metrics.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/kube-state-metrics.tf
@@ -48,5 +48,9 @@ resource "helm_release" "kube_state_metrics" {
 
   depends_on = [
     helm_release.prometheus_operator_crds,
+    # LB Controller webhook must be ready before this chart's Service hits
+    # admission (kube-state-metrics exposes a Service for scraping).
+    # See Incident 17 (ArgoCD fix) + Incident 33 (this race recurrence).
+    helm_release.aws_lb_controller,
   ]
 }

--- a/terraform/environments/staging/platform/modules/eks-cluster/kyverno-helm.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/kyverno-helm.tf
@@ -66,6 +66,13 @@ resource "helm_release" "kyverno" {
   depends_on = [
     aws_eks_cluster.main,
     helm_release.karpenter,
+    # LB Controller webhook must be ready before this chart's Services hit
+    # admission (admission-controller, background-controller, cleanup-controller,
+    # reports-controller — Kyverno installs many Services). First-apply failure
+    # here is especially painful: Kyverno's own admission webhook then blocks
+    # its own helm uninstall via CRD finalizers, turning a retry into a manual
+    # K8s cleanup. See Incident 17 (ArgoCD fix) + Incident 33 (this race).
+    helm_release.aws_lb_controller,
     # Cluster-admin via group — needed for CRD delete at teardown.
     # See Incident 18 + 21.
     kubectl_manifest.aegis_cluster_admin_binding,

--- a/terraform/environments/staging/platform/modules/eks-cluster/lb-controller.tf
+++ b/terraform/environments/staging/platform/modules/eks-cluster/lb-controller.tf
@@ -1,6 +1,32 @@
 # -----------------------------------------------------------------------------
 # AWS Load Balancer Controller — Helm install (per-cluster)
 # -----------------------------------------------------------------------------
+# ⚠️  Admission webhook ordering policy (Incidents 17 + 33)
+#
+# LBC installs a cluster-wide MutatingWebhookConfiguration (`mservice.elbv2.k8s.aws`)
+# that intercepts EVERY `Service` resource at admission — not just `type=LoadBalancer`.
+# Until LBC's own Pod is Ready and its backing Service has Endpoints, Service
+# creations elsewhere in the cluster fail with "no endpoints available for
+# service aws-load-balancer-webhook-service".
+#
+# **Rule: any helm_release in this module that creates K8s Services must add**
+# **`helm_release.aws_lb_controller` to its `depends_on` block.**
+#
+# Current compliance (as of Incident 33 fix, PR following 2026-04-24):
+#   ✅ argocd.tf — depends_on aws_lb_controller (Incident 17 original fix)
+#   ✅ cert-manager-helm.tf — added at Incident 33
+#   ✅ external-secrets-helm.tf — added at Incident 33
+#   ✅ kyverno-helm.tf — added at Incident 33
+#   ✅ kube-state-metrics.tf — added at Incident 33
+#   ⏭️ karpenter-helm.tf — installed BEFORE LBC (no race)
+#   ⏭️ prometheus-operator-crds.tf — CRDs only, no Service
+#   ⏭️ alloy.tf — transitive via external_secrets; explicit safer but not failing today
+#
+# Future helm_release additions: audit at PR time for Service-creating charts
+# and add the depends_on before merge. This policy is the load-bearing
+# prevention for a multi-cluster webhook race that wasted a full cold-apply
+# slot + forced manual K8s cleanup (Incident 33).
+# -----------------------------------------------------------------------------
 resource "helm_release" "aws_lb_controller" {
   provider = helm.this
 


### PR DESCRIPTION
## Summary

Today's first real cold-apply end-to-end (Qdrant + aegis-core rollout wiring together) hit a **recurrence of Incident 17** across 5 helm_releases × 2 clusters, plus a mirror-image race on the teardown path, plus a Kyverno self-finalizer poison-pill that turned a retry into 90min of manual K8s cleanup.

**Root cause**: Incident 17 (2026-04-14) prescribed in its Prevention section that any helm_release creating K8s Services must `depends_on = [helm_release.aws_lb_controller]`. That rule was applied only to `argocd.tf`; five subsequent helm_releases (cert-manager, external-secrets, kyverno, kube-state-metrics, and transitively alloy) never got it. Terraform's resource graph gave no signal — these resources don't reference LBC attributes — so they were scheduled in parallel with LBC's install, before LBC's pod was Ready on a freshly Karpenter-provisioned EC2 node.

The apply-side race and the teardown-side race (ClusterSecretStore blocked by ESO's own ValidatingWebhookConfiguration after TF destroys ESO's helm_release) are **structurally identical** — same missing-depends_on class in opposite directions. The Kyverno uninstall hang on retry is a second-order effect: failed first-apply left CRDs + finalizers that the missing Kyverno controller couldn't reconcile.

## What changed

| File | Change |
|---|---|
| `cert-manager-helm.tf` | +4 — add `helm_release.aws_lb_controller` to `depends_on` |
| `external-secrets-helm.tf` | +4 — same |
| `kyverno-helm.tf` | +7 — same, with note on the compound finalizer deadlock |
| `kube-state-metrics.tf` | +4 — same |
| `lb-controller.tf` | +26 — prominent top-of-file policy comment enumerating the rule + current compliance checklist + future-author guidance. **Load-bearing**: Incident 17's Prevention rule lived only in `docs/incidents.md` and thus failed to reach authors of the 5 later helm_releases. Co-locating the rule with the code is the structural fix for that failure mode. |
| `docs/incidents.md` | +136 — Incident 33 full writeup with resolution sequence, EKS Access Entry gap follow-up, and lessons on where Prevention rules should physically live |
| `terraform/environments/staging/observability/.terraform.lock.hcl` | NEW — byproduct of the pre-cold-apply `terraform init` run during Qdrant retrofit import today. Lock files are meant to be checked in per Terraform best practice; this PR is just the first commit that happens to carry it. Orthogonal to the fix. |

## Change Review Discipline checklist (per `docs/principles/change-review-discipline.md`)

### 1. Blast radius
**Low.** Serializes 4 helm_releases behind LBC on fresh cluster apply; adds ~30–60s to first apply. No-op on subsequent applies (TF graph doesn't re-plan completed depends_on). No change to running clusters — they already have these releases installed in arbitrary order; the depends_on only affects the next cold-apply.

### 2. Dependency assumptions
- LBC `helm_release`'s default `wait = true` means `depends_on` completes only once the LBC chart reports Ready (all Deployments' pods schedulable + scheduled + ready + Endpoints populated). Same semantics as the `argocd.tf` fix that's been in place since 2026-04-14 and has worked through many cold-apply cycles.
- No new providers, no new resources, no new IAM. Pure HCL attribute addition.

### 3. Deprecation status
- No upstream chart changes.
- `helm_release` provider resource itself: latest; `depends_on` is a first-class HCL attribute with stable semantics.

### 4. Rollback plan
- Revert is a single-PR operation.
- Net effect of revert: restore the pre-fix race-y state. Does NOT break existing clusters that are already up — the `depends_on` only affects scheduling on a fresh apply.
- No state migration required on revert.

### 5. 2 AM readability
- Top-of-file comment in `lb-controller.tf` names the rule + Incident 33 + compliance checklist. An operator reading `lb-controller.tf` cold during an incident will see the rule inline without having to cross-reference `docs/incidents.md`.
- Each edited file's new `depends_on` entry has a 2–3 line comment naming Incident 17 + Incident 33, so a file-by-file diff review can follow the trail without the PR description.

## Follow-ups (intentionally not in this PR)

- **Kyverno `atomic = true`**: make `helm_release.kyverno` auto-rollback on failed install so retry is cleaner. One-change-per-PR principle; next Kyverno-touching PR.
- **SSO EKS Access Entry in platform layer**: provision the human SSO admin role's Access Entry in the Terraform platform layer (today only the CI role gets one). Exposed by today's recovery path but structurally independent of this webhook race. Separate issue.
- **`alloy.tf` explicit `depends_on`**: alloy transitively waits via `external_secrets`, but should get its own explicit `depends_on = [helm_release.aws_lb_controller]` for safety. Not failing today. Follow-up audit PR once this lands.
- **Enforcement**: the depends_on rule is a code-review convention. Custom Checkov/OPA policy checking `helm_release` → Service creation → depends_on on aws_lb_controller would be stronger. Separate investment.

## Test plan

- [ ] Checkov green
- [ ] All Plan matrix jobs green (especially `staging/platform` — should show the 4 depends_on edges in the plan graph)
- [ ] Visual sanity: `lb-controller.tf` top comment renders with correct line breaks
- [ ] Once merged: next cold-apply (scheduled for future dedicated session after Incident 33 recovery completes) validates the fix end-to-end
- [ ] No regression on teardown path — same ordering logic applies in reverse

## Related

- [Incident 17 (2026-04-14)](https://github.com/BinHsu/aegis-aws-landing-zone/blob/main/docs/incidents.md#incident-17--aws-load-balancer-controller-webhook-endpoint-not-ready-when-argocd-installs) — original fix for ArgoCD only
- [Incident 33 (2026-04-24)](https://github.com/BinHsu/aegis-aws-landing-zone/blob/main/docs/incidents.md#incident-33--lbc-webhook-race-recurrence-incident-17-prevention-never-propagated-to-5-later-helm_releases-kyverno-finalizer-cascade-turned-a-first-apply-retry-into-manual-k8s-cleanup) — this incident's full writeup (added in this PR)
- [PR #148](https://github.com/BinHsu/aegis-aws-landing-zone/pull/148) — Runbook 007 unfreeze (prior to this session's cold-apply attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)