### PR TITLE
feat(iam): cutover apply-workload + teardown workflows (ADR-029 PR-6)

### DIFF
--- a/.github/workflows/terraform-apply-workload.yml
+++ b/.github/workflows/terraform-apply-workload.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-apply-workload
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4
@@ -123,7 +123,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-apply-workload
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4
@@ -179,7 +179,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-apply-workload
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4
@@ -240,7 +240,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-apply-workload
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4

--- a/.github/workflows/terraform-teardown-workload.yml
+++ b/.github/workflows/terraform-teardown-workload.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-teardown-workload
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4
@@ -180,7 +180,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-teardown-workload
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4
@@ -236,7 +236,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-teardown-workload
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4
@@ -362,7 +362,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/github-actions-terraform
+          role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-teardown-workload
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@v4


### PR DESCRIPTION
## Summary

PR-6 of the IAM scope-down rollout. Switches the two `workflow_dispatch` workload workflows to their purpose-scoped roles:

- `terraform-apply-workload.yml` → `gh-tf-apply-workload` (3 `role-to-assume` lines)
- `terraform-teardown-workload.yml` → `gh-tf-teardown-workload` (3 `role-to-assume` lines)

After this merges, every `workflow_dispatch` for workload apply or teardown assumes a role narrowed to its respective action surface — no more Admin on cost-incurring layers.

## Files changed

- `.github/workflows/terraform-apply-workload.yml` — 3-line change
- `.github/workflows/terraform-teardown-workload.yml` — 3-line change

## Change-review-discipline checklist

- **Blast radius**: only affects `workflow_dispatch` events with environments `workload-apply` / `workload-teardown`. The required-reviewer + main-only deployment branch policies on those environments still apply on top of the role narrowing.
- **Dependency assumptions**: `gh-tf-apply-workload` and `gh-tf-teardown-workload` exist in staging (verified by sha=27eb246 apply success). Trust policies are keyed on `sub: environment:workload-apply` / `environment:workload-teardown` only.
- **Deprecation status**: N/A.
- **Rollback plan**: revert this PR. Legacy role still in main (cleanup in PR-7).
- **2 AM readability**: 6 identical-pattern line changes across 2 files.

## Test plan

- [ ] On merge: workflow files updated. Next `gh workflow run terraform-apply-workload.yml` will use the new role.
- [ ] First real workload-apply after merge: verify all 3 stages (network/platform/workloads) plan + apply via `gh-tf-apply-workload`. Expect no AccessDenied — if any layer hits one, the apply-workload policy is missing a service surface (see ADR-029 Appendix A.3 for the design).
- [ ] First real workload-teardown after merge: verify all stages run via `gh-tf-teardown-workload`. Expect no AccessDenied on Delete* / Detach* / etc. — workflow safety-net steps' Describe* calls covered by the role's read-shape Sids.

## Bundling rationale (vs splitting into PR-6a / PR-6b)

Both workflows are environment-gated against the `workload-apply` / `workload-teardown` environments respectively, both target the same `aegis-staging` account, both share the same trust-policy-keying-by-environment pattern, and both apply zero TF state changes (workflow file only). Single PR is cleaner than two stacked PRs that would land in lockstep anyway.

## Related

- ADR-029 — design rationale
- PR #173 — created `gh-tf-apply-workload` + `gh-tf-teardown-workload`
- PR #175 — apply-baseline policy convergence