### PR TITLE
chore(docs): forker-friendliness batch 4 — architecture diagram + interview-notes banner + war-story framing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ AWS Organizations structure with the six accounts, three OUs, and SCP attachment
 
 ```mermaid
 flowchart TB
-  Org["AWS Organization<br/>o-f5xi4j1hrx<br/>Control Tower home: eu-central-1"]
+  Org["AWS Organization<br/>(your org id)<br/>Control Tower home: eu-central-1"]
 
   Mgmt["aegis-management<br/><br/>Organizations<br/>SCPs<br/>Identity Center<br/>Billing<br/>RAM org-sharing"]
 
@@ -129,10 +129,10 @@ What lives in the `aegis-shared` account, and how other accounts consume its ser
 
 ```mermaid
 flowchart TB
-  subgraph shared["aegis-shared (345895787808)"]
+  subgraph shared["aegis-shared"]
     direction TB
 
-    bucket["S3: aegis-terraform-state-345895787808<br/>SSE-KMS + versioning<br/>30-day noncurrent expiration<br/>prevent_destroy"]
+    bucket["S3: aegis-terraform-state-&lt;shared-account-id&gt;<br/>SSE-KMS + versioning<br/>30-day noncurrent expiration<br/>prevent_destroy"]
 
     ipam["AWS IPAM (Advanced tier)"]
     top["Top Pool: 10.0.0.0/8"]

--- a/docs/design-narrative.md
+++ b/docs/design-narrative.md
@@ -64,7 +64,7 @@ Every multi-account AWS landing zone faces this exact cycle. Some projects ignor
 
 ## War stories
 
-Real incidents from this project's deployment are kept in [`docs/incidents.md`](incidents.md) as postmortem-style entries (Symptom → Root cause → Detection → Resolution → Prevention → Lessons). Highlights:
+Real incidents from this project's deployment history are kept in [`docs/incidents.md`](incidents.md) as postmortem-style entries (Symptom → Root cause → Detection → Resolution → Prevention → Lessons). Highlights below illustrate the *kind* of issues a multi-account landing zone surfaces under cold-apply — not a prescriptive checklist a forker should expect to encounter in this exact order or set:
 
 - **KMS key policy wasn't enough at Control Tower launch** — the wizard's default key policy was missing CloudTrail and Config service principals. Rollback itself failed because a CloudWatch Log Group couldn't be cleaned up. See [Incident 1](incidents.md#incident-1--kms-key-policy-insufficient-at-control-tower-launch).
 - **IAM alias collided with another AWS customer worldwide** — aliases are globally unique, not org-scoped. `list-account-aliases` returning empty is not proof the alias is available. Fixed by `binhsu-` prefix. See [Incident 2](incidents.md#incident-2--iam-account-alias-globally-unique-collision).

--- a/docs/interview-notes.md
+++ b/docs/interview-notes.md
@@ -3,9 +3,11 @@
 
 A reader's guide for recruiters, hiring managers, and technical leadership reviewing this project as a portfolio artifact. Different from the rest of the repo, this document is written *about* the project rather than *inside* it — its job is to frame scope, stance, and what a conversation could productively cover.
 
+> **Forking this repo?** This document is portfolio-framing, not operational guidance — start with [`README.md`](../README.md) for the architecture overview and [`docs/runbooks/`](runbooks/) for how-to walk-throughs.
+
 **Time budget**:
 - Recruiter / HR / hunter: read all of this doc (~10 min).
-- Technical leader / architect peer: skim section 1 (stance), then jump to [`docs/decisions/`](decisions/) for the 28 ADRs and [`docs/incidents.md`](incidents.md) for the 34 postmortems.
+- Technical leader / architect peer: skim section 1 (stance), then jump to [`docs/decisions/`](decisions/) for the 28 ADRs and [`docs/incidents.md`](incidents.md) for the 35 postmortems.
 
 ---
 
@@ -100,7 +102,7 @@ Each entry: what was built → where to look in the repo → the kind of questio
 **Where to look**:
 - [`CLAUDE.md`](../CLAUDE.md) — 6 explicit "Rule: AI must..." clauses
 - [`docs/decisions/`](decisions/) — 28 ADRs
-- [`docs/incidents.md`](incidents.md) — 34 postmortems
+- [`docs/incidents.md`](incidents.md) — 35 postmortems
 - [`docs/runbooks/`](runbooks/) — 8 runbooks
 - [`docs/principles/`](principles/) — 2 cross-cutting discipline docs (change-review, break-glass-apply)
 
@@ -200,7 +202,7 @@ Positive statements of what this project demonstrates, paired with explicit stat
 ### What is claimed
 
 - **Cross-cutting architectural design**: composing 10+ AWS services into a working multi-account landing zone with explicit decisions (ADRs) and documented trade-offs.
-- **Operational discipline**: 28 ADRs + 34 incident postmortems + 8 runbooks + 2 cross-cutting principle docs, each written to a consistent format, never softened retroactively.
+- **Operational discipline**: 28 ADRs + 35 incident postmortems + 8 runbooks + 2 cross-cutting principle docs, each written to a consistent format, never softened retroactively.
 - **Production-shaped patterns** — not production-*hardened* (the lab is single-operator, single-region-primary, no DR-tested, no SOC 2 audit trail). The patterns are transferable to production; the lab itself isn't production.
 - **Reproducibility**: a single `config/landing-zone.yaml` + two shell scripts land the whole foundation in a fresh AWS organization. Fork-and-deploy is not a slogan here; it's tested.
 
@@ -253,7 +255,7 @@ This doc is frame-level. For the actual substance:
 | Interest | Open |
 |---|---|
 | "Walk me through the architectural decisions" | [`docs/decisions/`](decisions/) — 28 ADRs |
-| "Show me real failures and what you learned" | [`docs/incidents.md`](incidents.md) — 34 postmortems |
+| "Show me real failures and what you learned" | [`docs/incidents.md`](incidents.md) — 35 postmortems |
 | "How do I reproduce this?" | [`docs/runbooks/001-bootstrap-aws-account.md`](runbooks/001-bootstrap-aws-account.md) |
 | "How would an AI agent work on this?" | [`CLAUDE.md`](../CLAUDE.md) |
 | "What does the config contract look like?" | [`config/landing-zone.example.yaml`](../config/landing-zone.example.yaml) + [`config/schema.json`](../config/schema.json) + [ADR-004](decisions/004-deployment-configuration-contract.md) |


### PR DESCRIPTION
## Summary

Closes the remaining items from the forker-perspective audit. After this PR, the audit's punch list is empty barring intentional skips (ADRs as historical record, project-identity strings like \`aegis\`, region values that document SCP intent).

**Net diff**: 3 files, +10 / -8.

## What changed

### \`docs/architecture.md\` — Mermaid diagrams

The diagrams are the public architecture reference; one specific org's IDs should not appear in them.

- Org node: literal \`o-f5xi4j1hrx\` replaced with \`(your org id)\`
- \`aegis-shared\` subgraph title: stripped \`(345895787808)\`; reads as \`aegis-shared\` alone
- State bucket node: \`aegis-terraform-state-345895787808\` templated as \`aegis-terraform-state-<shared-account-id>\` (HTML-escaped angle brackets so Mermaid renders them as literal text)

### \`docs/interview-notes.md\`

- **Forker banner** added directly under the doc intro: a one-line callout pointing readers who are forking the repo at \`README.md\` + \`docs/runbooks/\` instead. Keeps the doc's hiring-review framing (by-design per the project_portfolio_docs memory) while preventing forkers from reading the wrong manual.
- **Stale postmortem count corrected**: \`34 postmortems\` → \`35 postmortems\` in the 5 places it is asserted. Historical footer entries (lines 264+) are intentionally left as-is per the rule against retroactive editing of timestamped session notes.

### \`docs/design-narrative.md\` — War stories intro

Added explicit framing that the listed incidents illustrate \"the *kind* of issues a multi-account landing zone surfaces under cold-apply\", not \"a prescriptive checklist a forker should expect to encounter in this exact order or set\". A stranger reading the highlights might otherwise assume their deployment will hit Incidents 1–6 verbatim; the new sentence blocks that misreading without softening any actual incident content.

## Sequence summary (this session's forker-friendliness track)

| PR | Scope |
|---|---|
| #158 | CLAUDE.md split: discipline vs personal preferences (-77 lines; 5 memory files added) |
| #159 | README portfolio language + Phase 5 status + runbooks 006/007/008 emails + CLAUDE.md count drift |
| #160 | Runbook 004 (Cloudflare DNS delegation) templating |
| **#161 (this)** | Architecture diagrams + interview-notes banner + war-stories framing |

Audit items still NOT addressed by design:
- ADR personal references (CLAUDE.md rule: never retroactively edit ADRs to soften)
- Project-identity strings \`aegis\` / \`aegis-core\` (CLAUDE.md rule: acceptable to hardcode)
- Region values \`eu-central-1\` / \`eu-west-1\` in SCPs (these document policy intent, not location)

## Test plan

- [ ] Mermaid diagrams in \`docs/architecture.md\` still render on GitHub (HTML-escaped \`&lt;\`/\`&gt;\` should appear as literal angle brackets)
- [ ] Interview-notes counts agree with reality: \`grep -c '^## Incident ' docs/incidents.md\` → 35 (footer historical entries excepted)
- [ ] No links broken; design-narrative war-stories incidents still link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)