### PR TITLE
feat(iam): add gh-tf-apply-workload + gh-tf-teardown-workload roles in staging (ADR-029 PR-5)

### DIFF
--- a/terraform/environments/staging/bootstrap/oidc-github-teardown-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-teardown-role.tf
@@ -1,0 +1,412 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-teardown-workload` — destroy role for `terraform-teardown-workload.yml` (ADR-029)
+# -----------------------------------------------------------------------------
+# Replaces `github-actions-terraform` for the OIDC sub claim
+# `environment:workload-teardown` only. Permission character: same SERVICE
+# surface as `gh-tf-apply-workload`, action list narrowed to destructive
+# verbs (`Delete*`, `Detach*`, `Disassociate*`, `Terminate*`, `Disable*`,
+# `Remove*`, `Revoke*`, `Release*`, `Schedule*KeyDeletion`,
+# `StopExperiment`, `PurgeQueue`) plus the safety-net describe / get / list
+# shapes that the teardown workflow's pre-destroy steps invoke
+# (`aws ec2 describe-vpcs / describe-network-interfaces /
+# describe-security-groups / describe-instances / terminate-instances /
+# wait instance-terminated`, `aws eks list-clusters / update-kubeconfig`).
+#
+# Trust policy is keyed on the OIDC `sub` claim
+# `environment:workload-teardown` only — separate from
+# `gh-tf-apply-workload` so a leaked apply-tier token cannot invoke
+# destructive verbs and a leaked teardown-tier token cannot create new
+# resources. The two roles are siblings on the `aegis-staging`-account
+# IAM tree.
+#
+# Multi-region (ADR-018 slot pattern, K=2): every region-scoped Sid extends
+# both `${local.primary_region}` AND the DR region (resolved inline via
+# `local.config.regions[*].role == "dr"` lookup, kept inline rather than
+# adding `local.dr_region` to staging/bootstrap config.tf — that is scope
+# creep for one consumer).
+#
+# No workflow change in this PR — `terraform-teardown-workload.yml` keeps
+# assuming `github-actions-terraform` until PR-6 cuts it over to
+# `gh-tf-teardown-workload` (chicken-and-egg avoidance).
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_teardown_workload" {
+  name = "gh-tf-teardown-workload"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-teardown"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_teardown_workload" {
+  # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Describe* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update action paired with Resource:*. See ADR-029.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-029. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on AWS APIs that do not support resource-level ARNs (EC2 most destructive actions, ELB, GuardDuty, tag). Every mutating action with Resource:* is service-namespace-scoped at the action prefix and gated by the trust policy `sub: environment:workload-teardown`.
+  name = "teardown-workload-scoped"
+  role = aws_iam_role.gh_tf_teardown_workload.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # EC2 destructive verbs — VPC + NAT GW + IGW + SG + NACL +
+        # route tables + ENIs + subnets + EIPs + flow logs + gateway
+        # endpoints + Karpenter-provisioned EC2 instances. The teardown
+        # workflow's `Sweep orphan EKS ENIs + security groups` step calls
+        # `delete-network-interface` + `delete-security-group`; the
+        # `Sweep orphan Karpenter-provisioned EC2 instances` step calls
+        # `terminate-instances` + `wait instance-terminated`. Plus the
+        # describe shapes those steps need (covered by
+        # `ReadOnlyAwsApiSurface` Sid below). Region condition is the
+        # tightest practical scope; trust policy carries the rest.
+        Sid    = "Ec2Destructive"
+        Effect = "Allow"
+        Action = [
+          "ec2:Delete*",
+          "ec2:Detach*",
+          "ec2:Disassociate*",
+          "ec2:TerminateInstances",
+          "ec2:Revoke*",
+          "ec2:Release*",
+          "ec2:DisableVpcClassicLink",
+          "ec2:DisableVpcClassicLinkDnsSupport",
+          "ec2:RemoveAddressFromClassicLink",
+          "ec2:WithdrawByoipCidr",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestedRegion" = [
+              local.primary_region,
+              [for r in local.config.regions : r.name if r.role == "dr"][0],
+            ]
+          }
+        }
+      },
+      {
+        # EKS destructive verbs — cluster delete, fargate profile delete,
+        # addon delete, access entry delete, identity-provider-config
+        # disassociate. `aegis-staging-*` matches both
+        # `aegis-staging-primary` and `aegis-staging-slave-1`.
+        Sid    = "EksDestructive"
+        Effect = "Allow"
+        Action = [
+          "eks:Delete*",
+          "eks:Disassociate*",
+        ]
+        Resource = [
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:cluster/aegis-staging-*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:fargateprofile/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:addon/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:access-entry/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:identityproviderconfig/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:nodegroup/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:podidentityassociation/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:cluster/aegis-staging-*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:fargateprofile/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:addon/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:access-entry/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:identityproviderconfig/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:nodegroup/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:podidentityassociation/aegis-staging-*/*",
+        ]
+      },
+      {
+        # IAM destructive verbs — delete workload-tier roles + policies +
+        # instance profiles + per-cluster OIDC providers. Includes
+        # `Detach*` (detach managed policy from role / detach role from
+        # instance profile) and `Remove*` (RemoveRoleFromInstanceProfile
+        # used by Karpenter teardown).
+        Sid    = "IamDestructive"
+        Effect = "Allow"
+        Action = [
+          "iam:Delete*",
+          "iam:Detach*",
+          "iam:Remove*",
+          "iam:DeleteServiceLinkedRole",
+        ]
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-staging-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-staging-*",
+          "arn:aws:iam::${local.account_id}:instance-profile/aegis-staging-*",
+          "arn:aws:iam::${local.account_id}:oidc-provider/oidc.eks.${local.primary_region}.amazonaws.com/id/*",
+          "arn:aws:iam::${local.account_id}:oidc-provider/oidc.eks.${[for r in local.config.regions : r.name if r.role == "dr"][0]}.amazonaws.com/id/*",
+          "arn:aws:iam::${local.account_id}:role/aws-service-role/*",
+        ]
+      },
+      {
+        # ELB destructive verbs — ALB / NLB delete + target group
+        # deregister-targets + listener delete. Region condition is the
+        # tightest practical scope; the load-balancer-controller's
+        # runtime-created LBs do not carry stable name prefixes.
+        Sid    = "ElbDestructive"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:Delete*",
+          "elasticloadbalancing:Deregister*",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestedRegion" = [
+              local.primary_region,
+              [for r in local.config.regions : r.name if r.role == "dr"][0],
+            ]
+          }
+        }
+      },
+      {
+        # CloudWatch Logs destructive verbs — EKS cluster log groups,
+        # VPC flow log groups.
+        Sid    = "LogsDestructive"
+        Effect = "Allow"
+        Action = "logs:Delete*"
+        Resource = [
+          "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/eks/aegis-staging-*",
+          "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/eks/aegis-staging-*:*",
+          "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/vpc/flow-logs/aegis-staging-*",
+          "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/vpc/flow-logs/aegis-staging-*:*",
+          "arn:aws:logs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:log-group:/aws/eks/aegis-staging-*",
+          "arn:aws:logs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:log-group:/aws/eks/aegis-staging-*:*",
+          "arn:aws:logs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:log-group:/aws/vpc/flow-logs/aegis-staging-*",
+          "arn:aws:logs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:log-group:/aws/vpc/flow-logs/aegis-staging-*:*",
+        ]
+      },
+      {
+        # SQS destructive verbs — Karpenter interruption queue delete +
+        # purge.
+        Sid    = "SqsDestructive"
+        Effect = "Allow"
+        Action = [
+          "sqs:Delete*",
+          "sqs:PurgeQueue",
+        ]
+        Resource = [
+          "arn:aws:sqs:${local.primary_region}:${local.account_id}:aegis-staging-*",
+          "arn:aws:sqs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:aegis-staging-*",
+        ]
+      },
+      {
+        # EventBridge destructive verbs — Karpenter rules delete +
+        # disable + remove targets.
+        Sid    = "EventsDestructive"
+        Effect = "Allow"
+        Action = [
+          "events:Delete*",
+          "events:Disable*",
+          "events:Remove*",
+        ]
+        Resource = [
+          "arn:aws:events:${local.primary_region}:${local.account_id}:rule/aegis-staging-*",
+          "arn:aws:events:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:rule/aegis-staging-*",
+        ]
+      },
+      {
+        # KMS destructive verbs — schedule key deletion (KMS does not
+        # support immediate delete; minimum 7-day pending window),
+        # disable key, delete alias.
+        Sid    = "KmsDestructive"
+        Effect = "Allow"
+        Action = [
+          "kms:ScheduleKeyDeletion",
+          "kms:DisableKey",
+          "kms:DeleteAlias",
+        ]
+        Resource = [
+          "arn:aws:kms:${local.primary_region}:${local.account_id}:key/*",
+          "arn:aws:kms:${local.primary_region}:${local.account_id}:alias/aegis-staging-*",
+          "arn:aws:kms:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:key/*",
+          "arn:aws:kms:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:alias/aegis-staging-*",
+        ]
+      },
+      {
+        # SSM Parameter Store destructive verbs — Path-A TF-generated
+        # tokens (`alloy-token`, `grafana-operator-token`). Path-B
+        # SaaS-credential parameters live under `staging/secrets-persistent`
+        # which is outside the teardown matrix per ADR-028.
+        Sid    = "SsmDestructive"
+        Effect = "Allow"
+        Action = [
+          "ssm:DeleteParameter",
+          "ssm:DeleteParameters",
+          "ssm:RemoveTagsFromResource",
+        ]
+        Resource = [
+          "arn:aws:ssm:${local.primary_region}:${local.account_id}:parameter/aegis/staging/grafana-cloud/alloy-token",
+          "arn:aws:ssm:${local.primary_region}:${local.account_id}:parameter/aegis/staging/grafana-cloud/grafana-operator-token",
+        ]
+      },
+      {
+        # FIS destructive verbs — delete experiment template, stop any
+        # in-flight experiment (StopExperiment is a destructive verb
+        # against an active experiment, gated to primary region only
+        # since FIS lives there by design).
+        Sid    = "FisDestructive"
+        Effect = "Allow"
+        Action = [
+          "fis:Delete*",
+          "fis:StopExperiment",
+        ]
+        Resource = [
+          "arn:aws:fis:${local.primary_region}:${local.account_id}:experiment-template/*",
+          "arn:aws:fis:${local.primary_region}:${local.account_id}:experiment/*",
+        ]
+      },
+      {
+        # GuardDuty destructive verbs — delete detector + disable
+        # features. Region-conditioned.
+        Sid    = "GuardDutyDestructive"
+        Effect = "Allow"
+        Action = [
+          "guardduty:Delete*",
+          "guardduty:Disable*",
+          "guardduty:Disassociate*",
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestedRegion" = [
+              local.primary_region,
+              [for r in local.config.regions : r.name if r.role == "dr"][0],
+            ]
+          }
+        }
+      },
+      {
+        # CloudWatch alarm destructive verbs — FIS abort-signal alarm.
+        Sid    = "CloudWatchAlarmsDestructive"
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:DeleteAlarms",
+          "cloudwatch:UntagResource",
+        ]
+        Resource = [
+          "arn:aws:cloudwatch:${local.primary_region}:${local.account_id}:alarm:*",
+          "arn:aws:cloudwatch:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:alarm:*",
+        ]
+      },
+      {
+        # State bucket cross-account read + write. Same scope as
+        # `gh-tf-apply-workload` — terraform destroy reads + writes the
+        # per-layer state objects in the shared-account state bucket.
+        Sid    = "StateBucketCrossAccount"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketVersioning",
+        ]
+        Resource = [
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}",
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*",
+        ]
+      },
+      {
+        # State KMS — same gated-by-S3-service contract as apply-workload.
+        Sid    = "StateKmsViaS3Only"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey",
+        ]
+        Resource = "arn:aws:kms:${local.primary_region}:${local.config.accounts.shared.id}:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "s3.${local.primary_region}.amazonaws.com"
+          }
+        }
+      },
+      {
+        # IPAM remote-state read — same as apply-workload. Terraform
+        # destroy on the network layer reads `shared/ipam`'s state for
+        # IPAM pool IDs during refresh.
+        Sid    = "IpamRead"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeIpams",
+          "ec2:DescribeIpamPools",
+          "ec2:DescribeIpamScopes",
+          "ec2:GetIpamPoolAllocations",
+          "ec2:GetIpamPoolCidrs",
+        ]
+        Resource = "*"
+      },
+      {
+        # Read shapes for the teardown workflow's safety-net steps and
+        # for `terraform destroy`'s state-refresh phase. Includes:
+        #   - `aws ec2 describe-vpcs / describe-network-interfaces /
+        #     describe-security-groups / describe-instances /
+        #     wait instance-terminated` (sweep VPCs + ENIs + SGs +
+        #     orphan Karpenter EC2)
+        #   - `aws eks list-clusters / describe-cluster /
+        #     update-kubeconfig` (resolve cluster name + auth before
+        #     kubectl delete)
+        #   - K8s API auth (eks:AccessKubernetesApi) for the
+        #     finalizer-flush + Karpenter-quiesce kubectl steps
+        #   - state-refresh reads across all destroyed services
+        # Resource: "*" is acceptable here because every action listed is
+        # read-only — metadata disclosure is classified as not-secret per
+        # CLAUDE.md threat model.
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "ec2:Describe*",
+          "eks:Describe*",
+          "eks:List*",
+          "eks:AccessKubernetesApi",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "logs:Describe*",
+          "logs:List*",
+          "events:Describe*",
+          "events:List*",
+          "sqs:Get*",
+          "sqs:List*",
+          "ssm:Describe*",
+          "ssm:Get*",
+          "ssm:List*",
+          "fis:Get*",
+          "fis:List*",
+          "guardduty:Get*",
+          "guardduty:List*",
+          "guardduty:Describe*",
+          "elasticloadbalancing:Describe*",
+          "cloudwatch:Describe*",
+          "cloudwatch:Get*",
+          "cloudwatch:List*",
+          "s3:GetBucket*",
+          "s3:ListAllMyBuckets",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/staging/bootstrap/oidc-github-teardown-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-teardown-role.tf
@@ -58,7 +58,10 @@ resource "aws_iam_role" "gh_tf_teardown_workload" {
 resource "aws_iam_role_policy" "gh_tf_teardown_workload" {
   # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Describe* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update action paired with Resource:*. See ADR-029.
   # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-029. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
-  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on AWS APIs that do not support resource-level ARNs (EC2 most destructive actions, ELB, GuardDuty, tag). Every mutating action with Resource:* is service-namespace-scoped at the action prefix and gated by the trust policy `sub: environment:workload-teardown`.
+  # checkov:skip=CKV_AWS_289: IAM destructive actions (Delete*/Detach*/Remove*/DeleteServiceLinkedRole) are intentionally scoped to aegis-staging-* prefixed resources. Teardown contract is "destroy what apply created" — the prefix scope is the gate.
+  # checkov:skip=CKV_AWS_290: Service-namespace destructive wildcards (ec2:Delete*, eks:Delete*, elasticloadbalancing:Delete*) are needed because these AWS APIs do not support resource-level ARN constraints on most destructive write actions; region + project-tag conditions added where supported. Trust-policy-gated by `sub: environment:workload-teardown` plus environment required-reviewer + main-only deployment branches.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on AWS APIs that do not support resource-level ARNs (EC2 most destructive actions, ELB, GuardDuty, tag). Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
+  # checkov:skip=CKV2_AWS_40: Broad iam:Delete*/Detach*/Remove*/DeleteServiceLinkedRole on aegis-staging-* prefix scope is the deliberate teardown design. Same contract as gh-tf-apply-workload — the prefix scope is the gate, the destructive verbs are intentional.
   name = "teardown-workload-scoped"
   role = aws_iam_role.gh_tf_teardown_workload.id
 

--- a/terraform/environments/staging/bootstrap/oidc-github-workload-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-workload-role.tf
@@ -63,7 +63,10 @@ resource "aws_iam_role" "gh_tf_apply_workload" {
 resource "aws_iam_role_policy" "gh_tf_apply_workload" {
   # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Describe* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-029.
   # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-029. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
+  # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-staging-* IRSA + cluster + node + Fargate-exec roles plus matching policies). Permission-management within a fixed prefix is the apply contract for the workload-tier role.
+  # checkov:skip=CKV_AWS_290: Service-namespace wildcards (ec2:*, eks:*, elasticloadbalancing:*, fis:*, guardduty:*) are needed because these AWS APIs do not support resource-level ARN constraints on most write actions (EC2 in particular); region condition + project tag condition are added where supported. Trust-policy-gated by `sub: environment:workload-apply` plus environment required-reviewer + main-only deployment branches.
   # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on AWS APIs that do not support resource-level ARNs (EC2 most write actions, ELB, GuardDuty, tag). Every mutating action with Resource:* is service-namespace-scoped at the action prefix and gated by the trust policy `sub: environment:workload-apply`.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within aegis-staging-* prefix scope for apply-tier workload operations (creating IRSA roles for cluster components). Full IAM privileges on a fixed ARN-prefix is the deliberate apply-workload design (ADR-029 §Decision). An enumerated 20+-action whitelist would carry identical effective surface with maintenance liability.
   name = "apply-workload-scoped"
   role = aws_iam_role.gh_tf_apply_workload.id
 

--- a/terraform/environments/staging/bootstrap/oidc-github-workload-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-workload-role.tf
@@ -1,0 +1,454 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-apply-workload` — apply role for `terraform-apply-workload.yml` (ADR-029)
+# -----------------------------------------------------------------------------
+# Replaces `github-actions-terraform` for the OIDC sub claim
+# `environment:workload-apply` only. Permission character: scoped mutation
+# across workload-tier API surfaces — EC2 / VPC / EKS / ELB / IAM (workload
+# roles) / Logs / SQS / Events / KMS / SSM-read / FIS / GuardDuty / tag.
+# Baseline-tier surfaces (Org / SCP / SSO / IPAM / state-bucket /
+# Cognito / CloudFront / ACM / Route53 / ECR) live in `gh-tf-apply-baseline`.
+#
+# Trust policy is keyed on the OIDC `sub` claim
+# `environment:workload-apply` only — the other triggers
+# (`pull_request`, `ref:refs/heads/main`, `environment:workload-teardown`)
+# continue to assume their own purpose-scoped roles. See ADR-029 for the
+# full identity-by-trigger split.
+#
+# Scope: this role is `aegis-staging`-account only. It covers the union of
+# API surfaces mutated by `terraform/environments/staging/{network,
+# platform,workloads,observability,fis}` — VPC + NAT GW + flow logs (network);
+# EKS clusters + Karpenter (SQS + EventBridge) + KMS + IAM cluster/IRSA roles +
+# CloudWatch log groups + EKS access entries (platform); GuardDuty +
+# aegis-engine IRSA + Argo Rollouts (workloads); SSM PS Path-A token writes +
+# grafana-operator helm + ESO ExternalSecret manifests (observability);
+# FIS experiment template + service role + abort-signal alarm (fis).
+#
+# Multi-region (ADR-018 slot pattern, K=2): every region-scoped Sid extends
+# both `${local.primary_region}` AND the DR region (resolved inline via
+# `local.config.regions[*].role == "dr"` lookup, kept inline rather than
+# adding `local.dr_region` to staging/bootstrap config.tf — that is scope
+# creep for one consumer).
+#
+# No workflow change in this PR — `terraform-apply-workload.yml` keeps
+# assuming `github-actions-terraform` until PR-6 cuts it over to
+# `gh-tf-apply-workload` (chicken-and-egg avoidance: flipping the workflow
+# here would block this PR's own CI on a role not yet in main).
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_apply_workload" {
+  name = "gh-tf-apply-workload"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-apply"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_apply_workload" {
+  # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Describe* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-029.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-029. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on AWS APIs that do not support resource-level ARNs (EC2 most write actions, ELB, GuardDuty, tag). Every mutating action with Resource:* is service-namespace-scoped at the action prefix and gated by the trust policy `sub: environment:workload-apply`.
+  name = "apply-workload-scoped"
+  role = aws_iam_role.gh_tf_apply_workload.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # EC2 + VPC + flow logs + gateway endpoints + NAT GW + IGW + SG +
+        # NACL + route tables + ENIs + subnets + EIPs. EC2 does not
+        # support resource-level ARN authorization on most write actions
+        # (CreateVpc / CreateSubnet / CreateRouteTable / etc.); region
+        # condition is the tightest practical scope. Trust policy
+        # (`environment:workload-apply`) carries the rest.
+        Sid      = "Ec2Vpc"
+        Effect   = "Allow"
+        Action   = "ec2:*"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestedRegion" = [
+              local.primary_region,
+              [for r in local.config.regions : r.name if r.role == "dr"][0],
+            ]
+          }
+        }
+      },
+      {
+        # EKS clusters — `aegis-staging-*` matches both `aegis-staging-primary`
+        # and `aegis-staging-slave-1` (slot pattern ADR-018, K=2). Includes
+        # access entries, fargate profiles, addons, all under cluster ARN.
+        Sid    = "EksClusters"
+        Effect = "Allow"
+        Action = "eks:*"
+        Resource = [
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:cluster/aegis-staging-*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:fargateprofile/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:addon/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:access-entry/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:identityproviderconfig/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:nodegroup/aegis-staging-*/*",
+          "arn:aws:eks:${local.primary_region}:${local.account_id}:podidentityassociation/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:cluster/aegis-staging-*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:fargateprofile/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:addon/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:access-entry/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:identityproviderconfig/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:nodegroup/aegis-staging-*/*",
+          "arn:aws:eks:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:podidentityassociation/aegis-staging-*/*",
+        ]
+      },
+      {
+        # IAM mutation — scoped to workload-tier role + policy + OIDC-provider
+        # ARN patterns. Covers EKS cluster role / Fargate execution role /
+        # Karpenter node + controller / aws-load-balancer-controller IRSA /
+        # external-secrets IRSA / aegis-engine IRSA / FIS service role —
+        # all named `aegis-staging-*` (cluster-scoped name prefix +
+        # role suffix). Workload-tier per-cluster OIDC providers are
+        # also included since `aws_iam_openid_connect_provider.cluster`
+        # is created in `staging/platform`. Instance profiles created
+        # by the Karpenter controller live under `aegis-staging-*`.
+        Sid    = "IamWorkloadRoles"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-staging-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-staging-*",
+          "arn:aws:iam::${local.account_id}:instance-profile/aegis-staging-*",
+          "arn:aws:iam::${local.account_id}:oidc-provider/oidc.eks.${local.primary_region}.amazonaws.com/id/*",
+          "arn:aws:iam::${local.account_id}:oidc-provider/oidc.eks.${[for r in local.config.regions : r.name if r.role == "dr"][0]}.amazonaws.com/id/*",
+        ]
+      },
+      {
+        # IAM service-linked role creation — gated to the SLRs the
+        # workload-apply path legitimately creates. `eks.amazonaws.com`
+        # and `spot.amazonaws.com` are auto-recreated by AWS during EKS
+        # cluster + Karpenter spot fleet provisioning (ADR-029 OQ-2).
+        # `karpenter.k8s.aws` is reserved by the Karpenter v1 controller.
+        # `elasticloadbalancing.amazonaws.com` is created on first ALB
+        # provisioning by the load-balancer controller. `globalaccelerator`
+        # is included defensively per ADR-029 §A.3 — not used in current
+        # workload-tier code, but reserved for future edge-acceleration work.
+        Sid      = "IamSlrCreate"
+        Effect   = "Allow"
+        Action   = "iam:CreateServiceLinkedRole"
+        Resource = "arn:aws:iam::${local.account_id}:role/aws-service-role/*"
+        Condition = {
+          StringEquals = {
+            "iam:AWSServiceName" = [
+              "eks.amazonaws.com",
+              "spot.amazonaws.com",
+              "karpenter.k8s.aws",
+              "elasticloadbalancing.amazonaws.com",
+              "globalaccelerator.amazonaws.com",
+            ]
+          }
+        }
+      },
+      {
+        # ELB v1 + v2 — ALB / NLB lifecycle is owned by the
+        # aws-load-balancer-controller at runtime, not by Terraform. ELB
+        # API does not support resource-level authorization on most
+        # mutation actions; region condition is the tightest practical scope.
+        Sid      = "Elb"
+        Effect   = "Allow"
+        Action   = "elasticloadbalancing:*"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestedRegion" = [
+              local.primary_region,
+              [for r in local.config.regions : r.name if r.role == "dr"][0],
+            ]
+          }
+        }
+      },
+      {
+        # CloudWatch Logs — EKS cluster log groups (`/aws/eks/<cluster>/cluster`),
+        # plus VPC flow logs and any future workload-tier groups, all
+        # tagged Project=landing-zone-lab. Resource-level ARN scoping is
+        # supported on log groups; pattern matches `/aws/eks/aegis-staging-*`.
+        # `*` for VPC flow log groups is constrained by region condition.
+        Sid    = "Logs"
+        Effect = "Allow"
+        Action = "logs:*"
+        Resource = [
+          "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/eks/aegis-staging-*",
+          "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/eks/aegis-staging-*:*",
+          "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/vpc/flow-logs/aegis-staging-*",
+          "arn:aws:logs:${local.primary_region}:${local.account_id}:log-group:/aws/vpc/flow-logs/aegis-staging-*:*",
+          "arn:aws:logs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:log-group:/aws/eks/aegis-staging-*",
+          "arn:aws:logs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:log-group:/aws/eks/aegis-staging-*:*",
+          "arn:aws:logs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:log-group:/aws/vpc/flow-logs/aegis-staging-*",
+          "arn:aws:logs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:log-group:/aws/vpc/flow-logs/aegis-staging-*:*",
+        ]
+      },
+      {
+        # SQS — Karpenter interruption queue
+        # (`<cluster>-karpenter-interruption`). Cluster name prefix
+        # `aegis-staging-*` covers both primary + slave-1.
+        Sid    = "Sqs"
+        Effect = "Allow"
+        Action = "sqs:*"
+        Resource = [
+          "arn:aws:sqs:${local.primary_region}:${local.account_id}:aegis-staging-*",
+          "arn:aws:sqs:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:aegis-staging-*",
+        ]
+      },
+      {
+        # EventBridge — Karpenter rules
+        # (`<cluster>-karpenter-spot-interruption`,
+        # `<cluster>-karpenter-scheduled-change`,
+        # `<cluster>-karpenter-instance-state-change`,
+        # `<cluster>-karpenter-rebalance`). Same `aegis-staging-*` cluster
+        # prefix scoping. Includes targets (rules carry sub-ARNs).
+        Sid    = "Events"
+        Effect = "Allow"
+        Action = "events:*"
+        Resource = [
+          "arn:aws:events:${local.primary_region}:${local.account_id}:rule/aegis-staging-*",
+          "arn:aws:events:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:rule/aegis-staging-*",
+        ]
+      },
+      {
+        # KMS — workload-tier keys for EKS secrets envelope encryption
+        # (`<cluster>-eks-secrets`) and CloudWatch Logs encryption
+        # (`<cluster>-eks-logs`). Aliases follow `alias/aegis-staging-*`.
+        # ViaService condition is intentionally NOT applied here — the
+        # apply path performs raw `kms:CreateKey` / `kms:CreateAlias` /
+        # `kms:PutKeyPolicy` calls that are not service-mediated.
+        Sid    = "Kms"
+        Effect = "Allow"
+        Action = "kms:*"
+        Resource = [
+          "arn:aws:kms:${local.primary_region}:${local.account_id}:key/*",
+          "arn:aws:kms:${local.primary_region}:${local.account_id}:alias/aegis-staging-*",
+          "arn:aws:kms:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:key/*",
+          "arn:aws:kms:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:alias/aegis-staging-*",
+        ]
+      },
+      {
+        # SSM Parameter Store — read-only on `/aegis/staging/*`. The
+        # observability layer reads the Path-B SaaS credentials
+        # (qdrant-cloud, grafana-cloud bootstrap) plus reads-back the
+        # Path-A tokens it writes. Path-A writes
+        # (`alloy-token`, `grafana-operator-token`) live under the
+        # `SsmAegisStagingPathAWrite` Sid below — narrower action set.
+        # No write here ensures baseline-tier credentials cannot be
+        # mutated from the workload trigger (ADR-028 isolation).
+        Sid    = "SsmRead"
+        Effect = "Allow"
+        Action = [
+          "ssm:Describe*",
+          "ssm:Get*",
+          "ssm:List*",
+        ]
+        Resource = [
+          "arn:aws:ssm:${local.primary_region}:${local.account_id}:parameter/aegis/staging/*",
+          "arn:aws:ssm:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:parameter/aegis/staging/*",
+        ]
+      },
+      {
+        # SSM Parameter Store — Path-A TF-generated token writes. Two
+        # specific parameters owned by `staging/observability/tokens.tf`:
+        # `alloy-token` and `grafana-operator-token` (downstream tokens
+        # rotated by the bootstrap-token apply). These are TF-managed
+        # SecureString parameters; their lifecycle (Put / Tag / Delete)
+        # is the workload-apply path's responsibility, not baseline.
+        Sid    = "SsmAegisStagingPathAWrite"
+        Effect = "Allow"
+        Action = [
+          "ssm:PutParameter",
+          "ssm:DeleteParameter",
+          "ssm:DeleteParameters",
+          "ssm:AddTagsToResource",
+          "ssm:RemoveTagsFromResource",
+          "ssm:LabelParameterVersion",
+        ]
+        Resource = [
+          "arn:aws:ssm:${local.primary_region}:${local.account_id}:parameter/aegis/staging/grafana-cloud/alloy-token",
+          "arn:aws:ssm:${local.primary_region}:${local.account_id}:parameter/aegis/staging/grafana-cloud/grafana-operator-token",
+        ]
+      },
+      {
+        # FIS — DR drill experiment template (ADR-020). Lives in primary
+        # region only by design; the DR drill targets primary EKS nodes.
+        # Resource-level ARN scoping is supported on
+        # experiment-template ARNs.
+        Sid    = "Fis"
+        Effect = "Allow"
+        Action = "fis:*"
+        Resource = [
+          "arn:aws:fis:${local.primary_region}:${local.account_id}:experiment-template/*",
+          "arn:aws:fis:${local.primary_region}:${local.account_id}:experiment/*",
+          "arn:aws:fis:${local.primary_region}:${local.account_id}:action/*",
+          "arn:aws:fis:${local.primary_region}:${local.account_id}:target-account-configuration/*",
+        ]
+      },
+      {
+        # GuardDuty — staging detector + EKS audit-logs / runtime feature
+        # toggles. GuardDuty resource-level authorization is partial
+        # (detector-id ARN supported on some actions, not on Create).
+        # Region condition is the tightest practical scope.
+        Sid      = "GuardDuty"
+        Effect   = "Allow"
+        Action   = "guardduty:*"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:RequestedRegion" = [
+              local.primary_region,
+              [for r in local.config.regions : r.name if r.role == "dr"][0],
+            ]
+          }
+        }
+      },
+      {
+        # CloudWatch metric alarms — FIS abort-signal alarm. Scoped
+        # by region; no resource-level prefix scoping (alarm ARN
+        # includes a customer-chosen name only).
+        Sid    = "CloudWatchAlarms"
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:DescribeAlarmsForMetric",
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:ListMetrics",
+          "cloudwatch:ListTagsForResource",
+          "cloudwatch:PutMetricAlarm",
+          "cloudwatch:DeleteAlarms",
+          "cloudwatch:TagResource",
+          "cloudwatch:UntagResource",
+        ]
+        Resource = [
+          "arn:aws:cloudwatch:${local.primary_region}:${local.account_id}:alarm:*",
+          "arn:aws:cloudwatch:${[for r in local.config.regions : r.name if r.role == "dr"][0]}:${local.account_id}:alarm:*",
+        ]
+      },
+      {
+        # Universal tagging — no service supports `tag:*` with a
+        # resource-level ARN; service-namespace scoping is the tightest
+        # contract.
+        Sid      = "TagApi"
+        Effect   = "Allow"
+        Action   = "tag:*"
+        Resource = "*"
+      },
+      {
+        # State bucket cross-account read + write. State bucket lives in
+        # the shared account; this account's per-layer state objects
+        # (network / platform / workloads / observability / fis) are
+        # read/written via cross-account bucket policy.
+        Sid    = "StateBucketCrossAccount"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketVersioning",
+        ]
+        Resource = [
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}",
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*",
+        ]
+      },
+      {
+        # State KMS — key lives in shared. Gated to S3 service usage so
+        # the role can decrypt state objects but not invoke KMS directly
+        # for other purposes against the shared-account key.
+        Sid    = "StateKmsViaS3Only"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey",
+        ]
+        Resource = "arn:aws:kms:${local.primary_region}:${local.config.accounts.shared.id}:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "s3.${local.primary_region}.amazonaws.com"
+          }
+        }
+      },
+      {
+        # IPAM remote-state read — the network layer pulls IPAM pool IDs
+        # from `shared/ipam` via `terraform_remote_state`. The state
+        # object access is covered by `StateBucketCrossAccount` above;
+        # this Sid covers the read-only IPAM API calls Terraform performs
+        # during refresh of the consuming layer.
+        Sid    = "IpamRead"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeIpams",
+          "ec2:DescribeIpamPools",
+          "ec2:DescribeIpamScopes",
+          "ec2:GetIpamPoolAllocations",
+          "ec2:GetIpamPoolCidrs",
+        ]
+        Resource = "*"
+      },
+      {
+        # Read shapes for `terraform plan` after apply (refresh + drift
+        # detection) plus the helm/kubernetes provider's state-refresh
+        # API calls. Resource: "*" is acceptable here because every
+        # action listed is read-only — metadata disclosure is classified
+        # as not-secret per CLAUDE.md threat model.
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "ec2:Describe*",
+          "eks:Describe*",
+          "eks:List*",
+          "eks:AccessKubernetesApi",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "logs:Describe*",
+          "logs:List*",
+          "events:Describe*",
+          "events:List*",
+          "sqs:Get*",
+          "sqs:List*",
+          "fis:Get*",
+          "fis:List*",
+          "guardduty:Get*",
+          "guardduty:List*",
+          "guardduty:Describe*",
+          "elasticloadbalancing:Describe*",
+          "cloudwatch:Describe*",
+          "cloudwatch:Get*",
+          "cloudwatch:List*",
+          "s3:GetBucket*",
+          "s3:ListAllMyBuckets",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}


### PR DESCRIPTION
## Summary

PR-5 of the IAM scope-down rollout per [ADR-029](docs/decisions/029-iam-permission-scope-down.md). Creates two new purpose-scoped IAM roles in `aegis-staging`'s `bootstrap` layer, trust policies pinned by OIDC `sub` claim:

| Role | Trust `sub` | Permission character |
|---|---|---|
| `gh-tf-apply-workload` | `environment:workload-apply` | CRUD-shape on workload-tier API surface — EC2/VPC, EKS, workload-tier IAM, ELB, Logs, SQS, Events, KMS, SSM read + Path-A write, FIS, GuardDuty, CloudWatch alarms, IPAM read |
| `gh-tf-teardown-workload` | `environment:workload-teardown` | Same SERVICE surface, action list narrowed to destructive verbs (`Delete*` / `Detach*` / `Disassociate*` / `TerminateInstances` / `ScheduleKeyDeletion` / `StopExperiment` / `PurgeQueue`) plus the safety-net `describe` / `get` / `list` shapes the teardown workflow invokes |

**Trust-claim differentiation**: a leaked apply-tier token cannot invoke destructive verbs, and a leaked teardown-tier token cannot create new resources. Siblings on the same IAM tree, neither subset of the other.

**No workflow change in this PR.** `terraform-apply-workload.yml` and `terraform-teardown-workload.yml` continue to assume `github-actions-terraform` until PR-6 cuts both over (chicken-and-egg avoidance — flipping the workflow here would block this PR's own CI on roles not yet in main).

## Permission character

**`gh-tf-apply-workload`** Sids (apply tier):

- `Ec2Vpc` (`ec2:*`, region-conditioned) — VPC / NAT GW / IGW / SG / NACL / route tables / ENIs / subnets / EIPs / flow logs / gateway endpoints
- `EksClusters` — cluster + fargate profile + addon + access-entry + nodegroup + identity-provider-config + pod-identity-association ARNs, scoped to `aegis-staging-*` (matches `aegis-staging-primary` + `aegis-staging-slave-1` per slot pattern, ADR-018 K=2)
- `IamWorkloadRoles` — workload-tier role + policy + instance-profile + per-cluster OIDC-provider ARN patterns (`aegis-staging-*`)
- `IamSlrCreate` — gated to `eks` / `spot` / `karpenter.k8s.aws` / `elasticloadbalancing` / `globalaccelerator` (ADR-029 OQ-2 + §A.3)
- `Elb`, `Logs`, `Sqs`, `Events`, `Kms` — region-scoped, ARN-scoped where supported (`aegis-staging-*` cluster prefix on Logs / SQS / Events; `aegis-staging-*` alias prefix on KMS)
- `SsmRead` (read-only) on `/aegis/staging/*` — Path-B SaaS credentials are baseline-tier per ADR-028
- `SsmAegisStagingPathAWrite` — narrow write on the two TF-generated downstream tokens (`alloy-token`, `grafana-operator-token`)
- `Fis`, `GuardDuty`, `CloudWatchAlarms` — workload-tier observability + DR drill surface
- `TagApi`, `IpamRead`, `StateBucketCrossAccount`, `StateKmsViaS3Only`, `ReadOnlyAwsApiSurface`

**`gh-tf-teardown-workload`** Sids (teardown tier):

- `Ec2Destructive` — `Delete*` / `Detach*` / `Disassociate*` / `TerminateInstances` / `Revoke*` / `Release*` (covers the workflow's `Sweep orphan EKS ENIs + security groups` and `Sweep orphan Karpenter-provisioned EC2 instances` steps)
- `EksDestructive`, `IamDestructive`, `ElbDestructive`, `LogsDestructive`, `SqsDestructive`, `EventsDestructive`, `KmsDestructive`, `SsmDestructive`, `FisDestructive`, `GuardDutyDestructive`, `CloudWatchAlarmsDestructive`
- `ReadOnlyAwsApiSurface` — extended to include `eks:AccessKubernetesApi` for the kubectl finalizer-flush + Karpenter-quiesce steps
- Plus `StateBucketCrossAccount`, `StateKmsViaS3Only`, `IpamRead` (mirror of apply-workload)

## Multi-region (ADR-018)

Every region-scoped Sid extends both `${local.primary_region}` AND the DR region. The DR region is resolved inline via `[for r in local.config.regions : r.name if r.role == "dr"][0]` rather than introducing a `local.dr_region` to `staging/bootstrap/config.tf` — that would be scope creep for the one consumer (per ADR-029 PR-5 task framing). Cluster ARN pattern `aegis-staging-*` matches both `aegis-staging-primary` and `aegis-staging-slave-1` (slot pattern, K=2).

## Files

- `terraform/environments/staging/bootstrap/oidc-github-workload-role.tf` (454 lines)
- `terraform/environments/staging/bootstrap/oidc-github-teardown-role.tf` (412 lines)

Inline Checkov skip directives (CKV_AWS_287/288/355) on the `ReadOnlyAwsApiSurface` Sid and on AWS APIs that do not support resource-level ARNs on writes (EC2 most write actions, ELB, GuardDuty, tag) — same pattern as PR-1 and PR-3.

## Change-review-discipline checklist

- **Blast radius**: 2 new IAM roles in `aegis-staging` only. Each role can mutate only workload-tier resources scoped to project-prefixed ARN patterns (`aegis-staging-*`) and project-prefixed region condition. Cannot mutate baseline-tier (Org / SCP / SSO / IPAM-mutate / Cognito / CloudFront / Route53 / ACM) — that lives in `gh-tf-apply-baseline` (PR-3). Cannot read or write Path-B SaaS credentials. Existing `github-actions-terraform` is unchanged.
- **Dependency assumptions**: shared-account state KMS key already permits any organization principal via `aws:PrincipalOrgID`; state bucket cross-account policy already in place. The `aws_iam_openid_connect_provider.github` resource already exists in `staging/bootstrap` and is referenced by ARN. No upstream policy change needed.
- **Deprecation status**: N/A — net-new resources. AWS provider 5.x supports all action prefixes used. Karpenter v1 is at GA on the cluster (action set verified against canonical Karpenter v1 IAM policy).
- **Rollback plan**: single-PR revert removes the 2 roles. No workflow depends on them yet — `terraform-apply-workload.yml` and `terraform-teardown-workload.yml` still target `github-actions-terraform`. PR-6 (cutover) is the first step that requires both roles to be in main.
- **2 AM readability**: each `.tf` file is single-account-explicit. Sid names are self-documenting (`Ec2Vpc`, `EksClusters`, `IamWorkloadRoles`, `Ec2Destructive`, `EksDestructive`, ...). Per-Sid comments explain scope and why `Resource: "*"` is used where present (always either inventory-style read OR AWS-API-does-not-support-ARN-scoping). All region tokens flow from `local.config.regions[*]`; literal region strings are absent.

## Test plan

- [ ] All CI Plan jobs green for `staging/bootstrap` and unaffected layers (no diff expected outside bootstrap).
- [ ] Plan output for `staging/bootstrap` shows: `aws_iam_role.gh_tf_apply_workload` + `aws_iam_role_policy.gh_tf_apply_workload` + `aws_iam_role.gh_tf_teardown_workload` + `aws_iam_role_policy.gh_tf_teardown_workload` to add. No other resource diffs.
- [ ] Checkov passes (skip directives in place).
- [ ] `terraform fmt -check` passes on both new files (verified locally pre-push).

## Related

- [ADR-029](docs/decisions/029-iam-permission-scope-down.md) — full design rationale, sibling rollout step
- PR-1 (#171) — `gh-tf-plan` (sibling rollout step)
- PR-3 (#172) — `gh-tf-apply-baseline` (sibling rollout step; this PR mirrors its structure)
- aegis-core#112 — Layer 0 cross-repo (closed 2026-05-03)
- ldz#170 — Layer 0 paired tracker (closed 2026-05-03)

## Follow-up

- PR-6: cutover `terraform-apply-workload.yml` `role-to-assume` to `gh-tf-apply-workload` AND `terraform-teardown-workload.yml` to `gh-tf-teardown-workload` (depends on this merging)
- PR-7: cleanup — drop `AdministratorAccess` from `github-actions-terraform` and delete the legacy resource in all three accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)