### PR TITLE
feat(prod/bootstrap): wire prod into CI plan + apply matrices (post-seed)

### DIFF
--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -60,6 +60,8 @@ jobs:
             account_id: "345895787808"
           - env: staging/bootstrap
             account_id: "251774439261"
+          - env: prod/bootstrap
+            account_id: "506221082337"
           - env: management/scps
             account_id: "186052668286"
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -43,6 +43,8 @@ jobs:
             account_id: "345895787808"
           - env: staging/bootstrap
             account_id: "251774439261"
+          - env: prod/bootstrap
+            account_id: "506221082337"
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What

Adds `{ env: prod/bootstrap, account_id: "506221082337" }` to the `include` matrix of both:
- `terraform-plan.yml` (PR plan via `gh-tf-plan`)
- `terraform-apply-baseline.yml` (main apply via `gh-tf-apply-baseline`; placed before `management/scps` per the documented "foundation first, SCPs last" order)

## Why now

`prod/bootstrap` is now **break-glass-seeded** — OIDC provider + `gh-tf-plan` + `gh-tf-apply-baseline` + `aegis-emergency-break-glass` are live in `506221082337`, state migrated to the shared S3 backend (`terraform plan` = No changes). The foundation PR (#241) deliberately deferred these matrix rows until the seed existed, so they go **green** instead of red against a not-yet-existent role.

**This PR's own `Plan prod/bootstrap` row is the end-to-end CI validation of the seed** — it assumes the freshly-created `gh-tf-plan` in prod and plans clean.

After merge, prod/bootstrap self-manages via CI like the other account-fabric layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)