### PR TITLE
feat(iam): aegis-emergency-break-glass role × 3 accounts (ADR-030 OQ-1 graduation)

### DIFF
--- a/terraform/environments/management/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/management/bootstrap/aegis-emergency-role.tf
@@ -1,0 +1,203 @@
+# -----------------------------------------------------------------------------
+# `aegis-emergency-break-glass` — break-glass recovery role (ADR-030 OQ-1)
+# -----------------------------------------------------------------------------
+# Materializes the `aegis-emergency-*` namespace reserved by ADR-030's SCP
+# allow-list (`deny-iam-privilege-escalation`). The role exists so the
+# operator's PlatformAdmin SSO session has a documented assume-target during
+# break-glass recovery — i.e., the kind of recovery driven by Incident 36,
+# where the operator's SSO role itself is intentionally NOT in the SCP
+# allow-list and a TF-managed policy bug requires a manual `iam:put-role-policy`
+# to unstick `terraform apply`.
+#
+# The recovery shape that motivates this role:
+#   1. Apply-tier role (`gh-tf-apply-baseline`) gets a buggy policy via TF.
+#   2. CI fails because the buggy policy denies the very action the next
+#      `terraform apply` needs to mutate the policy back.
+#   3. Operator's SSO role is not in the SCP allow-list (intentional —
+#      humans don't bypass IAM-mutation guardrails by default).
+#   4. Operator assumes `aegis-emergency-break-glass`, runs the manual
+#      `aws iam put-role-policy` to fix the apply role, exits the role.
+#   5. CI is unblocked. Total session time: minutes.
+#
+# Trust policy: any session of the local-account PlatformAdmin SSO role.
+# IAM Identity Center materializes a reserved role per account named
+# `AWSReservedSSO_PlatformAdmin_<hash>` where the hash is account-specific
+# and stable. The trust uses `ArnLike` to match the wildcard hash; the
+# `Principal: { AWS = "...:root" }` clause is the standard "any IAM
+# principal in this account that ALSO satisfies the Condition" pattern.
+#
+# Permission policy: see `aws_iam_role_policy.aegis_emergency_break_glass`
+# below. The mgmt variant carries the full diagnosis surface (Org / SSO /
+# IAM / KMS / SSM PS) — Org and SSO live in mgmt, so this is where SCP
+# detach-and-reattach during recovery happens.
+#
+# Session is time-bounded to 1 hour (`max_session_duration = 3600`). Operator
+# can re-assume if the recovery takes longer; the bound is the discipline
+# signal that break-glass is not a working mode.
+#
+# SCP interaction: `aegis-emergency-break-glass` matches `aegis-emergency-*`
+# in ADR-030's `deny-iam-privilege-escalation` SCP allow-list. No SCP change
+# is required by this PR.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "aegis_emergency_break_glass" {
+  name                 = "aegis-emergency-break-glass"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OperatorViaPlatformAdminSso"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${local.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
+  # checkov:skip=CKV_AWS_287: Read-shape Sids (IamReadAll, OrganizationsRead, SsoRead, KmsReadAndDecrypt's Describe/List/Get verbs, StsAndTagRead) intentionally use Resource:* for inventory access during break-glass diagnosis. Mutation surface is in IamMutationOnProjectRoles + OrganizationsScpManage + SsmReadProject's mutating verbs (none — read only), all scoped or trust-policy-gated. ADR-030 OQ-1.
+  # checkov:skip=CKV_AWS_288: Same as 287 — break-glass requires broad read for diagnosis; mutations are scoped. Read-shape data disclosure is the explicit threat model accepted by ADR-030.
+  # checkov:skip=CKV_AWS_289: iam:* is intentionally allowed but scoped to aegis-*/gh-tf-*/github-actions-* prefixes. Permission-management within fixed prefixes is the break-glass contract — the role exists precisely to fix bad policies on those role families.
+  # checkov:skip=CKV_AWS_290: organizations:* / sso:* / identitystore:* require Resource:* because the AWS APIs do not support resource-level ARN constraints. Trust policy (PlatformAdmin SSO only) is the gate.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sids and on AWS APIs without resource-level ARN support.
+  # checkov:skip=CKV2_AWS_40: iam:* on a fixed ARN-prefix scope is the deliberate break-glass design (ADR-030 OQ-1 graduation).
+  name = "emergency-break-glass-scoped"
+  role = aws_iam_role.aegis_emergency_break_glass.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Scoped IAM mutation — the primary break-glass primitive. Covers
+        # the role/policy families that TF-managed CI roles live under.
+        # When a buggy `aws_iam_role_policy` denies the action that would
+        # let `terraform apply` mutate it back, this is the manual exit.
+        Sid    = "IamMutationOnProjectRoles"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+        ]
+      },
+      {
+        # IAM read across the account. Diagnosis needs to enumerate every
+        # role / policy / attachment to find the bad state; mutations are
+        # bounded by IamMutationOnProjectRoles above.
+        Sid    = "IamReadAll"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:Simulate*",
+        ]
+        Resource = "*"
+      },
+      {
+        # Organizations read — mgmt-only. For diagnosing SCP propagation
+        # issues during recovery (e.g., "is the SCP currently attached?
+        # which target?"). No write power here; OrganizationsScpManage
+        # below carries the SCP-detach-and-reattach verbs.
+        Sid    = "OrganizationsRead"
+        Effect = "Allow"
+        Action = [
+          "organizations:Describe*",
+          "organizations:List*",
+        ]
+        Resource = "*"
+      },
+      {
+        # SCP detach / attach / update — the verbs needed to execute the
+        # SCP-propagation-recovery pattern from Incident 36 (detach SCP,
+        # wait ~30s for propagation, run the fix, reattach). Resource:*
+        # because Organizations APIs do not support resource-level ARNs;
+        # the trust policy (PlatformAdmin SSO only) is the gate.
+        Sid    = "OrganizationsScpManage"
+        Effect = "Allow"
+        Action = [
+          "organizations:DetachPolicy",
+          "organizations:AttachPolicy",
+          "organizations:UpdatePolicy",
+        ]
+        Resource = "*"
+      },
+      {
+        # SSO and identity store read — mgmt-only. Diagnosis-only;
+        # principal-set / permission-set inspection during recovery.
+        # No SSO write power (operator's SSO assignments are managed by
+        # `management/bootstrap/sso-assignments.tf` — break-glass does
+        # not edit those).
+        Sid    = "SsoRead"
+        Effect = "Allow"
+        Action = [
+          "sso:Describe*",
+          "sso:List*",
+          "sso:Get*",
+          "identitystore:Describe*",
+          "identitystore:List*",
+          "identitystore:Get*",
+        ]
+        Resource = "*"
+      },
+      {
+        # KMS read + Decrypt scoped to local-account keys only. Required
+        # for reading SSM PS SecureString values during diagnosis. No
+        # Encrypt / GenerateDataKey here — break-glass is read-recovery,
+        # not new-encryption.
+        Sid    = "KmsReadAndDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Describe*",
+          "kms:List*",
+          "kms:Get*",
+          "kms:Decrypt",
+        ]
+        Resource = "arn:aws:kms:*:${local.account_id}:key/*"
+      },
+      {
+        # SSM PS read on `/aegis/*` paths only. SaaS credentials and
+        # other ADR-028 secrets-persistent values live under this prefix;
+        # diagnosis often needs to confirm a token is present and decrypts
+        # cleanly. Read-only; no Put / Delete.
+        Sid    = "SsmReadProject"
+        Effect = "Allow"
+        Action = [
+          "ssm:Get*",
+          "ssm:Describe*",
+          "ssm:List*",
+        ]
+        Resource = "arn:aws:ssm:*:${local.account_id}:parameter/aegis/*"
+      },
+      {
+        # Identity + audit visibility. `sts:GetCallerIdentity` to confirm
+        # the assume worked; `tag:Get*` for cross-resource tag enumeration;
+        # the two `iam:Generate*` actions to produce credential / access
+        # reports during diagnosis. All read-only and AWS-API-shape
+        # Resource:* — these actions do not accept resource-level ARNs.
+        Sid    = "StsAndTagRead"
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "tag:Get*",
+          "iam:GenerateCredentialReport",
+          "iam:GenerateServiceLastAccessedDetails",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/management/bootstrap/outputs.tf
+++ b/terraform/environments/management/bootstrap/outputs.tf
@@ -22,3 +22,8 @@ output "github_oidc_provider_arn" {
   description = "GitHub OIDC identity provider ARN"
   value       = aws_iam_openid_connect_provider.github.arn
 }
+
+output "aegis_emergency_break_glass_role_arn" {
+  description = "ARN of the aegis-emergency-break-glass role for SSO PlatformAdmin assume during break-glass recovery"
+  value       = aws_iam_role.aegis_emergency_break_glass.arn
+}

--- a/terraform/environments/shared/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/shared/bootstrap/aegis-emergency-role.tf
@@ -1,0 +1,127 @@
+# -----------------------------------------------------------------------------
+# `aegis-emergency-break-glass` — break-glass recovery role (ADR-030 OQ-1)
+# -----------------------------------------------------------------------------
+# Materializes the `aegis-emergency-*` namespace reserved by ADR-030's SCP
+# allow-list (`deny-iam-privilege-escalation`). This is the shared-account
+# variant — see `terraform/environments/management/bootstrap/aegis-emergency-
+# role.tf` for the full design narrative and the recovery shape that
+# motivates the role.
+#
+# Scope difference from mgmt: no Organizations / SSO / IdentityStore Sids.
+# Those API surfaces only carry power in mgmt; in member accounts they
+# return empty inventories at best and produce no useful break-glass
+# primitive. The shared-account permission policy is therefore the IAM /
+# KMS / SSM PS subset.
+#
+# Trust policy: identical pattern to mgmt — local-account PlatformAdmin
+# SSO sessions only, time-bounded to 1 hour.
+#
+# SCP interaction: `aegis-emergency-break-glass` matches `aegis-emergency-*`
+# in ADR-030's SCP allow-list. No SCP change required by this PR.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "aegis_emergency_break_glass" {
+  name                 = "aegis-emergency-break-glass"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OperatorViaPlatformAdminSso"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${local.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
+  # checkov:skip=CKV_AWS_287: Read-shape Sids (IamReadAll, KmsReadAndDecrypt's Describe/List/Get verbs, StsAndTagRead) intentionally use Resource:* for inventory access during break-glass diagnosis. Mutation surface is in IamMutationOnProjectRoles, scoped or trust-policy-gated. ADR-030 OQ-1.
+  # checkov:skip=CKV_AWS_288: Same as 287 — break-glass requires broad read for diagnosis; mutations are scoped. Read-shape data disclosure is the explicit threat model accepted by ADR-030.
+  # checkov:skip=CKV_AWS_289: iam:* is intentionally allowed but scoped to aegis-*/gh-tf-*/github-actions-* prefixes. Permission-management within fixed prefixes is the break-glass contract.
+  # checkov:skip=CKV_AWS_290: Resource:* on read-only Sids is required because the corresponding AWS APIs do not support resource-level ARN constraints. Trust policy (PlatformAdmin SSO only) is the gate.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sids and on AWS APIs without resource-level ARN support.
+  # checkov:skip=CKV2_AWS_40: iam:* on a fixed ARN-prefix scope is the deliberate break-glass design (ADR-030 OQ-1 graduation).
+  name = "emergency-break-glass-scoped"
+  role = aws_iam_role.aegis_emergency_break_glass.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Scoped IAM mutation — the primary break-glass primitive.
+        Sid    = "IamMutationOnProjectRoles"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+        ]
+      },
+      {
+        # IAM read across the account. Diagnosis needs full inventory;
+        # mutations are bounded by IamMutationOnProjectRoles above.
+        Sid    = "IamReadAll"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:Simulate*",
+        ]
+        Resource = "*"
+      },
+      {
+        # KMS read + Decrypt scoped to local-account keys only. Required
+        # for reading SSM PS SecureString values during diagnosis. No
+        # Encrypt / GenerateDataKey — break-glass is read-recovery.
+        Sid    = "KmsReadAndDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Describe*",
+          "kms:List*",
+          "kms:Get*",
+          "kms:Decrypt",
+        ]
+        Resource = "arn:aws:kms:*:${local.account_id}:key/*"
+      },
+      {
+        # SSM PS read on `/aegis/*` paths only. ADR-028 secrets-persistent
+        # values live under this prefix; diagnosis often needs to confirm
+        # a token is present and decrypts cleanly. Read-only.
+        Sid    = "SsmReadProject"
+        Effect = "Allow"
+        Action = [
+          "ssm:Get*",
+          "ssm:Describe*",
+          "ssm:List*",
+        ]
+        Resource = "arn:aws:ssm:*:${local.account_id}:parameter/aegis/*"
+      },
+      {
+        # Identity + audit visibility. Read-only; AWS-API-shape Resource:*.
+        Sid    = "StsAndTagRead"
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "tag:Get*",
+          "iam:GenerateCredentialReport",
+          "iam:GenerateServiceLastAccessedDetails",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/shared/bootstrap/outputs.tf
+++ b/terraform/environments/shared/bootstrap/outputs.tf
@@ -32,3 +32,8 @@ output "github_oidc_provider_arn" {
   description = "GitHub OIDC identity provider ARN"
   value       = aws_iam_openid_connect_provider.github.arn
 }
+
+output "aegis_emergency_break_glass_role_arn" {
+  description = "ARN of the aegis-emergency-break-glass role for SSO PlatformAdmin assume during break-glass recovery"
+  value       = aws_iam_role.aegis_emergency_break_glass.arn
+}

--- a/terraform/environments/staging/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/staging/bootstrap/aegis-emergency-role.tf
@@ -1,0 +1,127 @@
+# -----------------------------------------------------------------------------
+# `aegis-emergency-break-glass` — break-glass recovery role (ADR-030 OQ-1)
+# -----------------------------------------------------------------------------
+# Materializes the `aegis-emergency-*` namespace reserved by ADR-030's SCP
+# allow-list (`deny-iam-privilege-escalation`). This is the staging-account
+# variant — see `terraform/environments/management/bootstrap/aegis-emergency-
+# role.tf` for the full design narrative and the recovery shape that
+# motivates the role.
+#
+# Scope difference from mgmt: no Organizations / SSO / IdentityStore Sids.
+# Those API surfaces only carry power in mgmt; in member accounts they
+# return empty inventories at best and produce no useful break-glass
+# primitive. The staging-account permission policy is therefore the IAM /
+# KMS / SSM PS subset.
+#
+# Trust policy: identical pattern to mgmt — local-account PlatformAdmin
+# SSO sessions only, time-bounded to 1 hour.
+#
+# SCP interaction: `aegis-emergency-break-glass` matches `aegis-emergency-*`
+# in ADR-030's SCP allow-list. No SCP change required by this PR.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "aegis_emergency_break_glass" {
+  name                 = "aegis-emergency-break-glass"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OperatorViaPlatformAdminSso"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${local.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
+  # checkov:skip=CKV_AWS_287: Read-shape Sids (IamReadAll, KmsReadAndDecrypt's Describe/List/Get verbs, StsAndTagRead) intentionally use Resource:* for inventory access during break-glass diagnosis. Mutation surface is in IamMutationOnProjectRoles, scoped or trust-policy-gated. ADR-030 OQ-1.
+  # checkov:skip=CKV_AWS_288: Same as 287 — break-glass requires broad read for diagnosis; mutations are scoped. Read-shape data disclosure is the explicit threat model accepted by ADR-030.
+  # checkov:skip=CKV_AWS_289: iam:* is intentionally allowed but scoped to aegis-*/gh-tf-*/github-actions-* prefixes. Permission-management within fixed prefixes is the break-glass contract.
+  # checkov:skip=CKV_AWS_290: Resource:* on read-only Sids is required because the corresponding AWS APIs do not support resource-level ARN constraints. Trust policy (PlatformAdmin SSO only) is the gate.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sids and on AWS APIs without resource-level ARN support.
+  # checkov:skip=CKV2_AWS_40: iam:* on a fixed ARN-prefix scope is the deliberate break-glass design (ADR-030 OQ-1 graduation).
+  name = "emergency-break-glass-scoped"
+  role = aws_iam_role.aegis_emergency_break_glass.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Scoped IAM mutation — the primary break-glass primitive.
+        Sid    = "IamMutationOnProjectRoles"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+        ]
+      },
+      {
+        # IAM read across the account. Diagnosis needs full inventory;
+        # mutations are bounded by IamMutationOnProjectRoles above.
+        Sid    = "IamReadAll"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:Simulate*",
+        ]
+        Resource = "*"
+      },
+      {
+        # KMS read + Decrypt scoped to local-account keys only. Required
+        # for reading SSM PS SecureString values during diagnosis. No
+        # Encrypt / GenerateDataKey — break-glass is read-recovery.
+        Sid    = "KmsReadAndDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Describe*",
+          "kms:List*",
+          "kms:Get*",
+          "kms:Decrypt",
+        ]
+        Resource = "arn:aws:kms:*:${local.account_id}:key/*"
+      },
+      {
+        # SSM PS read on `/aegis/*` paths only. ADR-028 secrets-persistent
+        # values live under this prefix; diagnosis often needs to confirm
+        # a token is present and decrypts cleanly. Read-only.
+        Sid    = "SsmReadProject"
+        Effect = "Allow"
+        Action = [
+          "ssm:Get*",
+          "ssm:Describe*",
+          "ssm:List*",
+        ]
+        Resource = "arn:aws:ssm:*:${local.account_id}:parameter/aegis/*"
+      },
+      {
+        # Identity + audit visibility. Read-only; AWS-API-shape Resource:*.
+        Sid    = "StsAndTagRead"
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "tag:Get*",
+          "iam:GenerateCredentialReport",
+          "iam:GenerateServiceLastAccessedDetails",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/staging/bootstrap/outputs.tf
+++ b/terraform/environments/staging/bootstrap/outputs.tf
@@ -66,3 +66,12 @@ output "secrets_kms_key_alias" {
   description = "KMS key alias (alias/aegis-staging-secrets) — matches Runbook 006 Part 2 step 5"
   value       = aws_kms_alias.secrets.name
 }
+
+# -----------------------------------------------------------------------------
+# Break-glass recovery role — ADR-030 OQ-1 graduation
+# -----------------------------------------------------------------------------
+
+output "aegis_emergency_break_glass_role_arn" {
+  description = "ARN of the aegis-emergency-break-glass role for SSO PlatformAdmin assume during break-glass recovery"
+  value       = aws_iam_role.aegis_emergency_break_glass.arn
+}


### PR DESCRIPTION
## Summary

Materializes the `aegis-emergency-*` namespace reserved by [ADR-030](docs/decisions/030-tier-2b-permission-boundary-hardening.md)'s SCP allow-list. Creates one role per account in `aegis-management` / `aegis-shared` / `aegis-staging` — same name `aegis-emergency-break-glass`, trust policy admits the local-account PlatformAdmin SSO role, permission policy is scoped wide enough to be useful for break-glass diagnosis + recovery but bounded so a stolen assume is not org-wide root-equivalent.

## Why

ADR-030 OQ-1 left the namespace aspirational ("the role materializes only when needed"). The first time it was needed was Incident 36 (today's morning session), when the SCP `deny-iam-privilege-escalation` correctly locked the operator out during break-glass recovery — the operator's `AWSReservedSSO_PlatformAdmin_*` SSO role is intentionally NOT in the SCP allow-list. Recovery required:

1. `organizations:DetachPolicy` from mgmt
2. ~30s SCP propagation wait
3. `iam:put-role-policy` to fix the apply-tier role's policy
4. `organizations:AttachPolicy` to re-attach

That sequence should run from a documented role with a bounded blast radius and a 1-hour session cap, not from the operator's persistent SSO session. This PR is the OQ-1 graduation — namespace stays the same, the role is now a real assumable resource.

## What ships

**3 new files** (one per account, ~95-150 lines each):

- `terraform/environments/management/bootstrap/aegis-emergency-role.tf` (8-Sid policy — adds Org / SSO surface)
- `terraform/environments/shared/bootstrap/aegis-emergency-role.tf` (5-Sid policy — IAM / KMS / SSM PS subset)
- `terraform/environments/staging/bootstrap/aegis-emergency-role.tf` (5-Sid policy — same subset as shared)

**3 outputs.tf modifications** — new `aegis_emergency_break_glass_role_arn` output per layer.

## Trust policy

Same shape in all 3 accounts:

```hcl
Principal = {
  AWS = "arn:aws:iam::${local.account_id}:root"
}
Action = "sts:AssumeRole"
Condition = {
  ArnLike = {
    "aws:PrincipalArn" = "arn:aws:iam::${local.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*"
  }
}
```

`Principal: {AWS = ".../:root"}` is the standard "any IAM principal in this account that ALSO meets the Condition" pattern. The `ArnLike` narrows to the operator's PlatformAdmin SSO reserved role, which IAM Identity Center materializes per member account with a stable per-account hash suffix.

`max_session_duration = 3600` — 1-hour bound is a discipline signal; operator can re-assume if recovery takes longer.

## Permission policy — Sid summary

**Mgmt variant (8 Sids):**

| Sid | Scope | Purpose |
|---|---|---|
| `IamMutationOnProjectRoles` | `iam:*` on `aegis-*` / `gh-tf-*` / `github-actions-*` role+policy ARNs | Primary break-glass primitive — fix bad TF-managed policies |
| `IamReadAll` | `iam:Get*` / `iam:List*` / `iam:Simulate*` on `*` | Diagnosis inventory |
| `OrganizationsRead` | `organizations:Describe*` / `List*` on `*` | SCP / OU diagnosis |
| `OrganizationsScpManage` | `organizations:DetachPolicy` / `AttachPolicy` / `UpdatePolicy` on `*` | The SCP-detach-and-reattach sequence from Incident 36 |
| `SsoRead` | `sso:*` / `identitystore:*` Describe/List/Get on `*` | Permission-set / assignment diagnosis |
| `KmsReadAndDecrypt` | `kms:Describe*` / `List*` / `Get*` / `Decrypt` on local-account keys only | Read SSM PS SecureString during diagnosis |
| `SsmReadProject` | `ssm:Get*` / `Describe*` / `List*` on `parameter/aegis/*` | ADR-028 secrets-persistent inspection |
| `StsAndTagRead` | `sts:GetCallerIdentity` / `tag:Get*` / `iam:GenerateCredentialReport` etc. | Identity + audit visibility |

**Shared and staging variants (5 Sids):** mgmt set minus `OrganizationsRead`, `OrganizationsScpManage`, `SsoRead` — those API surfaces only carry power in mgmt.

**Explicitly NOT included** (per ADR-030 OQ-1 design):

- `iam:CreateUser` / `AttachUserPolicy` / `PutUserPolicy` — break-glass should not create new IAM users; create a role and assume it instead
- `iam:CreateAccountAlias`
- `kms:Encrypt` / `kms:GenerateDataKey` — break-glass is read-recovery, not new-encryption
- Any service principal outside the diagnosis path (no `s3:*`, `ec2:*`, `eks:*`, `rds:*`, etc.)
- Any `Resource:*` on Create/Update/Delete actions outside the IAM/Organizations/SSO Sids

## SCP interaction

`aegis-emergency-break-glass` matches the existing `aegis-emergency-*` entry in ADR-030's `deny-iam-privilege-escalation` SCP `ArnNotLike` allow-list. **No SCP change required by this PR.**

## Change-review-discipline checklist

- **Blast radius**: 3-account IAM resource creation. Role is dormant until assumed; assume requires a live PlatformAdmin SSO session (Identity Center MFA-gated). The `iam:*` action is bounded to the `aegis-*`/`gh-tf-*`/`github-actions-*` prefix — apply-tier identity scope, not org-root.
- **Dependency assumptions**: zero `terraform_remote_state` consumers of the new outputs. `local.account_id` is already established in all three layers' `config.tf`. `local.tags` already propagates `Environment` per layer.
- **Deprecation status**: N/A — net-new resources. `aws_iam_role` and `aws_iam_role_policy` are stable in AWS provider 6.x. `Condition.ArnLike` on `aws:PrincipalArn` is documented AWS behavior.
- **Rollback plan**: single-PR revert deletes the 3 roles + their inline policies + the 3 outputs. SCP allow-list entry stays (pre-dates this PR). No state migration needed.
- **2 AM readability**: each file has a header banner explaining the recovery shape, trust-policy pattern, and SCP interaction. Sids are commented inline with their purpose. Mgmt file is the design-narrative source; shared/staging files reference back to it.

## Test plan

- [ ] CI Plan green for `management/bootstrap`, `shared/bootstrap`, `staging/bootstrap` matrix entries.
- [ ] Plan diff per account: 1 × `aws_iam_role` + 1 × `aws_iam_role_policy` to add. No other resource diffs.
- [ ] Checkov green (skip directives match the apply-tier roles' shape — `CKV_AWS_287/288/289/290/355` + `CKV2_AWS_40`).
- [ ] Post-merge: `terraform-apply-baseline.yml` creates the 3 roles.
- [ ] Operator verifies `aws sts assume-role --role-arn <output>` succeeds from a live PlatformAdmin SSO session against each account.

## Related

- [ADR-030 OQ-1](docs/decisions/030-tier-2b-permission-boundary-hardening.md#open-questions) — the open question this PR resolves.
- [ADR-029](docs/decisions/029-iam-permission-scope-down.md) — the apply-tier scope-down whose escalation primitive ADR-030 closes.
- [`docs/principles/break-glass-apply.md`](docs/principles/break-glass-apply.md) — break-glass discipline that the role materializes.
- Incident 36 — the first real break-glass operation that motivated graduating the namespace from aspirational to materialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)