### PR TITLE
docs: session-close drift fix — 2026-04-28 session

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Complete improvement index and reliability map: [`docs/improvements/README.md`](
 | [025](docs/decisions/025-qdrant-backend-cloud-free-tier.md) | Qdrant backend — Cloud free tier |
 | [026](docs/decisions/026-cognito-auth-user-pool.md) | Cognito User Pool — cloud-mode auth for aegis |
 | [027](docs/decisions/027-intra-environment-layer-sharding.md) | Intra-environment Terraservice layer sharding discipline |
+| [028](docs/decisions/028-persistent-saas-credential-isolation.md) | Persistent SaaS-credential SSM PS shells isolated from teardown matrix |
 
 ## Runbooks
 

--- a/docs/interview-notes.md
+++ b/docs/interview-notes.md
@@ -243,8 +243,8 @@ Two incidents caught during a Dependabot maintenance sweep after the Phase 3c ro
 ### Phase 4 — Observability + cluster security (done 2026-04-17)
 Three sub-phases shipped in PRs #67–#69: **4a'** (docking station — `aegis` namespace, IRSA skeleton, default-deny NetworkPolicy, ADR-017); **4b** (kube-prometheus-stack via ArgoCD with deprecated-API alert rule, VPC Flow Logs to S3 in Parquet, ADR-015) (observability backend reversed 2026-04-21 per ADR-022; see ADR-022 §Context for rationale); **4c** (GuardDuty EKS Runtime + Audit Log Monitoring, Kyverno admission controller with 4 baseline policies in Audit mode, ADR-016). Cross-repo coordination protocol ([#54](https://github.com/BinHsu/aegis-aws-landing-zone/issues/54), [#11](https://github.com/BinHsu/aegis-core/issues/11)) exercised live during the session. Phase 4a'' (actual workload deployment) gates on aegis-core shipping OCI images.
 
-### Phase 5 — Service mesh + per-pod TLS (not started)
-cert-manager, service mesh mTLS, private endpoints, EKS Pod Identity migration.
+### Phase 5 — Auth + Service Mesh (partial — Auth shipped, mesh not started)
+**Shipped**: Cognito User Pool ([ADR-026](decisions/026-cognito-auth-user-pool.md), Accepted; live `eu-central-1_0gdyxKxOB` user pool with validated Hosted UI + JWKS path); cert-manager and External Secrets Operator (Phase 4c platform layer). **Not started**: Istio service mesh mTLS, private endpoints, EKS Pod Identity migration (the `aegis-staging-aegis-engine` IRSA role is provisioned but Pod Identity hasn't replaced it). Persistent-credential layer ([ADR-028](decisions/028-persistent-saas-credential-isolation.md)) shipped to keep SSM PS shells out of the teardown matrix — supporting infrastructure for the auth + observability secret patterns.
 
 ---
 


### PR DESCRIPTION
## Summary

Two drift items found during the session-close marker review (per CLAUDE.md \`session-close-review\` discipline):

1. **README ADR table missing ADR-028** — landed 2026-04-25 (persistent SaaS-credential isolation), never indexed in the README ADR roster. Three sessions of forker-friendliness work since then; the count discrepancy was masked because no PR specifically touched the table.

2. **interview-notes.md §Phase 5** said \"Service mesh + per-pod TLS — not started\", contradicting the README Phase 5 row updated in PR #159 (\"Auth + Service Mesh; partial — Auth shipped, mesh not started\"). README reflects current state (Cognito ADR-026 Accepted, live user pool, cert-manager + ESO in Phase 4c platform layer). interview-notes §5 paragraph hadn't been refreshed.

Both flagged and fixed in this PR. The interview-notes Phase 5 paragraph now also references ADR-028 so the narrative reads end-to-end.

## Net diff

\`\`\`
README.md               | 1 +
docs/interview-notes.md | 4 ++--
2 files changed, 3 insertions(+), 2 deletions(-)
\`\`\`

## Not included (no drift found)

- docs/architecture.md — Mermaid diagrams reflect current topology
- docs/incidents.md — no new incidents this session
- docs/runbooks/* — no operational changes
- docs/principles/* — versions / triggers unchanged
- docs/improvements/* — multi-region / SPOF / GuardDuty status unchanged

## Cold-apply effect

None — this PR is pure docs hygiene. Cold-apply gates remain green per \`project_next_session_todos\` memory; next session = cold-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)