### PR TITLE
feat(security): ADR-030 Item B — state bucket + KMS policy allow-list (gh-tf-* / aegis-emergency-* / SSO PlatformAdmin)

### DIFF
--- a/terraform/environments/shared/bootstrap/kms-state.tf
+++ b/terraform/environments/shared/bootstrap/kms-state.tf
@@ -32,7 +32,7 @@ resource "aws_kms_key" "terraform_state" {
         Resource  = "*"
       },
       {
-        Sid       = "AllowOrganizationDecryptAndEncrypt"
+        Sid       = "AllowAllowListedPrincipalsDecryptAndEncrypt"
         Effect    = "Allow"
         Principal = { AWS = "*" }
         Action = [
@@ -46,6 +46,13 @@ resource "aws_kms_key" "terraform_state" {
         Condition = {
           StringEquals = {
             "aws:PrincipalOrgID" = local.org_id
+          }
+          ArnLike = {
+            "aws:PrincipalArn" = [
+              "arn:aws:iam::*:role/gh-tf-*",
+              "arn:aws:iam::*:role/aegis-emergency-*",
+              "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*",
+            ]
           }
         }
       },

--- a/terraform/environments/shared/bootstrap/main.tf
+++ b/terraform/environments/shared/bootstrap/main.tf
@@ -73,7 +73,7 @@ resource "aws_s3_bucket_policy" "terraform_state" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid       = "AllowOrganizationAccess"
+        Sid       = "AllowAllowListedPrincipals"
         Effect    = "Allow"
         Principal = "*"
         Action = [
@@ -90,6 +90,13 @@ resource "aws_s3_bucket_policy" "terraform_state" {
         Condition = {
           StringEquals = {
             "aws:PrincipalOrgID" = local.org_id
+          }
+          ArnLike = {
+            "aws:PrincipalArn" = [
+              "arn:aws:iam::*:role/gh-tf-*",
+              "arn:aws:iam::*:role/aegis-emergency-*",
+              "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*",
+            ]
           }
         }
       },


### PR DESCRIPTION
## Summary

Implements **ADR-030 Item B** — tightens the S3 Terraform-state bucket policy and its customer-managed KMS key policy beyond the existing `aws:PrincipalOrgID` org-membership gate by adding an `ArnLike` allow-list on `aws:PrincipalArn`.

The two affected statements are renamed from `AllowOrganizationAccess` / `AllowOrganizationDecryptAndEncrypt` to `AllowAllowListedPrincipals` / `AllowAllowListedPrincipalsDecryptAndEncrypt` to reflect that the gate is no longer just org-membership.

## Rationale

**Defense-in-depth.** Today's `aws:PrincipalOrgID`-only gate trusts every principal in the org — Karpenter IRSA, future IAM roles a forker might add inside the staging or shared accounts, etc. Tightening to `ArnLike` on known role patterns means a future broadly-scoped role inside the org cannot accidentally read or decrypt Terraform state.

Pattern-based allow-list (not enumerated ARNs) means new roles matching `gh-tf-*` / `aegis-emergency-*` are auto-allowed without policy edits — important because we are still expanding the role family and don't want every new role to require touching this policy.

## Allow-list patterns

- `arn:aws:iam::*:role/gh-tf-*` — covers the four ADR-029 CI role families (`gh-tf-plan`, `gh-tf-apply-baseline`, `gh-tf-apply-workload`, `gh-tf-teardown-workload`)
- `arn:aws:iam::*:role/aegis-emergency-*` — covers `aegis-emergency-break-glass` (ADR-030 Item A, in flight on a parallel branch)
- `arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*` — covers Bin's local SSO admin assumed-role

## Dependencies

- This depends on ADR-029 four-role family already existing (✅ in main as of PR #182).
- Pattern-based, so does **not** depend on `aegis-emergency-*` roles existing yet (parallel PR). `ArnLike` evaluates per-request against the calling principal's ARN; if no caller ever matches the `aegis-emergency-*` pattern, the entry is simply dormant.

## Blast radius

This is the most critical infrastructure in the repo — the state bucket policy.

**If a CI plan fails after merge with `s3:GetObject` AccessDenied, recovery is break-glass — PlatformAdmin SSO is in the allow-list and can directly `aws s3api put-bucket-policy` to revert.** The KMS key is similarly recoverable via `aws kms put-key-policy` from PlatformAdmin.

Outer guardrail (`aws:PrincipalOrgID`) is preserved — defense-in-depth, not replacement. `ArnLike` (wildcard-friendly) is used over `ArnEquals` so new roles within each family don't require policy edits.

## Change-review checklist (`docs/principles/change-review-discipline.md`)

1. **Blast radius** — bucket and KMS key policy on the single most critical artifact in the repo (Terraform state). Recovery via PlatformAdmin SSO direct-edit (in allow-list).
2. **Dependency assumptions** — relies on ADR-029 role family in main (verified PR #182). Pattern-based for ADR-030 Item A roles, so no hard dependency on parallel branch landing first.
3. **Deprecation status** — no deprecated APIs. `aws:PrincipalArn` + `ArnLike` is the standard IAM condition pattern; supported since the original IAM policy language.
4. **Rollback plan** — `git revert` if no behavioural issue, or `aws s3api put-bucket-policy` / `aws kms put-key-policy` from PlatformAdmin SSO if CI is locked out.
5. **2 AM readability** — Sid renames make the gate's intent obvious; allow-list patterns are inline so a future operator reading the policy in the AWS console sees exactly which role families are trusted.

## Files changed

- `terraform/environments/shared/bootstrap/main.tf` — `aws_s3_bucket_policy.terraform_state` Sid `AllowOrganizationAccess` → `AllowAllowListedPrincipals` + `ArnLike` condition. `DenyInsecureTransport` Sid untouched.
- `terraform/environments/shared/bootstrap/kms-state.tf` — `aws_kms_key.terraform_state` Sid `AllowOrganizationDecryptAndEncrypt` → `AllowAllowListedPrincipalsDecryptAndEncrypt` + `ArnLike` condition. `EnableRootAccountPermissions` Sid untouched.

## Test plan

- [ ] Checkov green on the diff
- [ ] Terraform Plan (matrix) green on `shared/bootstrap` — and the plan diff for the state bucket should show only the policy update (no bucket replacement)
- [ ] After merge: next baseline-apply runs cleanly (gh-tf-apply-baseline role hits the allow-list)
- [ ] After merge: next CI plan on any layer (which reads remote state from this bucket) returns successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)