### PR TITLE
feat(iam): cleanup legacy github-actions-terraform role (ADR-029 PR-7 final)

### DIFF
--- a/terraform/environments/management/bootstrap/oidc-github.tf
+++ b/terraform/environments/management/bootstrap/oidc-github.tf
@@ -1,56 +1,22 @@
 # -----------------------------------------------------------------------------
 # GitHub OIDC Federation — Zero Static Credentials
 # -----------------------------------------------------------------------------
-# Allows GitHub Actions to authenticate to the management account via OIDC.
-# Used for terraform plan/apply of organization-level resources (SCPs, etc.).
+# Provides the OIDC provider that all gh-tf-* roles federate against. Each
+# role's trust policy + permission policy lives in its own oidc-github-*-role.tf
+# file (plan / apply-baseline). The provider is shared.
+#
+# Legacy `github-actions-terraform` (Admin) was removed by ADR-029 PR-7
+# cleanup; see incidents.md §Incident 36 for the rollout narrative.
 # -----------------------------------------------------------------------------
 
 locals {
   github_org        = local.config.github.org
   github_infra_repo = local.config.github.infra_repo
   github_oidc_url   = "https://token.actions.githubusercontent.com"
-
-  github_oidc_subjects = [
-    "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main",
-    "repo:${local.github_org}/${local.github_infra_repo}:pull_request",
-  ]
 }
 
 resource "aws_iam_openid_connect_provider" "github" {
   url             = local.github_oidc_url
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
-}
-
-resource "aws_iam_role" "github_ci" {
-  name = "github-actions-terraform"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-          }
-          StringLike = {
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = local.github_oidc_subjects
-          }
-        }
-      }
-    ]
-  })
-}
-
-# Management account CI role permissions are scoped to Organizations operations.
-# AdministratorAccess is used here for lab simplicity — production should use
-# a custom policy limited to organizations:*, sso:*, iam:Read*, etc.
-resource "aws_iam_role_policy_attachment" "github_ci" {
-  role       = aws_iam_role.github_ci.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/terraform/environments/management/bootstrap/outputs.tf
+++ b/terraform/environments/management/bootstrap/outputs.tf
@@ -22,13 +22,3 @@ output "github_oidc_provider_arn" {
   description = "GitHub OIDC identity provider ARN"
   value       = aws_iam_openid_connect_provider.github.arn
 }
-
-output "github_ci_role_arn" {
-  description = "IAM role ARN for GitHub Actions CI/CD"
-  value       = aws_iam_role.github_ci.arn
-}
-
-output "github_ci_role_name" {
-  description = "IAM role name for GitHub Actions CI/CD"
-  value       = aws_iam_role.github_ci.name
-}

--- a/terraform/environments/management/scps/main.tf
+++ b/terraform/environments/management/scps/main.tf
@@ -161,11 +161,10 @@ resource "aws_organizations_policy_attachment" "deny_leave_org" {
 #   - AWSControlTowerExecution / aws-controltower-* / stacksets-exec-* —
 #     Control Tower / StackSets create and modify IAM during account
 #     provisioning; required for the platform to function.
-#   - github-actions-terraform — legacy Admin role retained during the
-#     ADR-029 rollout window; will be removed when the cleanup PR drops it.
-#   - gh-tf-* — the four purpose-scoped CI roles that supersede the legacy
-#     role per ADR-029. Apply-tier members of this family legitimately create
-#     IAM roles for new infrastructure.
+#   - gh-tf-* — the four purpose-scoped CI roles per ADR-029
+#     (gh-tf-plan / gh-tf-apply-baseline / gh-tf-apply-workload /
+#     gh-tf-teardown-workload). Apply-tier members of this family legitimately
+#     create IAM roles for new infrastructure.
 #   - aegis-emergency-* — break-glass pattern aligned with
 #     `docs/principles/break-glass-apply.md`. Aspirational at present (no role
 #     of this name exists yet); the SCP allow-list reserves the namespace so
@@ -224,7 +223,6 @@ resource "aws_organizations_policy" "deny_iam_privilege_escalation" {
               "arn:aws:iam::*:role/AWSControlTowerExecution",
               "arn:aws:iam::*:role/aws-controltower-*",
               "arn:aws:iam::*:role/stacksets-exec-*",
-              "arn:aws:iam::*:role/github-actions-terraform",
               "arn:aws:iam::*:role/gh-tf-*",
               "arn:aws:iam::*:role/aegis-emergency-*",
               "arn:aws:iam::*:role/*-karpenter-controller",

--- a/terraform/environments/shared/bootstrap/oidc-github.tf
+++ b/terraform/environments/shared/bootstrap/oidc-github.tf
@@ -1,8 +1,12 @@
 # -----------------------------------------------------------------------------
 # GitHub OIDC Federation — Zero Static Credentials
 # -----------------------------------------------------------------------------
-# Allows GitHub Actions to authenticate to this account via OIDC.
-# No IAM access keys are created or stored anywhere.
+# Provides the OIDC provider that all gh-tf-* roles federate against. Each
+# role's trust policy + permission policy lives in its own oidc-github-*-role.tf
+# file. The provider is shared.
+#
+# Legacy `github-actions-terraform` (Admin) was removed by ADR-029 PR-7
+# cleanup; see incidents.md §Incident 36 for the rollout narrative.
 # See: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
 # -----------------------------------------------------------------------------
 
@@ -10,14 +14,6 @@ locals {
   github_org        = local.config.github.org
   github_infra_repo = local.config.github.infra_repo
   github_oidc_url   = "https://token.actions.githubusercontent.com"
-
-  # OIDC subject claims allowed to assume the CI role
-  # Format: repo:<org>/<repo>:<context>
-  # Using wildcard to allow both PR plans and main-branch applies
-  github_oidc_subjects = [
-    "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main",
-    "repo:${local.github_org}/${local.github_infra_repo}:pull_request",
-  ]
 }
 
 resource "aws_iam_openid_connect_provider" "github" {
@@ -28,46 +24,4 @@ resource "aws_iam_openid_connect_provider" "github" {
   # This thumbprint is required by the API but not used for verification
   # when the OIDC provider is a known provider (GitHub, Google, etc.).
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
-}
-
-# -----------------------------------------------------------------------------
-# CI/CD IAM Role — assumed by GitHub Actions via OIDC
-# -----------------------------------------------------------------------------
-# This role is used by GitHub Actions workflows for terraform plan/apply
-# against the shared account (state bucket, AFT, shared resources).
-#
-# Permissions: AdministratorAccess (lab project, single operator).
-# Production environments should scope down to least-privilege.
-# The OIDC condition is the primary access control — only the specific
-# GitHub repo can assume this role.
-# -----------------------------------------------------------------------------
-
-resource "aws_iam_role" "github_ci" {
-  name = "github-actions-terraform"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-          }
-          StringLike = {
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = local.github_oidc_subjects
-          }
-        }
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "github_ci" {
-  role       = aws_iam_role.github_ci.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/terraform/environments/shared/bootstrap/outputs.tf
+++ b/terraform/environments/shared/bootstrap/outputs.tf
@@ -32,8 +32,3 @@ output "github_oidc_provider_arn" {
   description = "GitHub OIDC identity provider ARN"
   value       = aws_iam_openid_connect_provider.github.arn
 }
-
-output "github_ci_role_arn" {
-  description = "IAM role ARN for GitHub Actions CI/CD"
-  value       = aws_iam_role.github_ci.arn
-}

--- a/terraform/environments/staging/bootstrap/oidc-github.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github.tf
@@ -1,9 +1,14 @@
 # -----------------------------------------------------------------------------
 # GitHub OIDC Federation — staging account CI access
 # -----------------------------------------------------------------------------
-# Same pattern as management/bootstrap and shared/bootstrap. Allows GitHub
-# Actions to deploy staging resources (network, platform, workloads layers)
-# without static credentials.
+# Provides the OIDC provider that all gh-tf-* roles + the four
+# github-actions-aegis-core-* roles federate against. Each role's trust policy
+# + permission policy lives in its own .tf file (see oidc-github-*-role.tf
+# and oidc-aegis-core.tf).
+#
+# `github_app_repo` local stays — used by the aegis-core CI roles below.
+# Legacy `github-actions-terraform` (Admin) was removed by ADR-029 PR-7
+# cleanup; see incidents.md §Incident 36 for the rollout narrative.
 # -----------------------------------------------------------------------------
 
 locals {
@@ -12,62 +17,10 @@ locals {
   github_oidc_url   = "https://token.actions.githubusercontent.com"
 
   github_app_repo = local.config.github.app_repo
-
-  # Subject claims for Terraform CI. Each trigger type in GitHub Actions
-  # produces a different `sub` claim in the OIDC token:
-  #   - push to main                      → ref:refs/heads/main
-  #   - pull_request                      → pull_request
-  #   - workflow_dispatch + environment:X → environment:X
-  # Baseline apply uses main; plan uses pull_request; workload apply + teardown
-  # use environment-scoped claims (ADR-009 workflow split).
-  #
-  # aegis-core does NOT use this role — it has dedicated least-privilege
-  # roles below (github-actions-aegis-core-ecr, github-actions-aegis-core-cache).
-  # See #72 for the rationale: sharing Admin with the app repo is a
-  # supply-chain escalation risk.
-  github_oidc_subjects = [
-    "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main",
-    "repo:${local.github_org}/${local.github_infra_repo}:pull_request",
-    "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-apply",
-    "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-teardown",
-  ]
 }
 
 resource "aws_iam_openid_connect_provider" "github" {
   url             = local.github_oidc_url
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
-}
-
-resource "aws_iam_role" "github_ci" {
-  name = "github-actions-terraform"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-          }
-          StringLike = {
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = local.github_oidc_subjects
-          }
-        }
-      }
-    ]
-  })
-}
-
-# Staging CI role permissions are AdministratorAccess for lab simplicity.
-# Production should scope down per Terraservices layer (network, platform,
-# workloads) using least-privilege custom policies.
-resource "aws_iam_role_policy_attachment" "github_ci" {
-  role       = aws_iam_role.github_ci.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }

--- a/terraform/environments/staging/bootstrap/outputs.tf
+++ b/terraform/environments/staging/bootstrap/outputs.tf
@@ -13,11 +13,6 @@ output "github_oidc_provider_arn" {
   value       = aws_iam_openid_connect_provider.github.arn
 }
 
-output "github_ci_role_arn" {
-  description = "IAM role ARN for GitHub Actions CI/CD"
-  value       = aws_iam_role.github_ci.arn
-}
-
 output "ecr_aegis_core_repository_url" {
   description = "ECR repository URL for the aegis-core application image"
   value       = aws_ecr_repository.aegis_core.repository_url

--- a/terraform/environments/staging/platform/config.tf
+++ b/terraform/environments/staging/platform/config.tf
@@ -45,7 +45,12 @@ locals {
 
   cluster_name_base = "${local.config.organization.name}-staging"
 
-  ci_role_arn = "arn:aws:iam::${local.account_id}:role/github-actions-terraform"
+  # Cluster-admin EKS Access Entry principal — must match the role that
+  # actually performs `terraform apply` on this layer. Per ADR-029 PR-6,
+  # `terraform-apply-workload.yml` assumes `gh-tf-apply-workload`. The in-TF
+  # `helm` / `kubernetes` / `kubectl` providers need cluster-admin to install
+  # Karpenter / ArgoCD / Kyverno / cert-manager / ESO during apply.
+  ci_role_arn = "arn:aws:iam::${local.account_id}:role/gh-tf-apply-workload"
 
   tags = merge(local.config.tags, {
     Environment = "staging"


### PR DESCRIPTION
## Summary

Final step (PR-7) of the ADR-029 IAM scope-down rollout. Removes the legacy `github-actions-terraform` (AdministratorAccess) role and all its references. The four `gh-tf-*` purpose-scoped roles are now the sole CI identity surface.

## Files changed (8)

| # | File | Change |
|---|---|---|
| 1-3 | `terraform/environments/{management,shared,staging}/bootstrap/oidc-github.tf` | delete `aws_iam_role.github_ci`, `aws_iam_role_policy_attachment.github_ci`, `github_oidc_subjects` local |
| 4 | `terraform/environments/management/scps/main.tf` | remove legacy entry from `deny-iam-privilege-escalation` SCP allow-list |
| 5-7 | `terraform/environments/{management,shared,staging}/bootstrap/outputs.tf` | drop `github_ci_role_arn` outputs (zero remote-state consumers) |
| 8 | `terraform/environments/staging/platform/config.tf` | re-point `ci_role_arn` to `gh-tf-apply-workload` for EKS Access Entry |

## The non-obvious one — file 8

Per the grep audit (subagent flagged this as a stop-condition), the legacy role wasn't only referenced by IAM. `staging/platform/config.tf` defined a `ci_role_arn` that fed the EKS Access Entry granting cluster-admin to the CI role for in-TF `helm` / `kubernetes` / `kubectl` provider operations.

After PR-6, the role that performs `terraform apply` on the platform layer is `gh-tf-apply-workload` (not the legacy one). Re-pointing `ci_role_arn` is the smallest correct change: cluster-admin follows the apply role.

Without this edit, deleting the legacy role + leaving the access entry pointing at it would have left cluster-admin granted to a non-existent role, and the next platform apply would have failed with K8s `Forbidden` when the helm provider tried to install Karpenter.

## Plan expectation

| Layer | Diff |
|---|---|
| mgmt/bootstrap | DELETE `aws_iam_role.github_ci` + attachment |
| shared/bootstrap | same |
| staging/bootstrap | same |
| mgmt/scps | IN-PLACE update on `deny-iam-privilege-escalation` (one ARN entry removed) |
| staging/platform | per-cluster: replace `aws_eks_access_entry.ci` + `aws_eks_access_policy_association.ci_cluster_admin` (principal_arn change forces replacement) |

Total destruction: 6 IAM resources + 2 EKS access entries per cluster.

## Change-review-discipline checklist

- **Blast radius**: org-wide (SCP) + 3 accounts IAM cleanup + per-cluster EKS access entry replacement. EKS access entry replacement during `terraform apply` briefly drops then re-grants cluster-admin to the new role. No workload pod affected (kube-system addons run via IRSA).
- **Dependency assumptions**: zero `terraform_remote_state` consumers of the deleted outputs (verified). All workflows cut over in earlier PRs.
- **Deprecation status**: N/A — pure removal of superseded role.
- **Rollback plan**: revert recreates legacy role + Admin attachment + access entry re-points back. Safe.
- **2 AM readability**: 8 small targeted edits. Per-role files untouched. Comments retained explaining the historical context.

## Test plan

- [ ] CI Plan green for all baseline + staging/platform.
- [ ] Plan diff matches expectation table.
- [ ] Post-merge: apply-baseline applies the deletions.
- [ ] Post-cold-apply (next session): platform apply re-grants cluster-admin to the new role.

## Related

ADR-029 §Decision §Appendix; PRs #171 / #172 / #173 / #174 / #175 / #176 / #177 / #178 / #179 / #180 (full predecessor chain); PR #181 (incidents postmortem).