### PR TITLE
feat(security): ADR-031 Tier 3 — EventBridge alert on failed OIDC assumption

### DIFF
--- a/docs/decisions/031-tier-3-detective-controls.md
+++ b/docs/decisions/031-tier-3-detective-controls.md
@@ -1,0 +1,144 @@
+# 031. Tier 3 Detective Controls
+
+## Status
+
+Accepted (2026-05-04). Item A implemented in this PR; items B and C Accepted with implementation deferred to follow-up PRs.
+
+## Context
+
+[ADR-029](029-iam-permission-scope-down.md) closed Tier 1 — the over-privileged `github-actions-terraform` role was replaced by four purpose-scoped roles per account, keyed off the OIDC `sub` claim. [ADR-030](030-tier-2b-permission-boundary-hardening.md) closed Tier 2B — the SCP `deny-iam-privilege-escalation` plus the state bucket allow-list and OIDC `repository_id` claim raised the inner wall against the apply-tier-to-Admin privilege-escalation primitive. Together those tiers form the **preventive** layer of the fork-PR-OIDC + privilege-escalation defense.
+
+Tier 3 is the **detective** layer. It is asymmetric to the preventive tiers: it does not stop an attack, it surfaces one. The threat model that motivates it:
+
+- A fork PR slips past Layer 0 (rare, but past 24-hour drift in [ldz#170](https://github.com/BinHsu/aegis-aws-landing-zone/issues/170)'s `deployment_branch_policy: null` showed it is possible).
+- The fork attempts `sts:AssumeRoleWithWebIdentity` against one of the four `gh-tf-*` roles.
+- The trust policy's `:sub` claim check rejects the assumption — Tier 1 wall holds.
+- CloudTrail logs an `AccessDenied` STS event.
+- **Without alerting, this event sits in the Control Tower S3 archive unread.**
+
+The next operator (including future-Bin) finds out only by chance — searching CloudTrail months later for an unrelated reason. By then the attacker has either already pivoted or gone quiet. The detective layer's job is to convert "attempted breach" into a same-hour notification so the operator can investigate while the trail is fresh.
+
+A second motivating event class: `iam:CreateRole` / `iam:AttachRolePolicy` / `iam:PutRolePolicy` denials surfaced by ADR-030's SCP. If the apply-tier role's identity is ever used in a way that trips the SCP — by an attacker or by a buggy Terraform plan — the same alerting need applies. That class is documented as Item C below; this PR ships only Item A (the OIDC-failure case).
+
+### Architecture: EventBridge over CloudWatch Logs metric filter
+
+CloudTrail in this org is provisioned by AWS Control Tower. The trail is org-wide, KMS-encrypted with `alias/aegis-control-tower-key`, and archives to an S3 bucket in `aegis-logarchive`. The trail is **CT-managed — do not modify**. Two paths to alerting:
+
+| Path | Pros | Cons |
+|---|---|---|
+| CloudWatch Logs metric filter on CT log group | Standard pattern, supports complex pattern matching, history queryable via Logs Insights | Requires CT trail to send to CWL (it does not by default); would need a SECOND trail at ~$2/mo per account, ~$12/mo across the six-account org |
+| **EventBridge rule directly on CloudTrail events** | Free for AWS-source events, no second trail, simpler IaC, lower-latency than CWL flush | Per-account scope (each account's EventBridge sees only its own events), no historical replay, pattern matching is JSON-only (no full regex) |
+
+**Decision: EventBridge.** The per-account scope is acceptable for MVP because the management account is the highest-leverage target — org-mutating actions (`organizations:*`, `sso:*`, attaching SCPs, mutating IAM trust policies) all originate there. The mgmt account is also where the four `gh-tf-*` roles live, so a fork-PR-OIDC attempt against any of those four trips an STS event in the mgmt-account event bus. Per-account scope means the rule sees mgmt's local STS events only — an attempted assumption against `aegis-staging`'s cross-account roles would be invisible. That is acceptable for MVP and is the explicit deferral in Item B.
+
+CloudWatch Logs metric filter is the more featureful path but its cost — and more importantly its requirement to provision a second org trail to CloudWatch Logs in parallel with the CT-managed trail — makes it the wrong choice for an MVP that just wants to know "was a denied OIDC assumption attempted today?"
+
+### Why not GuardDuty + EventBridge
+
+GuardDuty IS deployed in `staging/platform/` (per [ADR-013](013-eks-architecture.md)). It is the right tool for runtime threat detection — anomalous instance behavior, container escapes, credential exfiltration patterns. It is **not** the right tool for "alert me when an OIDC trust policy is exercised in an expected-deny shape." GuardDuty findings are tuned to high-confidence anomalies; a routine fork-PR-OIDC attempt is at best a low-confidence finding (it could be a misconfigured legitimate workflow) and at worst silently filtered. The detective control wanted here is deterministic: every `errorCode` on an `AssumeRoleWithWebIdentity` event triggers the alert, no ML, no tuning. EventBridge with a literal pattern match is the deterministic shape.
+
+GuardDuty also has a meaningful runtime cost (~$5-10/mo per account for the workload-tier feature set in EKS) that is hard to justify for the detective-control purpose alone. It earns its keep on the runtime side.
+
+## Decision
+
+| Item | Layer | Action | Status |
+|---|---|---|---|
+| A | EventBridge | Rule on failed `AssumeRoleWithWebIdentity` in mgmt account → SNS → email | **SHIPPED in this PR** |
+| B | EventBridge | Same rule deployed to staging + shared accounts (multi-account event surface) | DEFERRED |
+| C | EventBridge | SCP-denied IAM mutation alert on `iam:Create*` / `iam:Put*` / `iam:Attach*` / `iam:PassRole` with `errorCode ∈ {AccessDenied, AccessDeniedException}` and principal not in allow-list | DEFERRED |
+
+### A. EventBridge rule on failed OIDC assumption (SHIPPED)
+
+A new file `terraform/environments/management/bootstrap/detective-controls.tf` lands the following resources:
+
+- `aws_sns_topic.security_alerts` — name `aegis-security-alerts`, KMS-encrypted with `alias/aws/sns` (the AWS-managed SNS key — see Open Question 1). Standard `local.tags`.
+- `aws_sns_topic_subscription.security_alerts_email` — protocol `email`, endpoint `local.config.budget.alert_emails[0]`. The first email in the list reuses the budget-alerts mailbox; one less config field for forkers (see Open Question 2). The subscription is created in `Pending Confirmation` state; AWS sends a confirmation email to the endpoint, the operator clicks the link once, and the subscription becomes `Confirmed`. Until confirmation, alerts queue but are not delivered. The `terraform apply` succeeds regardless of the confirmation state.
+- `aws_cloudwatch_event_rule.failed_oidc_assumption` — pattern matches `source: aws.sts` + `detail-type: AWS API Call via CloudTrail` + `eventName: AssumeRoleWithWebIdentity` + `errorCode: {exists: true}`. The `errorCode` exists-test is the simplest deterministic shape that catches every denial mode (AccessDenied, AccessDeniedException, NotAuthorizedException, MalformedPolicyDocument, etc.) without the rule needing to enumerate them.
+- `aws_cloudwatch_event_target.failed_oidc_assumption_to_sns` — fans the rule to the SNS topic. Includes an Input transformer so the email body reads `"AEGIS DETECTIVE: Failed OIDC assumption at <eventTime> from <sourceIp> by <principalId>. Error: <errorMessage>"` instead of the raw 2KB CloudTrail JSON. The transformer is small (4 input paths + 1 template line); the readability win is worth the lines.
+- `aws_sns_topic_policy.security_alerts` — allows EventBridge service principal `events.amazonaws.com` to publish to the topic, conditioned on `aws:SourceArn` equaling the EventBridge rule's ARN. Least-privilege: only this specific rule can publish, not any EventBridge rule in the account.
+
+### B. Same rule deployed to staging + shared accounts (DEFERRED)
+
+The mgmt-account-only scope of Item A means cross-account `gh-tf-*` role assumptions targeting staging or shared are not surfaced. Adding the same EventBridge rule to those accounts would fan their events into independent SNS topics + email subscriptions. Trade-off: more SNS topics (one per account, each with its own pending-confirmation email link), more alert sources to mentally aggregate, slightly higher operator cognitive load. For MVP, the mgmt-account event surface is the highest-leverage target; multi-account deployment graduates from "deferred" to "Item B PR" if the detective layer ever surfaces evidence of a cross-account assumption attempt that mgmt's rule missed.
+
+Implementation when materialized: add `terraform/environments/staging/bootstrap/detective-controls.tf` and `terraform/environments/shared/bootstrap/detective-controls.tf` with the same shape, parameterized by the per-account email list (which today is uniform across `local.config.budget.alert_emails[0]` — a future split might give each account its own mailbox).
+
+### C. SCP-denied IAM mutation alert (DEFERRED)
+
+A second EventBridge rule on `eventName ∈ {CreateRole, AttachRolePolicy, PutRolePolicy, CreateUser, AttachUserPolicy, PassRole}` AND `errorCode ∈ {AccessDenied, AccessDeniedException}` AND principal NOT in the same allow-list ADR-030's SCP uses (Control Tower / StackSets / `gh-tf-*` / `aegis-emergency-*` / Karpenter). The pattern match on principal-arn is the higher-complexity bit — EventBridge's JSON-pattern matching supports `anything-but` and `prefix` operators on string fields but the construction is verbose. The same effect can be achieved more elegantly via Logs Insights queries on the CT trail, which suggests Item C may end up as a CloudWatch Logs metric filter pattern (the second-trail cost is amortized across both Items B and C if both ship at the same time).
+
+Deferred because the construction is non-trivial and the value is incremental over Item A — Item A catches the trust-policy bypass attempts; Item C catches the post-bypass escalation attempts. The escalation surface is already closed by ADR-030's SCP at the prevent layer, so Item C is the second-line detection that confirms the SCP is doing its job. Useful, not urgent.
+
+## Alternatives Considered
+
+### A1. Rely on Control Tower's existing trail + S3 logs (no live alert)
+
+Rejected. The CT trail is the authoritative audit log, but it is read-only from the operator's perspective unless someone explicitly queries it. The detective control's purpose is exactly to remove the "someone has to remember to query" step. Without alerting, the trail is forensic evidence, not detection. Same data, different time-to-notice.
+
+### A2. Second org trail to CloudWatch Logs with metric filter
+
+Rejected for MVP. CloudWatch Logs metric filter is the standard pattern in AWS reference architectures (well-architected security pillar, CIS Benchmarks, etc.) and is the right answer at scale — it supports Logs Insights queries, full-regex pattern matching, and historical replay. The cost of running a second org trail is ~$2/mo per account for management events, and the CWL ingestion is another ~$0.50/GB. For a six-account org that is ~$15/mo of audit-only storage. Not large in absolute terms, but the EventBridge path costs $0/mo for the same MVP-shape detection. The CloudWatch Logs path graduates from "rejected" to "considered" if and when the detective layer needs Item C-class principal-allow-list pattern matching, which is genuinely awkward in raw EventBridge JSON.
+
+### A3. GuardDuty + EventBridge on findings
+
+Rejected for MVP, as detailed in Context. GuardDuty is a sibling layer (deployed in `staging/platform/`) for a different purpose (runtime threat detection). The ML-tuned finding shape is wrong for "deterministic alert on every `errorCode` on `AssumeRoleWithWebIdentity`."
+
+### A4. Slack webhook instead of SNS email
+
+Rejected for MVP. Slack webhook subscription requires either (a) an SNS-to-Slack Lambda (more moving parts, more IAM), (b) AWS Chatbot integration (account-level setup, narrower applicability for the lab), or (c) a direct SNS HTTPS subscription to a Slack incoming webhook URL. Option (c) is the simplest but Slack incoming webhook URLs are themselves secrets that would need SSM Parameter Store stashing per ADR-028. Email is a one-line subscription with no secret management. If the detective layer matures into Items B and C and the alert volume grows enough that email becomes noise, the path forward is documented Future Work below.
+
+## Consequences
+
+### Makes easier
+
+- A fork-PR-OIDC attempt that fails Tier 1's trust-policy check generates a same-hour email alert. Operator notices within hours, not months.
+- The audit trail of denied OIDC assumptions is queryable via the EventBridge rule's CloudWatch metrics (`MatchedEvents`) — operator can chart "denied-OIDC events per day" and notice burst patterns even without reading individual alerts.
+- The SNS topic is reusable for Item B/C extensions. Adding the SCP-denied IAM mutation rule (Item C) is one more `aws_cloudwatch_event_rule` + one more `aws_cloudwatch_event_target` pointing at the same topic; the operator's email subscription handles both event classes.
+- The detective layer makes the four-ADR progression (029 → 030 → 031) read as a coherent layered defense: 029 closes Tier 1 prevent, 030 closes Tier 2B prevent (inner wall), 031 closes Tier 3 detect.
+
+### Makes harder
+
+- One additional SNS subscription Bin must monitor. Single alert source is fine; if Items B and C both ship, the per-account topic count grows.
+- Alert fatigue if the pattern catches expected denials. For example: a contributor temporarily breaks the OIDC trust policy via a PR (during an ADR-029-style refactor), CI runs `terraform plan`, the assumption fails, an alert fires. The PR's plan failure is the primary signal; the email is duplicate noise. Mitigation: the alert template names the source IP and principal, so the operator can recognize "this is my own CI run from a PR" within seconds of reading.
+- A new permission scope on `gh-tf-apply-baseline` (mgmt account variant): `events:*` and `sns:*` scoped to the new rule + topic ARNs. This is a marginal expansion of the apply-tier role's surface; documented in Implementation Pointer below.
+
+### Risks
+
+- **SNS email throttle**: SNS limits email delivery to 24 emails per second per topic. If an attack burst (or a legitimately-broken CI loop) generates thousands of failed assumptions in a short window, alerts are throttled. Mitigation: the EventBridge rule's `MatchedEvents` metric is the source of truth for volume; the email is the human notification, not the audit log. CloudTrail remains the authoritative record.
+- **SCP/role policy changes that legitimately deny actions trigger noise**: any future policy tightening that lands during a transition window can cause a flood of expected-deny alerts. This is the same risk profile as the change-review-discipline checklist's step 1 ("blast radius") — the operator answers "does this change generate detective-layer alerts?" at PR time and pre-warns the inbox.
+- **Email subscription not confirmed**: AWS requires the operator to click a confirmation link in the welcome email. Until confirmed, the subscription is `Pending Confirmation` and alerts are silently dropped. The `terraform apply` succeeds regardless. Mitigation: the PR body's "Manual step" item documents this; the runbook for the layer (when materialized) will include a `aws sns list-subscriptions-by-topic` check as part of the apply post-flight.
+- **No cross-account event visibility**: per Architecture above, mgmt-account-scope is acceptable for MVP but is a real gap. Items B closes it.
+
+## Open Questions
+
+1. **Does an SCP-denied event surface as `AccessDenied` from STS or from the IAM API itself?** Empirical confirmation needed. The hypothesis: SCP denial on `iam:CreateRole` surfaces as an `AccessDenied` on the IAM API, not on STS — the STS assumption succeeded, the IAM call after it is what got denied. The Item A rule (STS-only) does NOT catch SCP denials; Item C is needed for that surface. The first apply of this PR is the test case: when `terraform-apply-baseline.yml` runs, the role assumes via STS successfully (Tier 1 + Tier 2B both pass), then the apply itself runs `events:PutRule` etc. — if any of those trip the SCP, the rule won't fire (correct behavior — SCP denials are out of scope of Item A). A separate test would deliberately attempt an out-of-allow-list `iam:CreateRole` from `gh-tf-apply-baseline` and observe whether the event surfaces in mgmt's EventBridge bus at all.
+
+2. **Should email go to `budget.alert_emails[0]` or a separate `security_alert_emails[0]` field?** Decision for MVP: reuse `budget.alert_emails[0]`. Rationale: forkers cloning this lab already have to populate `budget.alert_emails`; adding a `security_alert_emails` field is one more config-onboarding step for marginal benefit at MVP volume (estimated 0–1 alerts per week in steady state). The split graduates from "no" to "yes" if and when the alert volume crosses ~1 per day, at which point a dedicated mailbox or Slack channel is the right shape and `security_alert_emails` becomes the config field. Documented as future work; no schema change in this PR.
+
+3. **KMS encryption of the SNS topic — `alias/aws/sns` vs a project CMK?** The mgmt account does not currently provision a project KMS key — the only project keys live in `shared/bootstrap/kms-state.tf` (state encryption) and `staging/bootstrap` (secrets). Using either of those for SNS would require cross-account KMS key policy edits, which is out of scope for an MVP detective control. `alias/aws/sns` (AWS-managed) is the chosen shape: encryption-at-rest is preserved, key rotation is AWS-handled, no cross-account complexity. Graduating to a project CMK is reasonable when the security account materializes a `security/bootstrap` layer (not currently planned). Documented as future polish.
+
+## Future Work
+
+- **Slack/PagerDuty integration**: when alert volume justifies it, replace the email subscription with an SNS-to-Slack Lambda (or AWS Chatbot). The SNS topic stays; only the subscription leg changes.
+- **Items B + C**: as documented in Decision above. Item B is mechanical; Item C requires either a richer EventBridge pattern or a CloudWatch Logs metric filter (and the second-trail cost analysis).
+- **EventBridge → CloudWatch metric**: add a CloudWatch metric alarm on `aws_cloudwatch_event_rule.failed_oidc_assumption`'s `MatchedEvents` metric so the rule itself triggers a CloudWatch alarm if any matched event lands. Belt-and-suspenders against the SNS email queueing-without-confirmation case.
+- **Project CMK for SNS** when a mgmt-or-security KMS bootstrap layer materializes (Open Question 3).
+
+## Related
+
+- [ADR-029](029-iam-permission-scope-down.md) — Tier 1 (preventive). The trust-policy bypass attempts that this ADR's rule alerts on are exactly the ones Tier 1 rejects.
+- [ADR-030](030-tier-2b-permission-boundary-hardening.md) — Tier 2B (preventive). The SCP denials that Item C would alert on are exactly the ones the SCP enforces.
+- [ADR-005](005-compliance-framework-iso-27001.md) — ISO 27001 Annex A.8.16 ("Monitoring activities") is the compliance reference for this layer. Detective controls are an explicit ISO 27001 requirement; this ADR is the implementation evidence.
+- [`docs/principles/change-review-discipline.md`](../principles/change-review-discipline.md) — step 1 (blast radius) gains an implicit "does this change generate detective-layer alerts?" line. Documented in the principle doc as the next amendment.
+- [`docs/principles/break-glass-apply.md`](../principles/break-glass-apply.md) — break-glass actions are intentionally NOT alert-suppressed by this layer. A break-glass `aws iam put-role-policy` from `aegis-emergency-break-glass` is a normal API call (no SCP denial because the role is in the allow-list, no STS denial because the assumption is from PlatformAdmin SSO), so it produces no alert. This is correct behavior — break-glass leaves its trace in CloudTrail directly, not via the detective layer.
+
+## Appendix A — Implementation Pointer
+
+The PR ships:
+
+- `docs/decisions/031-tier-3-detective-controls.md` — this file.
+- `terraform/environments/management/bootstrap/detective-controls.tf` — the five resources detailed in Decision Item A. ~100 lines including header banner.
+- `terraform/environments/management/bootstrap/oidc-github-baseline-role.tf` — adds two new Sids to the policy: `EventsForDetectiveRule` (events:* scoped to the rule ARN pattern) and `SnsForDetectiveTopic` (sns:* scoped to the topic ARN pattern). Marginal expansion of apply-baseline scope.
+- `terraform/environments/management/bootstrap/oidc-github-plan-role.tf` — adds `events:Get*`, `sns:Get*`, `sns:List*` to the read-only Sid for plan-tier refresh / drift detection. The role already has `events:Describe*` and `events:List*`.
+
+No other files modified by this PR.

--- a/terraform/environments/management/bootstrap/detective-controls.tf
+++ b/terraform/environments/management/bootstrap/detective-controls.tf
@@ -1,0 +1,103 @@
+# -----------------------------------------------------------------------------
+# Tier 3 Detective Controls — ADR-031 Item A (SHIPPED)
+# -----------------------------------------------------------------------------
+# EventBridge rule on failed `AssumeRoleWithWebIdentity` events in the mgmt
+# account, fanning to an SNS topic with an email subscription. The detective
+# complement to ADR-029 (Tier 1 preventive) and ADR-030 (Tier 2B preventive).
+# Mgmt-account scope only at MVP; staging + shared deferred per ADR-031 Item B.
+# -----------------------------------------------------------------------------
+
+resource "aws_sns_topic" "security_alerts" {
+  # SNS topic for Tier 3 detective alerts. Subscribers receive a notification
+  # whenever the failed-OIDC-assumption rule (or any future Item B/C rule)
+  # matches an event. KMS-encrypted with the AWS-managed SNS key per ADR-031
+  # OQ-3 (no mgmt-account project CMK exists today).
+  name              = "aegis-security-alerts"
+  kms_master_key_id = "alias/aws/sns"
+
+  tags = local.tags
+}
+
+resource "aws_sns_topic_subscription" "security_alerts_email" {
+  # Email subscription to the alert topic. Endpoint reuses the budget-alerts
+  # mailbox per ADR-031 OQ-2 (one less config field for forkers at MVP).
+  # Subscription lands in `Pending Confirmation` state — operator must click
+  # the AWS-sent confirmation link before alerts deliver. The apply succeeds
+  # regardless.
+  topic_arn = aws_sns_topic.security_alerts.arn
+  protocol  = "email"
+  endpoint  = local.config.budget.alert_emails[0]
+}
+
+resource "aws_cloudwatch_event_rule" "failed_oidc_assumption" {
+  # EventBridge rule on failed `AssumeRoleWithWebIdentity` events. The
+  # `errorCode: {exists: true}` filter catches every denial mode (AccessDenied,
+  # AccessDeniedException, NotAuthorizedException, MalformedPolicyDocument)
+  # without enumerating them. Matches a fork-PR-OIDC trust-policy bypass
+  # attempt against any `gh-tf-*` role in the mgmt account.
+  name        = "aegis-detective-failed-oidc-assumption"
+  description = "Tier 3 detective: alert on failed AssumeRoleWithWebIdentity events (potential OIDC trust policy bypass attempt). ADR-031."
+
+  event_pattern = jsonencode({
+    source        = ["aws.sts"]
+    "detail-type" = ["AWS API Call via CloudTrail"]
+    detail = {
+      eventSource = ["sts.amazonaws.com"]
+      eventName   = ["AssumeRoleWithWebIdentity"]
+      errorCode   = [{ exists = true }]
+    }
+  })
+
+  tags = local.tags
+}
+
+resource "aws_cloudwatch_event_target" "failed_oidc_assumption_to_sns" {
+  # Fans matched events to the SNS topic. The input transformer reduces the
+  # 2KB raw CloudTrail JSON to a single human-readable line for the email
+  # body. `principalId` is the federated identity (e.g.,
+  # `AROAEXAMPLE:repo:fork-owner/fork-repo:ref:refs/heads/evil`); `sourceIp`
+  # is GitHub Actions' egress IP; `errorMessage` carries the trust-policy
+  # mismatch reason.
+  rule      = aws_cloudwatch_event_rule.failed_oidc_assumption.name
+  target_id = "send-to-sns-security-alerts"
+  arn       = aws_sns_topic.security_alerts.arn
+
+  input_transformer {
+    input_paths = {
+      eventTime    = "$.detail.eventTime"
+      sourceIp     = "$.detail.sourceIPAddress"
+      principalId  = "$.detail.userIdentity.principalId"
+      errorMessage = "$.detail.errorMessage"
+    }
+    input_template = "\"AEGIS DETECTIVE: Failed OIDC assumption at <eventTime> from <sourceIp> by <principalId>. Error: <errorMessage>\""
+  }
+}
+
+resource "aws_sns_topic_policy" "security_alerts" {
+  # Topic policy: only the EventBridge service principal can publish, and
+  # only on behalf of the specific rule above. `aws:SourceArn` pins the
+  # condition to the rule's ARN so any other EventBridge rule in the account
+  # (including future Items B/C, which would need their own statement
+  # additions or a parameterized policy refactor) cannot publish here.
+  arn = aws_sns_topic.security_alerts.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridgePublishFromDetectiveRule"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.security_alerts.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.failed_oidc_assumption.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
   # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-*/github-actions-*/gh-tf-*) plus the OIDC provider and account alias — see Sid IamScoped Resource list. The role is the apply-tier identity for `terraform-apply-baseline.yml` and must be able to manage the project's own IAM resources. Permission-management within a fixed prefix is the apply contract, not a misuse.
   # checkov:skip=CKV_AWS_290: Service-namespace wildcards (organizations:*, sso:*, identitystore:*) are needed because these AWS APIs do not support resource-level ARN constraints on most write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
   # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on AWS APIs without resource-level ARN support. Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
-  # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within the aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations (creating IRSA roles, OIDC providers, account aliases). Full IAM privileges on a fixed ARN-prefix scope is a deliberate design — an enumerated whitelist of iam:CreateRole/UpdateRole/DeleteRole/...x20+ would be a maintenance liability with the same effective surface. ADR-029 §Decision describes the apply-baseline scope.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within the aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations (creating IRSA roles, OIDC providers, account aliases). Full IAM privileges on a fixed ARN-prefix scope is a deliberate design — an enumerated whitelist of iam:CreateRole/UpdateRole/DeleteRole/...x20+ would be a maintenance liability with the same effective surface. ADR-029 §Decision describes the apply-baseline scope. Same pattern applies to `events:*` (scoped to `rule/aegis-detective-*`) and `sns:*` (scoped to `aegis-security-alerts*`) added by ADR-031 Item A.
   name = "apply-baseline-scoped"
   role = aws_iam_role.gh_tf_apply_baseline.id
 
@@ -187,6 +187,32 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
         Effect   = "Allow"
         Action   = "tag:*"
         Resource = "*"
+      },
+      {
+        # EventBridge rule mutation — scoped to the project's detective
+        # controls rule namespace. ADR-031 Item A creates the
+        # `aegis-detective-failed-oidc-assumption` rule on the default bus;
+        # this Sid covers PutRule / DeleteRule / PutTargets / RemoveTargets
+        # plus the tag-on-create flow Terraform uses. Resource ARN pins to
+        # the default event bus + `aegis-detective-*` rule prefix so a name
+        # outside the project namespace is denied.
+        Sid    = "EventsForDetectiveRule"
+        Effect = "Allow"
+        Action = "events:*"
+        Resource = [
+          "arn:aws:events:${local.primary_region}:${local.account_id}:rule/aegis-detective-*",
+          "arn:aws:events:${local.primary_region}:${local.account_id}:event-bus/default",
+        ]
+      },
+      {
+        # SNS topic mutation — scoped to the project's security-alerts
+        # topic namespace. ADR-031 Item A creates `aegis-security-alerts`;
+        # the prefix accommodates Items B/C if they add separate topics
+        # rather than reusing this one.
+        Sid      = "SnsForDetectiveTopic"
+        Effect   = "Allow"
+        Action   = "sns:*"
+        Resource = "arn:aws:sns:${local.primary_region}:${local.account_id}:aegis-security-alerts*"
       },
       {
         # Read shapes for `terraform plan` after apply (refresh + drift

--- a/terraform/environments/management/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-plan-role.tf
@@ -147,6 +147,12 @@ resource "aws_iam_role_policy" "gh_tf_plan" {
           "sqs:List*",
           "events:Describe*",
           "events:List*",
+          # ADR-031 Item A adds the `aegis-detective-failed-oidc-assumption`
+          # rule on the default bus + an SNS topic. Plan-tier refresh needs
+          # the read shapes for both services.
+          "events:Get*",
+          "sns:Get*",
+          "sns:List*",
           "ram:Get*",
           "ram:List*",
           "ec2:DescribeIpam*",


### PR DESCRIPTION
## Summary

Implements [ADR-031](docs/decisions/031-tier-3-detective-controls.md) Item A — the **detective** layer over Tier 1 ([ADR-029](docs/decisions/029-iam-permission-scope-down.md)) + Tier 2B ([ADR-030](docs/decisions/030-tier-2b-permission-boundary-hardening.md)) preventive walls.

A new `aws_cloudwatch_event_rule` in the mgmt account matches `AssumeRoleWithWebIdentity` events with any `errorCode` and fans them to a new `aegis-security-alerts` SNS topic with an email subscription to `local.config.budget.alert_emails[0]`. The threat model: a fork PR slips past Layer 0 (rare, but past 24-hour drift in #170 showed it is possible), attempts assumption, fails the trust policy `:sub` check, and CloudTrail logs the denial — without alerting the event sits in the CT archive unread. This rule converts that into a same-hour email.

Items B (multi-account event surface) and C (SCP-denied IAM mutation alert) are accepted-deferred to follow-up PRs, parallel to how ADR-030 staged its own B/C/D items.

Files:
- `docs/decisions/031-tier-3-detective-controls.md` — the ADR (~145 lines).
- `terraform/environments/management/bootstrap/detective-controls.tf` — the five resources detailed in ADR-031 §Decision A (~100 lines): `aws_sns_topic` + `aws_sns_topic_subscription` + `aws_cloudwatch_event_rule` + `aws_cloudwatch_event_target` (with input transformer) + `aws_sns_topic_policy`.
- `terraform/environments/management/bootstrap/oidc-github-baseline-role.tf` — adds `EventsForDetectiveRule` and `SnsForDetectiveTopic` Sids scoped to `aegis-detective-*` / `aegis-security-alerts*` ARN prefixes.
- `terraform/environments/management/bootstrap/oidc-github-plan-role.tf` — adds `events:Get*` / `sns:Get*` / `sns:List*` to the read-only Sid for plan-tier refresh.

## Change-review checklist (per `docs/principles/change-review-discipline.md`)

1. **Blast radius.** Mgmt-account-only. Resources: 1 SNS topic, 1 email subscription, 1 EventBridge rule, 1 rule target, 1 topic policy. IAM scope expansion: `events:*` and `sns:*` scoped to `aegis-detective-*` / `aegis-security-alerts*` ARN prefixes only — no other rule or topic name in the account is mutable by the apply-baseline role. The new rule does not fire on success, so no operational noise during normal CI runs.
2. **Dependency assumptions.** EventBridge default bus + AWS-managed SNS key (`alias/aws/sns`). Both are pre-existing AWS-managed resources; no provider/service additions. Email subscription requires a one-time manual confirmation click — `terraform apply` succeeds before that and the subscription stays `Pending Confirmation`. Documented as Manual Step below.
3. **Deprecation status.** None. `aws_cloudwatch_event_rule` and `aws_sns_topic` are stable in AWS provider v6.x ([provider docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule), [SNS topic docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic)). No deprecation notices on either resource as of provider 6.40.0 (current pin).
4. **Rollback plan.** `git revert` the commit. The EventBridge rule and SNS topic are independent of any other state — destroy is a no-op against running services. Email subscription is auto-deleted with the topic. No data persistence to drain.
5. **2 AM readability.** Each resource block has a 1-3 line comment explaining its purpose; the ADR carries the design rationale (~145 lines, threat model + alternative paths + open questions). A 2 AM operator opening `detective-controls.tf` sees the file's purpose in the first banner; opening the ADR sees Item A SHIPPED / B+C DEFERRED at the top of §Decision.

## Cost note

EventBridge for AWS-source events is free. SNS: $0.50 per million email deliveries (effectively free at expected volume — estimated 0–1 alerts per week in steady state). Total marginal cost: **$0/mo at MVP usage**. No second CloudTrail trail required (the alternative path; rejected in ADR-031 §A2).

## Test plan

- [ ] Wait for Checkov + all matrix Terraform Plan jobs to pass.
- [ ] After merge, `terraform-apply-baseline.yml` runs automatically. Verify in the AWS console: `aegis-security-alerts` SNS topic exists in mgmt account; `aegis-detective-failed-oidc-assumption` EventBridge rule exists; subscription is `Pending Confirmation`.
- [ ] Manual: click the AWS-sent confirmation link in the email to activate the subscription.
- [ ] Post-merge end-to-end test: temporarily change `gh-tf-plan` trust policy `:sub` to a wrong value (e.g., `repo:wrong-org/wrong-repo:*`), run a CI plan, observe the AccessDenied event, confirm the email alert arrives within ~5 minutes. Then revert.
- [ ] Confirm `MatchedEvents` metric on the EventBridge rule shows the test event.

## Manual step

After apply, AWS sends a confirmation email to `local.config.budget.alert_emails[0]`. **Click the confirmation link** to activate the subscription. Until then, alerts queue but are not delivered.

## Deviations from spec

- The user's spec assumed `events:PutRule` was already in `gh-tf-apply-baseline`'s scope. It was not (legacy `github-actions-terraform` admin role was removed in #182). This PR adds the minimal scoped `events:*` and `sns:*` Sids — same shape and same checkov-skip rationale as the existing `IamScoped` Sid (action wildcard, ARN-prefix-scoped Resource). Documented in ADR-031 §Appendix A and the role file's existing CKV2_AWS_40 skip annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)