### PR TITLE
fix(scp): correct ACK IAM controller carve-out prefix (missing "aws")

### DIFF
--- a/terraform/environments/management/scps/main.tf
+++ b/terraform/environments/management/scps/main.tf
@@ -236,7 +236,7 @@ resource "aws_organizations_policy" "deny_iam_privilege_escalation" {
               "arn:aws:iam::*:role/gh-tf-*",
               "arn:aws:iam::*:role/aegis-emergency-*",
               "arn:aws:iam::*:role/*-karpenter-controller",
-              "arn:aws:iam::*:role/aegis-platform-ack-iam-*",
+              "arn:aws:iam::*:role/aegis-platform-aws-ack-iam-*",
             ]
           }
         }


### PR DESCRIPTION
The `DenyIamPrivilegeEscalation` `ArnNotLike` carve-out listed `aegis-platform-ack-iam-*`, but the ACK IAM controller's IRSA role is named `aegis-platform-aws-ack-iam-<region>` (`aegis-platform-aws/irsa-ack-iam.tf` line 32 — its banner says the prefix MUST be kept), and this SCP's own comment (lines 176/184) already documents `aegis-platform-aws-ack-iam-*`. The live glob dropped the `aws` segment.

**Impact:** without this, the ACK controller principal does not match the carve-out → its `iam:CreateRole` for workload IAM under `/aegis-workload/*` is SCP-denied → workload self-ownership (ADR-07) breaks. Prep for the prod platform-as-product joint-strike.

One-segment fix; offline `terraform validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)