### PR TITLE
fix(iam): allow gh-tf-apply-baseline to delete service-linked roles

### DIFF
--- a/terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf
@@ -70,6 +70,21 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
         ]
       },
       {
+        # IAM service-linked role lifecycle. The aws-service-role/* path is
+        # the only ARN shape AWS supports for these actions; the prefix
+        # bounds mutation to service-linked roles. SLRs may persist in an
+        # account after the consuming service is removed (AWS does not
+        # auto-delete them) — the apply-tier needs the delete API to
+        # reconcile state.
+        Sid    = "IamServiceLinkedRoleLifecycle"
+        Effect = "Allow"
+        Action = [
+          "iam:DeleteServiceLinkedRole",
+          "iam:GetServiceLinkedRoleDeletionStatus",
+        ]
+        Resource = "arn:aws:iam::${local.account_id}:role/aws-service-role/*"
+      },
+      {
         # Account alias — account-level operations. AWS IAM rejects any
         # resource-level ARN on these actions ("account-alias/*" is NOT
         # in the IAM-allowed-resource-path list); Resource: "*" is the


### PR DESCRIPTION
Fix for PR #218's `Apply staging/bootstrap` failure.

The descope-era policy trim removed `IamServiceLinkedRoleCreate` (Create for spot/eks), which incidentally also dropped `iam:DeleteServiceLinkedRole`. The staging account's Terraform state still holds `aws_iam_service_linked_role.spot` from an earlier apply, so `baseline-apply` after PR #218 errors at SLR destroy:

```
Error: deleting IAM Service Linked Role (AWSServiceRoleForEC2Spot): AccessDenied
... iam:DeleteServiceLinkedRole ... no identity-based policy allows the action
```

All ~20 other destroys completed in the same run; only the SLR is stuck in state.

Adds an `IamServiceLinkedRoleLifecycle` Sid to `gh-tf-apply-baseline` with `iam:DeleteServiceLinkedRole` + `iam:GetServiceLinkedRoleDeletionStatus` scoped to `arn:aws:iam::<account>:role/aws-service-role/*`. After merge the next baseline-apply destroys the SLR cleanly. May need a workflow_dispatch retry if the in-apply policy update + SLR destroy race goes the wrong way the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
