### PR TITLE
fix(security): SHA-pin third-party GitHub Actions (post-LinkedIn-Post-3 audit)

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run Checkov
         id: checkov
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@9201a8e6eaa919e3444d7c4ca691896efde4f033 # v12.3101.0
         with:
           directory: terraform/
           framework: terraform

--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -163,12 +163,12 @@ jobs:
           ${{ secrets.LANDING_ZONE_CONFIG }}
           EOFCONFIG
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/gh-tf-apply-baseline
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 

--- a/.github/workflows/terraform-apply-workload.yml
+++ b/.github/workflows/terraform-apply-workload.yml
@@ -61,12 +61,12 @@ jobs:
           fi
           echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-apply-workload
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -121,12 +121,12 @@ jobs:
           ")
           echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-apply-workload
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -177,12 +177,12 @@ jobs:
           ")
           echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-apply-workload
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -238,12 +238,12 @@ jobs:
           ")
           echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-apply-workload
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -170,12 +170,12 @@ jobs:
           echo "--- multi-region config patched ---"
           python3 -c "import yaml; c=yaml.safe_load(open('config/landing-zone.yaml')); print('eks.staging.regions length:', len(c['eks']['staging']['regions'])); print('vpcs keys:', list(c['accounts']['staging']['vpcs'].keys()))"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/gh-tf-plan
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 

--- a/.github/workflows/terraform-teardown-workload.yml
+++ b/.github/workflows/terraform-teardown-workload.yml
@@ -71,12 +71,12 @@ jobs:
           ")
           echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-teardown-workload
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -178,12 +178,12 @@ jobs:
           ")
           echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-teardown-workload
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -234,12 +234,12 @@ jobs:
           ")
           echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-teardown-workload
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -360,12 +360,12 @@ jobs:
           ")
           echo "account_id=${ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
 
-      - uses: aws-actions/configure-aws-credentials@v6
+      - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ steps.acct.outputs.account_id }}:role/gh-tf-teardown-workload
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ env.TF_VERSION }}
 


### PR DESCRIPTION
## Summary

Internal audit before posting LinkedIn Post 3 ("Private repo isn't a vulnerability shield") found ldz pinned third-party Actions to tags / moving branch refs — exactly the failure mode Post 3 calls out using the March 2025 \`tj-actions/changed-files\` incident as the reference attack.

## Changes

| Action | Before | After |
|---|---|---|
| \`aws-actions/configure-aws-credentials\` | \`@v6\` (tag) | \`@ec61189d14ec14c8efccab744f656cffd0e33f37\` # v6.1.0 |
| \`hashicorp/setup-terraform\` | \`@v4\` (tag) | \`@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85\` # v4.0.0 |
| \`bridgecrewio/checkov-action\` | \`@master\` (moving branch ref) | \`@9201a8e6eaa919e3444d7c4ca691896efde4f033\` # v12.3101.0 |

The \`bridgecrewio @master\` pin was the worst — moving branch ref means whatever the upstream pushes to \`master\` runs in CI with the workflow's declared permissions. Same shape as the March 2025 \`tj-actions/changed-files\` backdoor.

## Files

5 workflow files: \`terraform-plan\`, \`terraform-apply-baseline\`, \`terraform-apply-workload\`, \`terraform-teardown-workload\`, \`checkov\`. 21 lines changed.

## Out of scope

- GitHub-first-party Actions (\`actions/checkout\`, \`actions/github-script\`, \`github/codeql-action\`) remain on major-version tags. Different supply-chain trust boundary — GitHub controls the namespace.
- \`Actions allowlist\` (Settings → Actions → Allow specific actions) — currently \`allowed_actions: \"all\"\`. This is the second gap Post 3 calls out. Switching to \`selected\` mode has ongoing onboarding cost (every new Action needs allowlist entry); decision deferred to operator.

## Change-review checklist (5 steps)

1. **Blast radius**: 5 workflow files. CI runs against the new SHA pins on this PR's own \`Plan\` jobs and on the merge-to-main \`Apply (Baseline)\` job. Verifies the SHAs resolve cleanly.
2. **Dependency assumptions**: SHAs taken from the latest release tag of each Action repo (verified via \`gh api .../releases/latest\` + \`.../git/refs/tags/<tag>\`). \`bridgecrewio/checkov-action\` releases were stale on GitHub Releases, but the latest git tag \`v12.3101.0\` is current as of 2026-04-30.
3. **Deprecation status**: All three Actions are actively maintained, current major versions. Source: each Action's repo activity.
4. **Rollback plan**: revert the commit. SHA → tag is a single sed substitution; CI immediately uses the previous (looser) pinning.
5. **2 AM readability**: each \`uses:\` line has \`# vX.Y.Z\` comment so a future reader sees both the SHA and the human-readable version. Standard pinning style — see GitHub's "Using third-party actions" hardening guide.

## Test plan

- [ ] All Terraform Plan matrix jobs green (proves new SHAs resolve)
- [ ] Checkov job green (proves \`bridgecrewio/checkov-action@9201a8e6...\` runs cleanly)
- [ ] Apply-baseline run on merge succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)