### PR TITLE
feat(prod/bootstrap): OIDC foundation (provider + gh-tf roles + break-glass)

### DIFF
--- a/terraform/environments/prod/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/prod/bootstrap/aegis-emergency-role.tf
@@ -1,0 +1,126 @@
+# -----------------------------------------------------------------------------
+# `aegis-emergency-break-glass` — break-glass recovery role (ADR-015 OQ-1)
+# -----------------------------------------------------------------------------
+# Materializes the `aegis-emergency-*` namespace reserved by ADR-015's SCP
+# allow-list (`deny-iam-privilege-escalation`). This is the prod-account
+# variant — see `terraform/environments/management/bootstrap/aegis-emergency-
+# role.tf` for the full design narrative and the recovery shape that
+# motivates the role.
+#
+# Scope difference from mgmt: no Organizations / SSO / IdentityStore Sids.
+# Those API surfaces only carry power in mgmt; in member accounts they
+# return empty inventories at best and produce no useful break-glass
+# primitive. The prod-account permission policy is therefore the IAM /
+# KMS / SSM PS subset.
+#
+# Trust policy: identical pattern to mgmt — local-account PlatformAdmin
+# SSO sessions only, time-bounded to 1 hour.
+#
+# SCP interaction: `aegis-emergency-break-glass` matches `aegis-emergency-*`
+# in ADR-015's SCP allow-list. No SCP change required by this PR.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "aegis_emergency_break_glass" {
+  name                 = "aegis-emergency-break-glass"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OperatorViaPlatformAdminSso"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${local.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
+  # checkov:skip=CKV_AWS_287: Read-shape Sids (IamReadAll, KmsReadAndDecrypt's Describe/List/Get verbs, StsAndTagRead) intentionally use Resource:* for inventory access during break-glass diagnosis. Mutation surface is in IamMutationOnProjectRoles, scoped or trust-policy-gated. ADR-015 OQ-1.
+  # checkov:skip=CKV_AWS_288: Same as 287 — break-glass requires broad read for diagnosis; mutations are scoped. Read-shape data disclosure is the explicit threat model accepted by ADR-015.
+  # checkov:skip=CKV_AWS_289: iam:* is intentionally allowed but scoped to aegis-*/gh-tf-*/github-actions-* prefixes. Permission-management within fixed prefixes is the break-glass contract.
+  # checkov:skip=CKV_AWS_290: Resource:* on read-only Sids is required because the corresponding AWS APIs do not support resource-level ARN constraints. Trust policy (PlatformAdmin SSO only) is the gate.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sids and on AWS APIs without resource-level ARN support.
+  # checkov:skip=CKV2_AWS_40: iam:* on a fixed ARN-prefix scope is the deliberate break-glass design (ADR-015 OQ-1 graduation).
+  name = "emergency-break-glass-scoped"
+  role = aws_iam_role.aegis_emergency_break_glass.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Scoped IAM mutation — the primary break-glass primitive.
+        Sid    = "IamMutationOnProjectRoles"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+        ]
+      },
+      {
+        # IAM read across the account. Diagnosis needs full inventory;
+        # mutations are bounded by IamMutationOnProjectRoles above.
+        Sid    = "IamReadAll"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:Simulate*",
+        ]
+        Resource = "*"
+      },
+      {
+        # KMS read + Decrypt scoped to local-account keys only. Required
+        # for reading SSM PS SecureString values during diagnosis. No
+        # Encrypt / GenerateDataKey — break-glass is read-recovery.
+        Sid    = "KmsReadAndDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Describe*",
+          "kms:List*",
+          "kms:Get*",
+          "kms:Decrypt",
+        ]
+        Resource = "arn:aws:kms:*:${local.account_id}:key/*"
+      },
+      {
+        # SSM PS read on `/aegis/*` paths only. Diagnosis often needs to
+        # confirm a parameter is present and decrypts cleanly. Read-only.
+        Sid    = "SsmReadProject"
+        Effect = "Allow"
+        Action = [
+          "ssm:Get*",
+          "ssm:Describe*",
+          "ssm:List*",
+        ]
+        Resource = "arn:aws:ssm:*:${local.account_id}:parameter/aegis/*"
+      },
+      {
+        # Identity + audit visibility. Read-only; AWS-API-shape Resource:*.
+        Sid    = "StsAndTagRead"
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "tag:Get*",
+          "iam:GenerateCredentialReport",
+          "iam:GenerateServiceLastAccessedDetails",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/prod/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/prod/bootstrap/oidc-github-baseline-role.tf
@@ -1,0 +1,168 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-apply-baseline` — apply role for `terraform-apply-baseline.yml` (ADR-014)
+# -----------------------------------------------------------------------------
+# Apply role for the `ref:refs/heads/main` trigger. The `pull_request` trigger
+# assumes its own read-only role, `gh-tf-plan`. These two are the only CI roles.
+#
+# Scope: the prod account's only landing-zone Terraform is `prod/bootstrap`
+# itself — the account alias, the GitHub OIDC provider, and the gh-tf-* /
+# aegis-emergency-* roles. The permission policy below is therefore exactly
+# IAM-on-project-prefixes + account alias + cross-account Terraform state.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_apply_baseline" {
+  name = "gh-tf-apply-baseline"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
+          # Rename-proof: the immutable repository_id (StringEquals above) is the
+          # binding; the sub wildcards the repo NAME so a repo rename cannot break
+          # OIDC auth (the failure this trust restructure fixes).
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
+  # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Simulate* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-014.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-014. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
+  # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-*/github-actions-*/gh-tf-*) plus the OIDC provider and account alias. Permission-management within a fixed prefix is the apply contract for the prod baseline role.
+  # checkov:skip=CKV_AWS_290: Service-namespace wildcard `tag:*` is needed because the AWS tagging API does not support resource-level ARN constraints on write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on the account-alias actions (AWS rejects resource-level ARNs there). Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations. Full IAM privileges on a fixed ARN-prefix is the deliberate apply-baseline design (ADR-014 §Decision).
+  name = "apply-baseline-scoped"
+  role = aws_iam_role.gh_tf_apply_baseline.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # IAM mutation — scoped to project-prefixed resources plus the
+        # OIDC provider. Covers aegis-* roles, github-actions-* (terraform CI
+        # roles), and gh-tf-* (this very layer's role family — supports
+        # in-place updates). Account alias management is a separate Sid
+        # below because AWS IAM does not accept resource-level ARNs on the
+        # alias actions.
+        Sid    = "IamScoped"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+          "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com",
+        ]
+      },
+      {
+        # Account alias — account-level operations. AWS IAM rejects any
+        # resource-level ARN on these actions ("account-alias/*" is NOT
+        # in the IAM-allowed-resource-path list); Resource: "*" is the
+        # only accepted shape. The trust policy `sub: ref:refs/heads/main`
+        # plus branch protection on main is the gate; the action set is
+        # narrowed to alias-only verbs (no other iam:* leaks through).
+        Sid    = "AccountAliasManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateAccountAlias",
+          "iam:DeleteAccountAlias",
+          "iam:ListAccountAliases",
+        ]
+        Resource = "*"
+      },
+      {
+        # State bucket cross-account read + write. State bucket lives in
+        # the shared account; this account's state object is read/written
+        # via cross-account bucket policy.
+        Sid    = "StateBucketCrossAccount"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketVersioning",
+        ]
+        Resource = [
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}",
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*",
+        ]
+      },
+      {
+        # State KMS — key lives in shared. Gated to S3 service usage so
+        # the role can decrypt state objects but not invoke KMS directly.
+        Sid    = "StateKmsViaS3Only"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey",
+        ]
+        Resource = "arn:aws:kms:${local.primary_region}:${local.config.accounts.shared.id}:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "s3.${local.primary_region}.amazonaws.com"
+          }
+        }
+      },
+      {
+        # Universal tagging — no service supports `tag:*` with a
+        # resource-level ARN; service-namespace scoping is the tightest
+        # contract.
+        Sid      = "TagApi"
+        Effect   = "Allow"
+        Action   = "tag:*"
+        Resource = "*"
+      },
+      {
+        # Read shapes for `terraform plan` after apply (refresh + drift
+        # detection). Resource: "*" is acceptable here because every
+        # action listed is read-only — metadata disclosure is classified
+        # as not-secret per CLAUDE.md threat model.
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "s3:GetBucket*",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetObjectLockConfiguration",
+          "s3:ListAllMyBuckets",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/prod/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/prod/bootstrap/oidc-github-plan-role.tf
@@ -1,0 +1,179 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-plan` — read-only role for `terraform-plan.yml` on PRs (ADR-014)
+# -----------------------------------------------------------------------------
+# Permission character: read-only AWS metadata + state-object read +
+# state-lock writes scoped to *.tflock + KMS via S3 service condition.
+#
+# Trust policy is keyed on the OIDC `sub` claim `pull_request` only — the
+# `main` trigger assumes its own apply role, `gh-tf-apply-baseline`. See
+# ADR-014 for the full identity-by-trigger split.
+#
+# This role purposefully cannot mutate any AWS resource other than the
+# Terraform state lockfile suffix. A leaked OIDC token from a fork-PR-OIDC
+# attack can at most run `terraform plan` and produce metadata disclosure
+# (which CLAUDE.md classifies as not-secret). This is the unlocking move
+# for closing fork-PR-OIDC as a meaningful blast-radius source.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_plan" {
+  name = "gh-tf-plan"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
+          # Rename-proof: the immutable repository_id (StringEquals above) is the
+          # binding; the sub wildcards the repo NAME so a repo rename cannot break
+          # OIDC auth (the failure this trust restructure fixes).
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:pull_request"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_plan" {
+  # checkov:skip=CKV_AWS_287: Read-only API surface (Get*/List*/Describe*) requires Resource:* — restrictable per-ARN scoping is not meaningful for inventory-style API calls. The policy's deny floor is mutation prevention, enforced via state-lock-suffix scoping (Sid WriteStateLockSuffixOnly) and the absence of any Create/Update/Delete actions. See ADR-014 §Decision and §Appendix A.2.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — data exfiltration via read-only metadata is the explicit threat model accepted by ADR-014. AWS account IDs, role ARNs, and similar metadata are classified non-secret per CLAUDE.md "What is NOT a secret" clause; the policy intentionally allows their disclosure to a fork-PR-OIDC-leaked token because the alternative (per-resource read scoping) is operationally infeasible for the breadth of reads `terraform plan` performs.
+  # checkov:skip=CKV_AWS_355: Resource:* on the ReadOnlyAwsApiSurface Sid is by design — every action in that statement is read-shape (Get*/List*/Describe*/Simulate*). No mutating action uses Resource:* in this policy.
+  name = "plan-readonly"
+  role = aws_iam_role.gh_tf_plan.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadStateObject"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:GetObjectVersion"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*"
+      },
+      {
+        Sid      = "ListStateBucket"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}"
+      },
+      {
+        Sid      = "WriteStateLockSuffixOnly"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:DeleteObject"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*.tflock"
+      },
+      {
+        # OQ-3 worst-case guard: `terraform plan -refresh=true` may write the
+        # state object during refresh. Allow PutObject on the state-key suffix
+        # to absorb that worst case. PR-1 will empirically observe whether
+        # plan-refresh writes state under our backend; if no, this statement
+        # tightens or is removed in a follow-up PR.
+        Sid      = "WriteStateOnRefreshGuard"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*.tfstate"
+      },
+      {
+        # KMS decryption gated by service condition. Two ViaService entries:
+        # - `s3.<region>.amazonaws.com` — for cross-account state-bucket
+        #   reads (state KMS lives in shared account)
+        # - `ssm.<region>.amazonaws.com` — for SSM PS SecureString reads
+        #   (each account's local KMS key encrypts /aegis/<env>/* secrets)
+        # Resource: "*" is bounded by the ViaService condition; without
+        # it the role cannot invoke KMS directly.
+        Sid      = "KmsForStateAndSsm"
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt", "kms:Encrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = "arn:aws:kms:*:*:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = [
+              "s3.${local.primary_region}.amazonaws.com",
+              "ssm.${local.primary_region}.amazonaws.com",
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "ec2:Describe*",
+          "eks:Describe*",
+          "eks:List*",
+          "s3:GetBucket*",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetObjectLockConfiguration",
+          "s3:ListAllMyBuckets",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "organizations:Describe*",
+          "organizations:List*",
+          # IAM Identity Center (formerly AWS SSO) — IAM service prefix
+          # is `sso:` even though the CLI verb is `aws sso-admin <command>`.
+          # Using `sso-admin:` here returns AccessDenied on every action.
+          "sso:Describe*",
+          "sso:List*",
+          "sso:Get*",
+          "identitystore:Describe*",
+          "identitystore:List*",
+          "identitystore:Get*",
+          "ssm:Describe*",
+          "ssm:Get*",
+          "ssm:List*",
+          "logs:Describe*",
+          "logs:List*",
+          "logs:Get*",
+          "sqs:Get*",
+          "sqs:List*",
+          "events:Describe*",
+          "events:List*",
+          "ram:Get*",
+          "ram:List*",
+          "ec2:DescribeIpam*",
+          "ec2:GetIpam*",
+          "fis:Get*",
+          "fis:List*",
+          "cognito-idp:Describe*",
+          "cognito-idp:List*",
+          "cognito-idp:Get*",
+          "cloudfront:Get*",
+          "cloudfront:List*",
+          "acm:Describe*",
+          "acm:List*",
+          "route53:Get*",
+          "route53:List*",
+          "ecr:Describe*",
+          "ecr:Get*",
+          "ecr:List*",
+          "elasticloadbalancing:Describe*",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/prod/bootstrap/oidc-github.tf
+++ b/terraform/environments/prod/bootstrap/oidc-github.tf
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------
+# GitHub OIDC Federation — prod account CI access
+# -----------------------------------------------------------------------------
+# Provides the OIDC provider that the gh-tf-* CI roles federate against. Each
+# role's trust + permission policy lives in its own .tf file (oidc-github-*-
+# role.tf). The two CI roles are `gh-tf-plan` and `gh-tf-apply-baseline`.
+#
+# Legacy `github-actions-terraform` (Admin) was removed by ADR-014 PR-7
+# cleanup; see incidents.md §Incident 12 for the rollout narrative.
+# -----------------------------------------------------------------------------
+
+locals {
+  github_org        = local.config.github.org
+  github_infra_repo = local.config.github.infra_repo
+  github_oidc_url   = "https://token.actions.githubusercontent.com"
+
+  github_infra_repo_id = try(local.config.github.infra_repo_id, null)
+
+  github_oidc_infra_repo_id_claim = local.github_infra_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_infra_repo_id
+  } : {}
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = local.github_oidc_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}

--- a/terraform/environments/prod/bootstrap/outputs.tf
+++ b/terraform/environments/prod/bootstrap/outputs.tf
@@ -7,3 +7,17 @@ output "account_alias" {
   description = "IAM account alias"
   value       = aws_iam_account_alias.this.account_alias
 }
+
+output "github_oidc_provider_arn" {
+  description = "GitHub OIDC identity provider ARN — referenced (data source) by workload repos' CI roles (e.g. aegis-platform-aws gh-tf-apply-platform). Account-foundation singleton owned here."
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+
+# -----------------------------------------------------------------------------
+# Break-glass recovery role — ADR-015 OQ-1 graduation
+# -----------------------------------------------------------------------------
+
+output "aegis_emergency_break_glass_role_arn" {
+  description = "ARN of the aegis-emergency-break-glass role for SSO PlatformAdmin assume during break-glass recovery"
+  value       = aws_iam_role.aegis_emergency_break_glass.arn
+}


### PR DESCRIPTION
## What

Ports the **staging/bootstrap IAM foundation → prod/bootstrap** so account `506221082337` can host CI-driven Terraform. Adds the four env-agnostic files (resolve to prod via `local.*`):

- `oidc-github.tf` — the GitHub OIDC provider (account-foundation singleton)
- `oidc-github-plan-role.tf` — `gh-tf-plan` (PR read-only)
- `oidc-github-baseline-role.tf` — `gh-tf-apply-baseline` (main apply)
- `aegis-emergency-role.tf` — `aegis-emergency-break-glass`

`outputs.tf` gains `github_oidc_provider_arn` + `aegis_emergency_break_glass_role_arn`.

## Why

Closes the **prod-foundation gap** (Stage 0) behind the platform-as-product joint-strike — see `aegis-platform-aws/docs/runbooks/prod-joint-strike-pattern-b.md`. The OIDC provider added here is the singleton that `aegis-platform-aws`'s `gh-tf-apply-platform` now references via a **data source** (its PR #15, merged).

## Not included by design

- **`gh-tf-apply-platform`** — that is platform-aws's own deploy role (its `envs/platform` composition, break-glass-seeded there). Workloads own their apply role, same as enclave's `gh-tf-apply-enclave`.
- **prod matrix rows** in `terraform-apply-baseline.yml` / `terraform-plan.yml` — deferred to a follow-up PR **after the first break-glass seed**, so the CI rows don't go red against a not-yet-existent prod `gh-tf-plan` / `gh-tf-apply-baseline`.

## Sequencing (chicken-and-egg)

First apply is **break-glass**: the org SCP `deny-iam-privilege-escalation` gates a human PlatformAdmin from creating the OIDC provider + `gh-tf-*` / `aegis-emergency-*` roles. The seed runs via the org's account-bootstrap path (operator). After the seed, the follow-up PR wires the CI matrix rows and the layer self-manages.

Offline `terraform validate` passes. No apply has run against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)