### PR TITLE
fix(iam): split account-alias actions into own Sid (AWS rejects ARN path)

### DIFF
--- a/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
@@ -63,10 +63,11 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
     Statement = [
       {
         # IAM mutation — scoped to project-prefixed resources plus the
-        # OIDC provider and account alias. `aegis-*` covers Terraform-
-        # controlled roles; `github-actions-*` and `gh-tf-*` cover the
-        # CI roles managed by this very layer (including this role's own
-        # in-place updates).
+        # OIDC provider. `aegis-*` covers Terraform-controlled roles;
+        # `github-actions-*` and `gh-tf-*` cover the CI roles managed
+        # by this very layer (including this role's own in-place updates).
+        # Account alias management is a separate Sid below because AWS IAM
+        # does not accept resource-level ARNs on the alias actions.
         Sid    = "IamScoped"
         Effect = "Allow"
         Action = "iam:*"
@@ -76,8 +77,23 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
           "arn:aws:iam::${local.account_id}:role/gh-tf-*",
           "arn:aws:iam::${local.account_id}:policy/aegis-*",
           "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com",
-          "arn:aws:iam::${local.account_id}:account-alias/*",
         ]
+      },
+      {
+        # Account alias — account-level operations. AWS IAM rejects any
+        # resource-level ARN on these actions ("account-alias/*" is NOT
+        # in the IAM-allowed-resource-path list); Resource: "*" is the
+        # only accepted shape. The trust policy `sub: ref:refs/heads/main`
+        # plus branch protection on main is the gate; the action set is
+        # narrowed to alias-only verbs (no other iam:* leaks through).
+        Sid    = "AccountAliasManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateAccountAlias",
+          "iam:DeleteAccountAlias",
+          "iam:ListAccountAliases",
+        ]
+        Resource = "*"
       },
       {
         # IAM service-linked role creation — gated to the two SLRs the

--- a/terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf
@@ -64,10 +64,11 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
     Statement = [
       {
         # IAM mutation — scoped to project-prefixed resources plus the
-        # OIDC provider and account alias. `aegis-*` covers Terraform-
-        # controlled roles; `github-actions-*` and `gh-tf-*` cover the
-        # CI roles managed by this very layer (including this role's own
-        # in-place updates).
+        # OIDC provider. `aegis-*` covers Terraform-controlled roles;
+        # `github-actions-*` and `gh-tf-*` cover the CI roles managed
+        # by this very layer (including this role's own in-place updates).
+        # Account alias management is a separate Sid below because AWS IAM
+        # does not accept resource-level ARNs on the alias actions.
         Sid    = "IamScoped"
         Effect = "Allow"
         Action = "iam:*"
@@ -77,8 +78,23 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
           "arn:aws:iam::${local.account_id}:role/gh-tf-*",
           "arn:aws:iam::${local.account_id}:policy/aegis-*",
           "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com",
-          "arn:aws:iam::${local.account_id}:account-alias/*",
         ]
+      },
+      {
+        # Account alias — account-level operations. AWS IAM rejects any
+        # resource-level ARN on these actions ("account-alias/*" is NOT
+        # in the IAM-allowed-resource-path list); Resource: "*" is the
+        # only accepted shape. The trust policy `sub: ref:refs/heads/main`
+        # plus branch protection on main is the gate; the action set is
+        # narrowed to alias-only verbs (no other iam:* leaks through).
+        Sid    = "AccountAliasManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateAccountAlias",
+          "iam:DeleteAccountAlias",
+          "iam:ListAccountAliases",
+        ]
+        Resource = "*"
       },
       {
         # IAM service-linked role creation — gated to the two SLRs the

--- a/terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf
@@ -67,9 +67,11 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
     Statement = [
       {
         # IAM mutation — scoped to project-prefixed resources plus the
-        # OIDC providers and account alias. Covers aegis-* roles,
-        # github-actions-* (terraform CI + aegis-core CI roles), and
-        # gh-tf-* (this very layer's role family — supports in-place updates).
+        # OIDC provider. Covers aegis-* roles, github-actions-* (terraform CI
+        # + aegis-core CI roles), and gh-tf-* (this very layer's role family
+        # — supports in-place updates). Account alias management is a
+        # separate Sid below because AWS IAM does not accept resource-level
+        # ARNs on the alias actions.
         Sid    = "IamScoped"
         Effect = "Allow"
         Action = "iam:*"
@@ -79,8 +81,23 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
           "arn:aws:iam::${local.account_id}:role/gh-tf-*",
           "arn:aws:iam::${local.account_id}:policy/aegis-*",
           "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com",
-          "arn:aws:iam::${local.account_id}:account-alias/*",
         ]
+      },
+      {
+        # Account alias — account-level operations. AWS IAM rejects any
+        # resource-level ARN on these actions ("account-alias/*" is NOT
+        # in the IAM-allowed-resource-path list); Resource: "*" is the
+        # only accepted shape. The trust policy `sub: ref:refs/heads/main`
+        # plus branch protection on main is the gate; the action set is
+        # narrowed to alias-only verbs (no other iam:* leaks through).
+        Sid    = "AccountAliasManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateAccountAlias",
+          "iam:DeleteAccountAlias",
+          "iam:ListAccountAliases",
+        ]
+        Resource = "*"
       },
       {
         # IAM service-linked role creation — gated to the SLRs the apply


### PR DESCRIPTION
## Summary

Hotfix for the post-merge apply-baseline failure of [PR #172](https://github.com/BinHsu/aegis-aws-landing-zone/pull/172) (gh-tf-apply-baseline role × 3 accounts).

3 of 4 post-merge apply-baseline runs failed with:
```
Error: putting IAM Role (gh-tf-apply-baseline) Policy (apply-baseline-scoped):
operation error IAM: PutRolePolicy, https response error StatusCode: 400,
MalformedPolicyDocument: IAM resource path must either be "*", root, or start
with user/, federated-user/, role/, group/, instance-profile/, mfa/,
server-certificate/, policy/, sms-mfa/, saml-provider/, oidc-provider/,
report/, access-report/.
```

`account-alias` is not in AWS IAM's allowed-resource-path list. Account-alias operations are account-level — AWS only accepts `Resource: "*"` for `iam:CreateAccountAlias` / `iam:DeleteAccountAlias` / `iam:ListAccountAliases`.

## Files changed

- `terraform/environments/management/bootstrap/oidc-github-baseline-role.tf`
- `terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf`
- `terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf`

All 3 files: remove the broken `account-alias/*` ARN from `IamScoped` Sid + add new `AccountAliasManagement` Sid with the 3 alias-specific actions and `Resource: "*"`. Comments document why the split exists.

## Why split rather than just remove

Removing alias actions entirely would break any future `terraform apply` that touches `aws_iam_account_alias.this`. The alias resources already exist in state (they were imported during initial bootstrap), so plan = no-op today, but if a forker re-applies into a fresh account or someone needs to update the alias, the role must be able to call the alias actions.

The split keeps the discipline tight:
- `iam:*` stays scoped by ARN prefix (`aegis-*`, `github-actions-*`, `gh-tf-*`, `policy/aegis-*`, `oidc-provider/...`).
- Account-alias actions are explicitly enumerated — no other action with `Resource: "*"` is introduced.

## Change-review-discipline checklist

- **Blast radius**: 3 IAM role-policy updates across 3 accounts. Existing roles get their inline policy rewritten with the same effective surface for non-alias actions plus alias-specific actions added. No new permission grant beyond what was originally intended in PR #172.
- **Dependency assumptions**: AWS IAM API requires `Resource: "*"` on alias actions — verified against [AWS IAM API reference](https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateAccountAlias.html) which lists no resource-level support.
- **Deprecation status**: N/A — bug fix.
- **Rollback plan**: revert this PR. The `gh-tf-apply-baseline` role would lose its inline policy entirely (because PR #172's PutRolePolicy never succeeded → no policy attached today); rollback would attempt to re-add the broken policy and fail again. **In practice, do not rollback — fix forward.**
- **2 AM readability**: each Sid has a clear name and inline comment explaining why it's split out.

## Test plan

- [ ] CI Plan jobs green for all 3 baseline matrix entries.
- [ ] Plan output shows: 3 × `aws_iam_role_policy.gh_tf_apply_baseline` to update (in-place, replace policy JSON).
- [ ] No other resource diffs.
- [ ] Post-merge: apply-baseline succeeds and creates the `gh-tf-apply-baseline` role policy in mgmt + shared + staging.
- [ ] Post-merge: any previously-locked layer (staging/auth, staging/edge) re-applies cleanly (lock contention from the stuck runs is now released).

## Related

- PR #172 (the broken ship). PR-3 of ADR-029.
- ADR-029 — design rationale for the role split.
- AWS IAM API reference — `Resource: "*"` requirement on alias actions is documented but easy to miss because the resource-arn-path syntax for account-alias is rejected silently at PolicyValidation, not surfaced earlier in the development path.