### PR TITLE
docs(incidents): Incident 38 — baseline-apply state-lock race + auth drift

### DIFF
--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -2961,6 +2961,49 @@ The new SNS topic and EventBridge rule then `depends_on = [time_sleep.wait_for_a
 
 ---
 
+## Incident 38 — Concurrent baseline-apply runs race the S3 state lock; pre-existing auth↔platform remote-state drift surfaced (2026-05-18)
+
+**Date**: 2026-05-18 (v1.0.0 release prep; Dependabot PRs #197–#205, ADR-033 PR #216)
+**Severity**: S4
+**Duration**: ~30 min detect + recover
+
+### Symptom
+
+After nine Dependabot PRs were merged in a roughly 30-second burst during v1.0.0 release prep, `terraform-apply-baseline.yml` reported 7 of 8 layer jobs failed. The genuine baseline layers (`management/bootstrap`, `management/scps`, `shared/bootstrap`, `shared/ipam`, `staging/bootstrap`, `staging/secrets-persistent`) failed with `Error acquiring the state lock` / `api error PreconditionFailed`. `staging/auth` failed differently: `Unable to find remote state ... data.terraform_remote_state.staging_platform`.
+
+### Root cause
+
+Two independent causes converged on one wall of red.
+
+1. **No concurrency guard on `terraform-apply-baseline.yml`.** Each merge to `main` triggers a baseline-apply run. Nine merges in ~30 seconds spawned overlapping runs that contended for the same S3 state-lock objects. The loser of each race failed with `PreconditionFailed` on the lock `PutObject` — failing at lock *acquisition*, before any plan or apply, so each such failure was a clean no-op that changed nothing.
+2. **`staging/auth` reads a torn-down workload layer's state.** `data.terraform_remote_state.staging_platform` resolves to a backend key with no stored state, because `staging/platform` is a workload layer and the environment is torn down. This is pre-existing drift from the ADR-032 multi-region refactor (#210, 2026-05-17), independent of this session — a baseline-apply on a push the previous evening had already failed the same way.
+
+### Detection
+
+`gh run list --workflow="Terraform Apply (Baseline)"` showed a wall of `completed/failure`. `gh run view --log-failed` separated the two error classes. Run history showed a failure that pre-dated the session, isolating cause 2 as not session-induced.
+
+### Resolution
+
+Re-ran the latest baseline-apply run once, with no other baseline-apply runs active:
+
+```bash
+gh run rerun <run-id>
+```
+
+With no contention every genuine baseline layer acquired its lock and applied cleanly under AWS provider 6.44. `staging/auth` stayed red, as expected — its failure is structural, not transient. No `terraform force-unlock` was needed: the contention failures never held a lock to leave stale.
+
+### Prevention
+
+- Add a `concurrency:` group to `terraform-apply-baseline.yml` (`group: baseline-apply`, `cancel-in-progress: false`) so baseline applies serialize instead of racing. Until that lands, do not merge multiple baseline-touching PRs in a burst — pace them.
+- `staging/auth`'s dependency on a workload layer is the deeper issue. Under ADR-033 `staging/auth` is reclassified to the Platform tier and extracts out of the landing zone in v2; the cross-tier remote-state read is resolved there. Until v2, a red `staging/auth` baseline-apply *while the environment is torn down* is expected — do not treat it as a regression.
+
+### Lessons
+
+- "All plan CI green" does not imply "apply will succeed." Plan jobs run isolated; apply jobs contend for shared state. A repo with apply-on-merge automation needs a CI concurrency guard or paced merges — the absence of both is a latent defect that only surfaces under a merge burst.
+- When a batch operation yields a wall of failures, separate transient from structural before reacting. Here six failures were transient (lock races, cleared by one serial re-run) and one was structural (a missing dependency). Blind re-running would have "fixed" six and left the seventh looking new; dating the structural one against run history is what classified it correctly.
+
+---
+
 ## Adding a new incident
 
 Append new sections at the bottom, before this footer, using the format:

--- a/docs/interview-notes.md
+++ b/docs/interview-notes.md
@@ -202,7 +202,7 @@ Positive statements of what this project demonstrates, paired with explicit stat
 ### What is claimed
 
 - **Cross-cutting architectural design**: composing 10+ AWS services into a working multi-account landing zone with explicit decisions (ADRs) and documented trade-offs.
-- **Operational discipline**: 31 ADRs + 37 incident postmortems + 8 runbooks + 2 cross-cutting principle docs, each written to a consistent format, never softened retroactively.
+- **Operational discipline**: 33 ADRs + 38 incident postmortems + 8 runbooks + 2 cross-cutting principle docs, each written to a consistent format, never softened retroactively.
 - **Production-shaped patterns** — not production-*hardened* (the lab is single-operator, single-region-primary, no DR-tested, no SOC 2 audit trail). The patterns are transferable to production; the lab itself isn't production.
 - **Reproducibility**: a single `config/landing-zone.yaml` + two shell scripts land the whole foundation in a fresh AWS organization. Fork-and-deploy is not a slogan here; it's tested.
 


### PR DESCRIPTION
## What

Adds **Incident 38** to `docs/incidents.md` and syncs the stale operational-discipline counts in `docs/interview-notes.md` (31→33 ADRs, 37→38 incidents).

## Incident 38 summary

During v1.0.0 release prep, nine Dependabot PRs merged in a ~30s burst spawned overlapping `terraform-apply-baseline.yml` runs. Two independent failure causes:

1. **Lock race** — no `concurrency` guard on the baseline-apply workflow; parallel runs contended for the S3 state lock → `PreconditionFailed` at lock acquisition (clean no-ops).
2. **Pre-existing drift** — `staging/auth` reads `staging/platform` remote state; the platform layer is a torn-down workload layer. ADR-032 fallout, not session-induced (a run the prior evening had already failed identically).

Resolved by one serial baseline-apply re-run — all baseline layers applied green under AWS provider 6.44. `staging/auth` stays red while the environment is torn down; ADR-033 resolves it by reclassifying `auth` to the Platform tier in v2.

## Scope

Docs only — `incidents.md` + `interview-notes.md`. The recommended fix (a `concurrency:` group on `terraform-apply-baseline.yml`) is captured in the incident's Prevention section, not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)