### PR TITLE
fix(iam): align mgmt apply-baseline sso prefix (code <-> AWS state alignment)

### DIFF
--- a/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
   # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Describe* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-029.
   # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-029. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
   # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-*/github-actions-*/gh-tf-*) plus the OIDC provider and account alias — see Sid IamScoped Resource list. The role is the apply-tier identity for `terraform-apply-baseline.yml` and must be able to manage the project's own IAM resources. Permission-management within a fixed prefix is the apply contract, not a misuse.
-  # checkov:skip=CKV_AWS_290: Service-namespace wildcards (organizations:*, sso-admin:*, identitystore:*) are needed because these AWS APIs do not support resource-level ARN constraints on most write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
+  # checkov:skip=CKV_AWS_290: Service-namespace wildcards (organizations:*, sso:*, identitystore:*) are needed because these AWS APIs do not support resource-level ARN constraints on most write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
   # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on AWS APIs without resource-level ARN support. Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
   # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within the aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations (creating IRSA roles, OIDC providers, account aliases). Full IAM privileges on a fixed ARN-prefix scope is a deliberate design — an enumerated whitelist of iam:CreateRole/UpdateRole/DeleteRole/...x20+ would be a maintenance liability with the same effective surface. ADR-029 §Decision describes the apply-baseline scope.
   name = "apply-baseline-scoped"
@@ -130,7 +130,7 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
         Sid    = "SsoAndIdentityStoreFull"
         Effect = "Allow"
         Action = [
-          "sso-admin:*",
+          "sso:*",
           "identitystore:*",
         ]
         Resource = "*"
@@ -210,9 +210,9 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
           "kms:GetKeyPolicy",
           "organizations:Describe*",
           "organizations:List*",
-          "sso-admin:Describe*",
-          "sso-admin:List*",
-          "sso-admin:Get*",
+          "sso:Describe*",
+          "sso:List*",
+          "sso:Get*",
           "identitystore:Describe*",
           "identitystore:List*",
           "tag:Get*",


### PR DESCRIPTION
## Summary

Code-side alignment for a break-glass operation done earlier this session.

`gh-tf-apply-baseline` role in `aegis-management` already has the fixed policy in AWS (set via direct `aws iam put-role-policy` after deny lift + SCP detach). This PR brings the .tf source of truth in line so a future TF apply does not regress to `sso-admin:*` (which AWS rejects at refresh time).

## Why two prefixes confused

`sso-admin:` is the AWS CLI verb namespace (`aws sso-admin list-instances`).
`sso:` is the IAM action prefix.

These are different. AWS docs UI sometimes uses `sso-admin` for display but the IAM authorization checks against `sso:`. The legacy `github-actions-terraform` Admin policy used `*:*` so the bug was masked; once we cut over to scoped roles in PR #177, the bug surfaced.

Same fix shape was applied to all 3 plan-role policies via PR #177's later commits. This PR is the apply-tier counterpart, only for the **mgmt** baseline-role variant (shared + staging baseline-role do not have SSO/identitystore Sids — those services live in mgmt only).

## Files changed

- `terraform/environments/management/bootstrap/oidc-github-baseline-role.tf` — 5 line changes (`sso-admin:*` → `sso:*` in mutation Sid, `sso-admin:Describe*/List*/Get*` → `sso:*` in read Sid, plus the Checkov skip directive comment)

## Plan expectation

`terraform plan` for management/bootstrap should show:

- 1 in-place update on `aws_iam_role_policy.gh_tf_apply_baseline` — JSON-string-equal to current AWS state because of the break-glass put. `terraform refresh` reads what's there now (sso:) and the new code says (sso:), so plan sees no semantic diff. The on-disk state may show a JSON ordering / formatting diff that terraform tries to normalize.

If plan shows zero changes, that's expected (refresh-then-encode produces the canonical form).

## Change-review checklist

- **Blast radius**: 1 IAM role-policy update on 1 account (mgmt). No new permissions; this corrects a prefix from a non-existent namespace (`sso-admin:`) to the IAM-recognized one (`sso:`).
- **Dependency assumptions**: AWS IAM authorization recognizes `sso:*` as the prefix for IAM Identity Center actions. Verified empirically when PR #177's plan jobs went green after the same prefix correction.
- **Deprecation status**: N/A — bug fix.
- **Rollback plan**: revert this PR. AWS state stays as-is (already `sso:`); revert restores the buggy code which would re-introduce the bug on the next refresh-write.
- **2 AM readability**: 5-line search-and-replace; comment in the Sid still explains what it covers.

## Test plan

- [ ] CI Plan job for management/bootstrap green.
- [ ] Plan diff shows the role-policy in-place update (or zero changes if refresh canonicalizes).

## Related

- Earlier session work: PR #171/172/173/174/175/176/177/178/179 (full ADR-029 + ADR-030 rollout)
- PR #177 commits: same prefix correction applied to the 3 plan-role policies
- Will document the break-glass operation in `docs/incidents.md` as a follow-up commit on a separate doc PR