### PR TITLE
fix(security): ADR-031 cold-apply IAM propagation guard (time_sleep 30s)

### DIFF
--- a/terraform/environments/management/bootstrap/detective-controls.tf
+++ b/terraform/environments/management/bootstrap/detective-controls.tf
@@ -7,6 +7,22 @@
 # Mgmt-account scope only at MVP; staging + shared deferred per ADR-031 Item B.
 # -----------------------------------------------------------------------------
 
+resource "time_sleep" "wait_for_apply_baseline_policy_propagation" {
+  # Cold-apply guard: AWS IAM has eventual consistency on policy updates of
+  # ~5-30 seconds. The same `terraform apply` that adds the `events:*` /
+  # `sns:*` Sids to `gh-tf-apply-baseline` ALSO creates the EventBridge rule
+  # and SNS topic, so without this sleep the assumed-role session cache may
+  # still be evaluating the OLD policy when CreateTopic / PutRule fires —
+  # AccessDeniedException on first cold-apply. PR #186's first apply hit
+  # exactly this race; rerun recovered cleanly because by then the policy had
+  # propagated. 30s is empirically sufficient for this account's policy size.
+  # `triggers` is intentionally omitted: the sleep fires on first create only,
+  # not on subsequent policy edits — once the resources exist, the race is
+  # past and re-waiting on every apply would be pure latency tax.
+  depends_on      = [aws_iam_role_policy.gh_tf_apply_baseline]
+  create_duration = "30s"
+}
+
 resource "aws_sns_topic" "security_alerts" {
   # SNS topic for Tier 3 detective alerts. Subscribers receive a notification
   # whenever the failed-OIDC-assumption rule (or any future Item B/C rule)
@@ -16,6 +32,8 @@ resource "aws_sns_topic" "security_alerts" {
   kms_master_key_id = "alias/aws/sns"
 
   tags = local.tags
+
+  depends_on = [time_sleep.wait_for_apply_baseline_policy_propagation]
 }
 
 resource "aws_sns_topic_subscription" "security_alerts_email" {
@@ -49,6 +67,8 @@ resource "aws_cloudwatch_event_rule" "failed_oidc_assumption" {
   })
 
   tags = local.tags
+
+  depends_on = [time_sleep.wait_for_apply_baseline_policy_propagation]
 }
 
 resource "aws_cloudwatch_event_target" "failed_oidc_assumption_to_sns" {

--- a/terraform/environments/management/bootstrap/versions.tf
+++ b/terraform/environments/management/bootstrap/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.40"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fix-it for the IAM eventual-consistency race that hit PR #186's first apply-baseline run on merge (`Apply management/bootstrap` → AccessDeniedException on `SNS:CreateTopic` + `events:TagResource`).

The same apply-baseline run both:

1. Updates `gh-tf-apply-baseline`'s inline policy to add `EventsForDetectiveRule` (`events:*`) + `SnsForDetectiveTopic` (`sns:*`) Sids.
2. Creates the EventBridge rule + SNS topic those Sids permit.

AWS IAM has eventual consistency on policy updates (~5–30s before assumed-role session caches see the new permissions). The race in #186: policy update completed at `09:54:17.24`, `SNS:CreateTopic` attempted at `~09:54:17.7`, `AccessDeniedException` returned because the active session was still evaluating the old policy.

`gh run rerun --failed` recovered cleanly because by retry time the policy had propagated. But a forker doing cold-apply would hit the same wall.

## Fix

Add a `time_sleep` resource that:
- `depends_on = [aws_iam_role_policy.gh_tf_apply_baseline]` — fires after the policy is written.
- `create_duration = "30s"` — empirical buffer for this account's policy size.
- No `triggers` — fires on first create only. Once the time_sleep resource exists in state, subsequent applies pass through in zero time. No latency tax on routine `terraform apply`.

The new SNS topic and EventBridge rule then `depends_on = [time_sleep.wait_for_apply_baseline_policy_propagation]`.

## Files

- `terraform/environments/management/bootstrap/versions.tf` — add `hashicorp/time ~> 0.13` provider.
- `terraform/environments/management/bootstrap/detective-controls.tf` — add `time_sleep` resource + `depends_on` on the SNS topic and EventBridge rule.

## Change-review checklist (5 steps)

1. **Blast radius**: mgmt/bootstrap only. The added resource is internal to the new detective-controls layer; no cross-layer impact. On Bin's already-applied repo, the apply will create the time_sleep, run the 30s wait once, no other diffs (existing SNS/EventBridge are stable). Forker cold-apply benefits.
2. **Dependency assumptions**: `hashicorp/time ~> 0.13` is HashiCorp-maintained, current major version, used widely in production AWS Terraform code. No transitive risk.
3. **Deprecation**: `time_sleep` is the canonical pattern for IAM-propagation waits — see Terraform AWS provider docs and HashiCorp's "AWS IAM eventual consistency" guidance. Not deprecated.
4. **Rollback plan**: revert the commit. The `time_sleep` resource is destroy-safe (it's metadata, no external state). Existing SNS/EventBridge resources stay put because the `depends_on` change is graph-only, not replacement-triggering.
5. **2 AM readability**: code comment explains the race + why `triggers` is omitted + why 30s. PR body links to #186's failure. Future-Bin or a forker reading the file in an incident sees the rationale inline.

## Test plan

- [ ] CI plan shows 1 to-create (`time_sleep`) and 0 changes to SNS / EventBridge / IAM policies.
- [ ] Apply on merge succeeds in one shot (no `--rerun --failed` needed).
- [ ] Subsequent unrelated apply-baseline runs do NOT re-execute the 30s wait (since `triggers` is omitted; `terraform plan` should show 0 diff on the `time_sleep` after first apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)