### PR TITLE
feat(security): ADR-030 Item C — add repository_id claim to OIDC trust policies (optional)

### DIFF
--- a/config/landing-zone.example.yaml
+++ b/config/landing-zone.example.yaml
@@ -78,6 +78,11 @@ github:
   org: YourGitHubOrg
   infra_repo: aegis-aws-landing-zone
   app_repo: aegis-core
+  # Optional — defense-in-depth against repo rename/transfer (ADR-030 Item C).
+  # Run: gh api repos/<owner>/<repo> --jq .id
+  # If unset, OIDC trust policies fall back to repo full_name pinning only.
+  infra_repo_id: "1234567890"  # placeholder — replace with actual numeric ID
+  app_repo_id: "1234567891"    # placeholder — replace with actual numeric ID
 
 tags:
   Project: landing-zone-lab

--- a/config/schema.json
+++ b/config/schema.json
@@ -133,6 +133,16 @@
         "app_repo": {
           "type": "string",
           "description": "Application repository name (aegis-core)"
+        },
+        "infra_repo_id": {
+          "type": "string",
+          "description": "GitHub numeric repository ID for the infra repo (run: gh api repos/OWNER/REPO --jq .id). When set, OIDC trust policies pin to this immutable ID in addition to the textual repo name. Defense-in-depth against repo rename/transfer edge cases.",
+          "pattern": "^[0-9]+$"
+        },
+        "app_repo_id": {
+          "type": "string",
+          "description": "GitHub numeric repository ID for the app repo (sister repo, e.g. aegis-core). Run: gh api repos/OWNER/REPO --jq .id. Same defense-in-depth role as infra_repo_id.",
+          "pattern": "^[0-9]+$"
         }
       }
     },

--- a/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
@@ -36,10 +36,13 @@ resource "aws_iam_role" "gh_tf_apply_baseline" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main"
-          }
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+              "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
         }
       }
     ]

--- a/terraform/environments/management/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-plan-role.tf
@@ -30,10 +30,13 @@ resource "aws_iam_role" "gh_tf_plan" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:pull_request"
-          }
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+              "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:pull_request"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
         }
       }
     ]

--- a/terraform/environments/management/bootstrap/oidc-github.tf
+++ b/terraform/environments/management/bootstrap/oidc-github.tf
@@ -13,6 +13,16 @@ locals {
   github_org        = local.config.github.org
   github_infra_repo = local.config.github.infra_repo
   github_oidc_url   = "https://token.actions.githubusercontent.com"
+
+  github_infra_repo_id = try(local.config.github.infra_repo_id, null)
+  github_app_repo_id   = try(local.config.github.app_repo_id, null)
+
+  github_oidc_infra_repo_id_claim = local.github_infra_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_infra_repo_id
+  } : {}
+  github_oidc_app_repo_id_claim = local.github_app_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_app_repo_id
+  } : {}
 }
 
 resource "aws_iam_openid_connect_provider" "github" {

--- a/terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf
@@ -37,10 +37,13 @@ resource "aws_iam_role" "gh_tf_apply_baseline" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main"
-          }
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+              "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
         }
       }
     ]

--- a/terraform/environments/shared/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/shared/bootstrap/oidc-github-plan-role.tf
@@ -30,10 +30,13 @@ resource "aws_iam_role" "gh_tf_plan" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:pull_request"
-          }
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+              "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:pull_request"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
         }
       }
     ]

--- a/terraform/environments/shared/bootstrap/oidc-github.tf
+++ b/terraform/environments/shared/bootstrap/oidc-github.tf
@@ -14,6 +14,16 @@ locals {
   github_org        = local.config.github.org
   github_infra_repo = local.config.github.infra_repo
   github_oidc_url   = "https://token.actions.githubusercontent.com"
+
+  github_infra_repo_id = try(local.config.github.infra_repo_id, null)
+  github_app_repo_id   = try(local.config.github.app_repo_id, null)
+
+  github_oidc_infra_repo_id_claim = local.github_infra_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_infra_repo_id
+  } : {}
+  github_oidc_app_repo_id_claim = local.github_app_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_app_repo_id
+  } : {}
 }
 
 resource "aws_iam_openid_connect_provider" "github" {

--- a/terraform/environments/staging/bootstrap/oidc-aegis-core.tf
+++ b/terraform/environments/staging/bootstrap/oidc-aegis-core.tf
@@ -31,9 +31,12 @@ resource "aws_iam_role" "aegis_core_ecr" {
       }
       Action = "sts:AssumeRoleWithWebIdentity"
       Condition = {
-        StringEquals = {
-          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-        }
+        StringEquals = merge(
+          {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          },
+          local.github_oidc_app_repo_id_claim,
+        )
         StringLike = {
           "token.actions.githubusercontent.com:sub" = "repo:${local.github_org}/${local.github_app_repo}:ref:refs/heads/main"
 
@@ -130,9 +133,12 @@ resource "aws_iam_role" "aegis_core_cache" {
       }
       Action = "sts:AssumeRoleWithWebIdentity"
       Condition = {
-        StringEquals = {
-          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-        }
+        StringEquals = merge(
+          {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          },
+          local.github_oidc_app_repo_id_claim,
+        )
         StringLike = {
           "token.actions.githubusercontent.com:sub" = "repo:${local.github_org}/${local.github_app_repo}:ref:refs/heads/main"
         }

--- a/terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf
@@ -40,10 +40,13 @@ resource "aws_iam_role" "gh_tf_apply_baseline" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main"
-          }
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+              "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:ref:refs/heads/main"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
         }
       }
     ]

--- a/terraform/environments/staging/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-plan-role.tf
@@ -30,10 +30,13 @@ resource "aws_iam_role" "gh_tf_plan" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:pull_request"
-          }
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+              "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:pull_request"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
         }
       }
     ]

--- a/terraform/environments/staging/bootstrap/oidc-github-teardown-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-teardown-role.tf
@@ -43,10 +43,13 @@ resource "aws_iam_role" "gh_tf_teardown_workload" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-teardown"
-          }
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+              "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-teardown"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
         }
       }
     ]

--- a/terraform/environments/staging/bootstrap/oidc-github-workload-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-workload-role.tf
@@ -48,10 +48,13 @@ resource "aws_iam_role" "gh_tf_apply_workload" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringEquals = {
-            "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-apply"
-          }
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+              "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/${local.github_infra_repo}:environment:workload-apply"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
         }
       }
     ]

--- a/terraform/environments/staging/bootstrap/oidc-github.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github.tf
@@ -17,6 +17,16 @@ locals {
   github_oidc_url   = "https://token.actions.githubusercontent.com"
 
   github_app_repo = local.config.github.app_repo
+
+  github_infra_repo_id = try(local.config.github.infra_repo_id, null)
+  github_app_repo_id   = try(local.config.github.app_repo_id, null)
+
+  github_oidc_infra_repo_id_claim = local.github_infra_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_infra_repo_id
+  } : {}
+  github_oidc_app_repo_id_claim = local.github_app_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_app_repo_id
+  } : {}
 }
 
 resource "aws_iam_openid_connect_provider" "github" {


### PR DESCRIPTION
## Summary

Tier 2B Item C from [ADR-030](docs/decisions/030-tier-2b-permission-boundary-hardening.md) — adds GitHub's immutable numeric `repository_id` claim to all 8 `gh-tf-*` OIDC trust policies plus the 2 `aegis-core-*` cross-repo CI trust policies.

**Rationale.** Today the trust policies pin to the repo via `:sub = repo:${org}/${repo}:ref:refs/heads/main` — a string match on the textual `full_name`. If the repo were renamed or transferred and another repo with the same `full_name` were later created, OIDC tokens from the new repo would still satisfy `:sub`. GitHub's `repository_id` claim is the immutable numeric identifier; pinning to it closes the rename/transfer reuse edge case. This is the parallel addition to ADR-029's `job_workflow_ref` pinning — same defense-in-depth shape, different claim.

**Backwards-compatible activation model.** The `infra_repo_id` / `app_repo_id` fields are OPTIONAL in `config/schema.json`. When unset, trust policies fall back to repo `full_name` pinning only. The merge logic uses Terraform's `merge()` with an empty-map fallback when the local is `null`, so the StringEquals condition is unchanged textually until the secret is populated. **No coordinated secret update needed for this PR to merge** — it activates the moment values land in `config/landing-zone.yaml` (locally) and the `LANDING_ZONE_CONFIG` GitHub Actions secret (CI).

## Files changed

- `config/schema.json` — add `infra_repo_id` / `app_repo_id` under `github` (optional, `^[0-9]+$`)
- `config/landing-zone.example.yaml` — placeholder values + comment pointing at `gh api repos/<owner>/<repo> --jq .id`
- `terraform/environments/{management,shared,staging}/bootstrap/oidc-github.tf` — three new locals each: `github_infra_repo_id`, `github_app_repo_id`, plus the two derived claim maps `github_oidc_infra_repo_id_claim` / `github_oidc_app_repo_id_claim` (defined symmetrically across all three layers; unused in two of them is fine)
- 8 trust-policy `.tf` files — `StringEquals` becomes `merge({ aud, sub }, local.github_oidc_infra_repo_id_claim)`:
  - `management/bootstrap/oidc-github-{plan,baseline}-role.tf`
  - `shared/bootstrap/oidc-github-{plan,baseline}-role.tf`
  - `staging/bootstrap/oidc-github-{plan,baseline,workload,teardown}-role.tf`
- `staging/bootstrap/oidc-aegis-core.tf` — both statements (ECR + cache) get the same merge pattern, but with `local.github_oidc_app_repo_id_claim` (sister-repo). Existing `StringLike` blocks (`:sub` glob + `:job_workflow_ref` pin) are unchanged.

## Activation

After merge, populate values in **both** locations:

```yaml
# config/landing-zone.yaml (gitignored, local)
github:
  ...
  infra_repo_id: "1207149475"   # BinHsu/aegis-aws-landing-zone
  app_repo_id:   "1207149088"   # BinHsu/aegis-core
```

Then update the `LANDING_ZONE_CONFIG` GitHub secret with the same content (so CI's `terraform plan` sees the values). The next baseline apply will add the `repository_id` claim to all 10 trust policies.

## Change-review checklist (per `docs/principles/change-review-discipline.md`)

1. **Blast radius.** Per-account: 4 trust policies in staging (plan / baseline / workload / teardown), 2 in management (plan / baseline), 2 in shared (plan / baseline), 2 sister-repo trust policies in staging (ECR / cache). 10 statements, 3 state files. Pre-activation diff: zero (the merge with an empty map is a no-op). Post-activation diff: each StringEquals gains one `:repository_id` key. No permission policy changes; no role rename; no resource recreate.
2. **Dependency assumptions.** GitHub OIDC always emits `repository_id` for tokens issued to a repo (documented in [GitHub OIDC token claims](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token)). The numeric IDs are constant across rename / transfer / re-creation of the textual name — that's the property we're leveraging. AWS IAM accepts arbitrary OIDC claims in `Condition` (no schema constraint).
3. **Deprecation status.** Nothing deprecated. `aws-actions/configure-aws-credentials` doesn't need a version bump — it forwards the OIDC token unchanged; AWS evaluates the claims. Terraform `merge()` and `try()` are stable across all supported provider versions.
4. **Rollback plan.** Two options. (a) Revert the PR; pre-activation no-op state means no resource diff. (b) Post-activation: leave the `.tf` as-is and remove `infra_repo_id` / `app_repo_id` from the secret + local config — the `try(..., null)` collapses the claim map to `{}` and the next apply removes the `:repository_id` key from each StringEquals. Either path is single-PR or single-config-edit.
5. **2 AM readability.** The `merge({ static }, local.optional_claim)` pattern reads top-to-bottom: "the static aud/sub is always there, plus whatever extra claim the optional config produces." A grep for `github_oidc_infra_repo_id_claim` lands directly on the local definition with the `try(...) != null ? {...} : {}` ternary — no indirection layer.

## Test plan

- [x] `terraform fmt -recursive terraform/environments/` — clean, no diffs
- [x] `python3 -c "yaml + jsonschema validate(example.yaml, schema.json)"` — example passes the updated schema
- [x] `grep -rn "1207149475|1207149088" terraform/ config/ scripts/` — zero matches (numeric IDs live only in `landing-zone.yaml` once populated, never in TF or example config)
- [ ] CI Terraform Plan matrix — all 5 layers must show ZERO changes pre-activation (the `merge()` with an empty-map fallback produces an identical statement to the current literal map). Post-activation (after secret + local config are updated with values), the next plan WILL show 10 trust-policy diffs adding the new `:repository_id` StringEquals key. After apply, drift settles. Subsequent CI runs are clean.
- [ ] Checkov

🤖 Generated with [Claude Code](https://claude.com/claude-code)