### PR TITLE
feat(iam): cutover terraform-apply-baseline.yml to gh-tf-apply-baseline (ADR-029 PR-4)

### DIFF
--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -165,7 +165,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/gh-tf-apply-baseline
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4


### PR DESCRIPTION
## Summary

PR-4 of the IAM scope-down rollout. Switches `terraform-apply-baseline.yml`'s `role-to-assume` from `github-actions-terraform` (Admin) to `gh-tf-apply-baseline` (scoped to baseline-tier API surface).

## Files changed

- `.github/workflows/terraform-apply-baseline.yml` — single line change (matrix-based; affects all 8 baseline-tier layers across 3 accounts)

## Change-review-discipline checklist

- **Blast radius**: only affects `push: main` event. Existing `github-actions-terraform` continues to serve apply-workload + teardown-workload until PR-6 lands.
- **Dependency assumptions**: `gh-tf-apply-baseline` exists in mgmt + shared + staging (verified by sha=27eb246 apply success). Trust policy is keyed on `sub: ref:refs/heads/main` only — matches `push: main` events.
- **Deprecation status**: N/A.
- **Rollback plan**: revert this PR. Legacy role is still in main (cleanup in PR-7).
- **2 AM readability**: 1-line change.

## Test plan

- [ ] On merge: apply-baseline workflow runs with new role, applies the workflow file diff (no TF state change for the workflow itself, but the workflow now uses new role going forward).
- [ ] Subsequent baseline applies (any future PR touching baseline-tier .tf) run via scoped role and succeed.

## Related

- ADR-029 — design rationale
- PR #172 — created `gh-tf-apply-baseline`
- PR #175 — policy fix (account-alias)