### PR TITLE
feat(fabric): Deployments OU + aegis-deployment account for the shared release registry (ADR-018, proposal)

### DIFF
--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - 'terraform/environments/management/**'
       - 'terraform/environments/shared/**'
+      - 'terraform/environments/deployment/bootstrap/**'
       - 'terraform/environments/staging/bootstrap/**'
       - 'terraform/environments/prod/bootstrap/**'
       - 'config/**'
@@ -58,6 +59,8 @@ jobs:
             account_id: "345895787808"
           - env: shared/ipam
             account_id: "345895787808"
+          - env: deployment/bootstrap
+            account_id: "162975888022"
           - env: staging/bootstrap
             account_id: "251774439261"
           - env: prod/bootstrap

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -41,6 +41,8 @@ jobs:
             account_id: "345895787808"
           - env: shared/ipam
             account_id: "345895787808"
+          - env: deployment/bootstrap
+            account_id: "162975888022"
           - env: staging/bootstrap
             account_id: "251774439261"
           - env: prod/bootstrap

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ terraform init && terraform plan
 
 ## Build phases
 
-Status reflects what exists in `main`. The 6-account fabric is complete; a 7th account (`aegis-deployment`, Deployments OU) is **proposed** in [ADR-018](docs/decisions/018-deployments-ou-and-shared-registry-account.md) — config + bootstrap Terraform are in the tree, but account creation is operator/Control-Tower-gated and the id is a placeholder until vended.
+Status reflects what exists in `main`. The account fabric is complete: the 7th account (`aegis-deployment`, Deployments OU) was vended via Control Tower on 2026-06-10 per [ADR-018](docs/decisions/018-deployments-ou-and-shared-registry-account.md); its bootstrap layer applies through the standard CI path once the per-account roles are seeded.
 
 | Phase | Scope | Cost | Status |
 |-------|-------|------|--------|
@@ -147,7 +147,7 @@ Status reflects what exists in `main`. The 6-account fabric is complete; a 7th a
 | 2. GitOps Pipeline | plan/apply workflows, Checkov, pre-commit, signed commits | ~Free | **Done** |
 | 3. IPAM | Org-wide IPAM + RAM cross-account sharing (ADR-012) | ~$0 idle | **Done** |
 | 4. Security baseline | Organizational CloudTrail, AWS Config, GuardDuty, IAM scope-down ladder (ADR-014–016) | ~$5/mo | **Done** |
-| 5. Deployments OU + registry account | Deployments OU + `aegis-deployment` bootstrap for the shared release-artifact registry (ADR-018; ECR lives in `aegis-platform-aws`) | ~Free fabric; ECR billed downstream | **Proposed** |
+| 5. Deployments OU + registry account | Deployments OU + `aegis-deployment` bootstrap for the shared release-artifact registry (ADR-018; ECR lives in `aegis-platform-aws`) | ~Free fabric; ECR billed downstream | **Account vended — first bootstrap apply pending role seed** |
 
 ## Reliability & Recovery Posture
 
@@ -162,7 +162,7 @@ The [improvements directory](docs/improvements/) is the productionization roadma
 
 ## Architecture Decision Records
 
-All ADRs are **Accepted** except ADR-018, which is **Proposed** (the Deployments OU + registry account; account creation is operator-gated).
+All ADRs are **Accepted**.
 
 | ADR | Decision |
 |-----|----------|
@@ -183,7 +183,8 @@ All ADRs are **Accepted** except ADR-018, which is **Proposed** (the Deployments
 | [015](docs/decisions/015-permission-boundary-hardening.md) | IAM permission-boundary hardening |
 | [016](docs/decisions/016-detective-controls.md) | Detective control — alert on failed OIDC assumption |
 | [017](docs/decisions/017-platform-tier-extraction.md) | Platform tier extracted from the landing zone |
-| [018](docs/decisions/018-deployments-ou-and-shared-registry-account.md) | Deployments OU + `aegis-deployment` account for the shared release-artifact registry (Proposed) |
+| [018](docs/decisions/018-deployments-ou-and-shared-registry-account.md) | Deployments OU + `aegis-deployment` account for the shared release-artifact registry |
+| [019](docs/decisions/019-budgets-iac-and-oidc-fail-closed.md) | Budgets are IaC and the OIDC trust fails closed |
 
 ## Runbooks
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Software is a bridge; business is the ground beneath it. A bridge can be rebuilt; a foundation cannot. This landing zone is built in that posture — speed where it helps, sovereignty where it matters, automation that assumes human judgment rather than replaces it — so that whatever the principals above decide to build can stand on ground that holds.
 
-What that looks like in practice: six AWS accounts under a single Organization with SCPs enforcing guardrails before any workload runs. Zero static credentials — humans authenticate through SSO, CI through OIDC federation. Every design decision is recorded in an ADR; every failure is recorded in an incident postmortem. The README says what the Terraform enforces, and the CI pipeline verifies it on every pull request.
+What that looks like in practice: seven AWS accounts under a single Organization with SCPs enforcing guardrails before any workload runs. Zero static credentials — humans authenticate through SSO, CI through OIDC federation. Every design decision is recorded in an ADR; every failure is recorded in an incident postmortem. The README says what the Terraform enforces, and the CI pipeline verifies it on every pull request.
 
 > A reference implementation of a production-grade multi-account AWS **account fabric**, managed entirely through GitOps — for single-operator labs and small-team deployments that want AWS best-practice structure without the enterprise overhead.
 
@@ -24,7 +24,7 @@ This repository is the **account fabric**: the multi-account AWS governance plan
 
 ## Features at a glance
 
-- **Multi-account AWS Organizations** — 6 accounts under Control Tower, 3 OUs, custom SCPs aligned to ISO 27001:2022 Annex A
+- **Multi-account AWS Organizations** — 7 accounts under Control Tower, 4 OUs, custom SCPs aligned to ISO 27001:2022 Annex A
 - **Zero static credentials** — AWS IAM Identity Center for humans, GitHub OIDC for CI/CD; no IAM users (enforced by SCP, not just policy)
 - **Terraform ≥ 1.10 with S3 native state locking** — no DynamoDB, Terraservices layered state (ADR-003)
 - **GitHub Actions GitOps pipeline** — plan on PR, apply on merge, Checkov security scan, all required status checks
@@ -78,6 +78,10 @@ flowchart TB
       Shared["aegis-shared<br/>Terraform state · IPAM"]
     end
 
+    subgraph Dep["OU: Deployments"]
+      Deploy["aegis-deployment<br/>Shared ECR registry<br/>(build once · promote by digest)"]
+    end
+
     subgraph Wrk["OU: Workloads"]
       Stg["aegis-staging"]
       Prd["aegis-prod"]
@@ -87,6 +91,7 @@ flowchart TB
   CI -. OIDC federation<br/>(no static creds) .-> Org
   Mgmt -. SCPs .-> Sec
   Mgmt -. SCPs .-> Inf
+  Mgmt -. SCPs .-> Dep
   Mgmt -. SCPs .-> Wrk
 ```
 
@@ -133,7 +138,7 @@ terraform init && terraform plan
 
 ## Build phases
 
-Status reflects what exists in `main`. The account fabric is complete.
+Status reflects what exists in `main`. The 6-account fabric is complete; a 7th account (`aegis-deployment`, Deployments OU) is **proposed** in [ADR-018](docs/decisions/018-deployments-ou-and-shared-registry-account.md) — config + bootstrap Terraform are in the tree, but account creation is operator/Control-Tower-gated and the id is a placeholder until vended.
 
 | Phase | Scope | Cost | Status |
 |-------|-------|------|--------|
@@ -142,6 +147,7 @@ Status reflects what exists in `main`. The account fabric is complete.
 | 2. GitOps Pipeline | plan/apply workflows, Checkov, pre-commit, signed commits | ~Free | **Done** |
 | 3. IPAM | Org-wide IPAM + RAM cross-account sharing (ADR-012) | ~$0 idle | **Done** |
 | 4. Security baseline | Organizational CloudTrail, AWS Config, GuardDuty, IAM scope-down ladder (ADR-014–016) | ~$5/mo | **Done** |
+| 5. Deployments OU + registry account | Deployments OU + `aegis-deployment` bootstrap for the shared release-artifact registry (ADR-018; ECR lives in `aegis-platform-aws`) | ~Free fabric; ECR billed downstream | **Proposed** |
 
 ## Reliability & Recovery Posture
 
@@ -156,7 +162,7 @@ The [improvements directory](docs/improvements/) is the productionization roadma
 
 ## Architecture Decision Records
 
-All ADRs are **Accepted**.
+All ADRs are **Accepted** except ADR-018, which is **Proposed** (the Deployments OU + registry account; account creation is operator-gated).
 
 | ADR | Decision |
 |-----|----------|
@@ -176,6 +182,8 @@ All ADRs are **Accepted**.
 | [014](docs/decisions/014-iam-permission-scope-down.md) | CI OIDC role scope-down |
 | [015](docs/decisions/015-permission-boundary-hardening.md) | IAM permission-boundary hardening |
 | [016](docs/decisions/016-detective-controls.md) | Detective control — alert on failed OIDC assumption |
+| [017](docs/decisions/017-platform-tier-extraction.md) | Platform tier extracted from the landing zone |
+| [018](docs/decisions/018-deployments-ou-and-shared-registry-account.md) | Deployments OU + `aegis-deployment` account for the shared release-artifact registry (Proposed) |
 
 ## Runbooks
 
@@ -228,6 +236,7 @@ aegis-landing-zone-aws/
 │       │   ├── bootstrap/         # State bucket, OIDC
 │       │   ├── ipam/              # Org-wide IPAM pools + RAM share
 │       │   └── aft/               # AFT code (committed, not deployed — ADR-011 Path A)
+│       ├── deployment/bootstrap/  # Alias, GitHub OIDC provider, gh-tf-* + break-glass (ADR-018; ECR lives in aegis-platform-aws)
 │       ├── staging/bootstrap/     # Alias, GitHub OIDC provider, gh-tf-* + break-glass roles
 │       └── prod/bootstrap/        # Alias only
 ├── scripts/

--- a/config/landing-zone.example.yaml
+++ b/config/landing-zone.example.yaml
@@ -33,6 +33,18 @@ accounts:
     id: "444444444444"
     email: "aws-aegis-shared@example.com"
     ou: Infrastructure
+  deployment:
+    # Shared release-artifact registry (ECR) for the build-once /
+    # promote-by-digest model (platform-aws ADR-10, this repo ADR-018).
+    # Distinct from `shared` by category: `shared` holds the control-plane
+    # state backend + IPAM + OIDC anchor; `deployment` holds the immutable
+    # release artifact that staging and prod both pull by digest. Lives in
+    # the Deployments OU. Account-creation is operator/Control-Tower-gated;
+    # leave id as the empty string until the account is vended, then fill in
+    # the 12-digit id (the `^$|^[0-9]{12}$` schema pattern permits empty).
+    id: ""
+    email: "aws-aegis-deployment@example.com"
+    ou: Deployments
   staging:
     id: "555555555555"
     email: "aws-aegis-staging@example.com"

--- a/config/schema.json
+++ b/config/schema.json
@@ -56,6 +56,7 @@
         "security",
         "logarchive",
         "shared",
+        "deployment",
         "staging",
         "prod"
       ],

--- a/config/schema.json
+++ b/config/schema.json
@@ -65,6 +65,7 @@
         "security": { "$ref": "#/$defs/account" },
         "logarchive": { "$ref": "#/$defs/account" },
         "shared": { "$ref": "#/$defs/account" },
+        "deployment": { "$ref": "#/$defs/account" },
         "staging": { "$ref": "#/$defs/account" },
         "prod": { "$ref": "#/$defs/account" }
       }
@@ -259,8 +260,8 @@
         },
         "ou": {
           "type": "string",
-          "enum": ["root", "Security", "Infrastructure", "Workloads"],
-          "description": "Target OU placement per ADR-006"
+          "enum": ["root", "Security", "Infrastructure", "Deployments", "Workloads"],
+          "description": "Target OU placement per ADR-006 (Deployments OU added in ADR-018)"
         }
       }
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ flowchart TB
   end
 
   subgraph Deployments["OU: Deployments (proposed — ADR-018)"]
-    Deploy["aegis-deployment<br/><br/>Shared ECR registry<br/>build once · promote by digest<br/>bootstrap only here;<br/>ECR in aegis-platform-aws"]
+    Deploy["aegis-deployment<br/><br/>Shared ECR registry<br/>build once · promote by digest<br/>bootstrap only here<br/>ECR in aegis-platform-aws"]
   end
 
   subgraph Work["OU: Workloads"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Each diagram is cross-referenced to the Architecture Decision Record (ADR) that 
 
 ## 1. Account Topology
 
-AWS Organizations structure with the seven accounts, four OUs, and SCP attachment point. See [ADR-006](decisions/006-account-taxonomy-and-ou-structure.md) for rationale and [ADR-018](decisions/018-deployments-ou-and-shared-registry-account.md) for the Deployments OU + `aegis-deployment` (Proposed — account creation is operator-gated, id is a placeholder until vended).
+AWS Organizations structure with the seven accounts, four OUs, and SCP attachment point. See [ADR-006](decisions/006-account-taxonomy-and-ou-structure.md) for rationale and [ADR-018](decisions/018-deployments-ou-and-shared-registry-account.md) for the Deployments OU + `aegis-deployment` (vended 2026-06-10).
 
 ```mermaid
 flowchart TB
@@ -28,7 +28,7 @@ flowchart TB
     Shared["aegis-shared<br/><br/>Terraform state bucket<br/>IPAM pools<br/>GitHub OIDC<br/>AFT (committed, not deployed)"]
   end
 
-  subgraph Deployments["OU: Deployments (proposed — ADR-018)"]
+  subgraph Deployments["OU: Deployments (ADR-018)"]
     Deploy["aegis-deployment<br/><br/>Shared ECR registry<br/>build once · promote by digest<br/>bootstrap only here<br/>ECR in aegis-platform-aws"]
   end
 
@@ -177,7 +177,7 @@ flowchart TB
 
 IPAM is the org-wide CIDR allocation authority ([ADR-012](decisions/012-ipam-and-cidr-allocation.md)): it RAM-shares regional pools to the whole organization, and downstream VPCs in the member accounts allocate their CIDRs from those pools via `ipv4_ipam_pool_id` rather than hand-planning ranges. The pools live here; the VPCs that consume them do not.
 
-**State key convention:** `<account>/<layer>/terraform.tfstate`. Live layers: management/bootstrap, management/scps, shared/bootstrap, shared/ipam, shared/aft, staging/bootstrap, prod/bootstrap. Proposed (ADR-018): deployment/bootstrap — applies once the `aegis-deployment` account is vended.
+**State key convention:** `<account>/<layer>/terraform.tfstate`. Live layers: management/bootstrap, management/scps, shared/bootstrap, shared/ipam, shared/aft, deployment/bootstrap (ADR-018), staging/bootstrap, prod/bootstrap.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Each diagram is cross-referenced to the Architecture Decision Record (ADR) that 
 
 ## 1. Account Topology
 
-AWS Organizations structure with the six accounts, three OUs, and SCP attachment point. See [ADR-006](decisions/006-account-taxonomy-and-ou-structure.md) for rationale.
+AWS Organizations structure with the seven accounts, four OUs, and SCP attachment point. See [ADR-006](decisions/006-account-taxonomy-and-ou-structure.md) for rationale and [ADR-018](decisions/018-deployments-ou-and-shared-registry-account.md) for the Deployments OU + `aegis-deployment` (Proposed — account creation is operator-gated, id is a placeholder until vended).
 
 ```mermaid
 flowchart TB
@@ -28,6 +28,10 @@ flowchart TB
     Shared["aegis-shared<br/><br/>Terraform state bucket<br/>IPAM pools<br/>GitHub OIDC<br/>AFT (committed, not deployed)"]
   end
 
+  subgraph Deployments["OU: Deployments (proposed — ADR-018)"]
+    Deploy["aegis-deployment<br/><br/>Shared ECR registry<br/>build once · promote by digest<br/>bootstrap only here;<br/>ECR in aegis-platform-aws"]
+  end
+
   subgraph Work["OU: Workloads"]
     Stg["aegis-staging<br/><br/>bootstrap only"]
     Prd["aegis-prod<br/><br/>bootstrap only"]
@@ -36,9 +40,11 @@ flowchart TB
   Org --> Mgmt
   Org --> Security
   Org --> Infra
+  Org --> Deployments
   Org --> Work
   Mgmt -. SCPs .-> Security
   Mgmt -. SCPs .-> Infra
+  Mgmt -. SCPs .-> Deployments
   Mgmt -. SCPs .-> Work
 ```
 
@@ -171,7 +177,7 @@ flowchart TB
 
 IPAM is the org-wide CIDR allocation authority ([ADR-012](decisions/012-ipam-and-cidr-allocation.md)): it RAM-shares regional pools to the whole organization, and downstream VPCs in the member accounts allocate their CIDRs from those pools via `ipv4_ipam_pool_id` rather than hand-planning ranges. The pools live here; the VPCs that consume them do not.
 
-**State key convention:** `<account>/<layer>/terraform.tfstate`. Live layers: management/bootstrap, management/scps, shared/bootstrap, shared/ipam, shared/aft, staging/bootstrap, prod/bootstrap.
+**State key convention:** `<account>/<layer>/terraform.tfstate`. Live layers: management/bootstrap, management/scps, shared/bootstrap, shared/ipam, shared/aft, staging/bootstrap, prod/bootstrap. Proposed (ADR-018): deployment/bootstrap — applies once the `aegis-deployment` account is vended.
 
 ---
 

--- a/docs/decisions/018-deployments-ou-and-shared-registry-account.md
+++ b/docs/decisions/018-deployments-ou-and-shared-registry-account.md
@@ -2,12 +2,15 @@
 
 ## Status
 
-Proposed (2026-06-05)
+Accepted (2026-06-10 — account vended: 162975888022)
 
-Account creation is operator/Control-Tower-gated. This ADR records the fabric-side
-decision; the account id stays a placeholder (empty string) in
-`config/landing-zone.example.yaml` until the account is vended. The ECR registry
-that justifies the account does **not** live here — it is the platform tier's job
+Account creation is operator/Control-Tower-gated; the operator vended the account
+via Control Tower on 2026-06-10 (OU `Deployments`, status ACTIVE). The vended
+account NAME is `aegis-deployments` (plural, cosmetic only); the config key stays
+`deployment` (singular) per this ADR — code and config never read the display
+name. The account id lives in the operator's `LANDING_ZONE_CONFIG` secret;
+`config/landing-zone.example.yaml` keeps a placeholder. The ECR registry that
+justifies the account does **not** live here — it is the platform tier's job
 ([ADR-017](017-platform-tier-extraction.md)) and ships in the `aegis-platform-aws`
 sibling PR.
 
@@ -55,10 +58,11 @@ Concretely, this repository:
 
 - Adds the `Deployments` value to the OU enum in `config/schema.json` and an
   `accounts.deployment` block to `config/landing-zone.example.yaml`
-  (`ou: Deployments`, placeholder id). `deployment` is **not** yet in the schema's
-  `accounts.required` list — it graduates to required when the account is vended,
-  mirroring the existing "empty id until provisioned" pattern (the account `id`
-  pattern already permits the empty string).
+  (`ou: Deployments`, placeholder id). `deployment` started outside the schema's
+  `accounts.required` list and graduated to required when the account was vended
+  (2026-06-10), mirroring the existing "empty id until provisioned" pattern (the
+  account `id` pattern still permits the empty string, so a forker who has not
+  vended the account yet keeps validating with `id: ""`).
 - Adds `terraform/environments/deployment/bootstrap` — the same account-bootstrap
   shape as `staging/bootstrap`: account alias, the GitHub OIDC identity provider,
   the `gh-tf-plan` / `gh-tf-apply-baseline` CI roles, and the
@@ -135,10 +139,14 @@ future work rather than guessed at before the platform-aws ECR PR lands.
   The addition is additive per ADR-006 — no existing account moves OU, no Root SCP
   changes, the region/IPAM/identity layers are untouched.
 - `config/landing-zone.example.yaml` and `config/schema.json` gain the
-  `deployment` account and the `Deployments` OU value. A forker's live
-  `config/landing-zone.yaml` keeps validating unchanged because `deployment` is not
-  yet `required`; it becomes required when the account is vended (the same
-  graduation the empty-id pattern already encodes).
+  `deployment` account and the `Deployments` OU value. With the account vended,
+  `deployment` is in the schema's `accounts.required` list: a live
+  `config/landing-zone.yaml` must carry the block (the `id` may stay `""` until
+  a forker vends their own account — the empty-id pattern encodes that
+  graduation). The operator updates the `LANDING_ZONE_CONFIG` secret in the same
+  motion as this merge; nothing in CI validates the secret against the schema,
+  and no other Terraform layer reads `accounts.deployment`, so a briefly stale
+  secret cannot break the other layers' plans or applies.
 - A new Terraform layer `deployment/bootstrap` exists with state key
   `deployment/bootstrap/terraform.tfstate`. It cannot apply until the account id is
   filled in — the `check "config_account_id_not_empty"` block fails fast with the

--- a/docs/decisions/018-deployments-ou-and-shared-registry-account.md
+++ b/docs/decisions/018-deployments-ou-and-shared-registry-account.md
@@ -1,0 +1,172 @@
+# 018. Deployments OU and `aegis-deployment` Account for the Shared Release-Artifact Registry
+
+## Status
+
+Proposed (2026-06-05)
+
+Account creation is operator/Control-Tower-gated. This ADR records the fabric-side
+decision; the account id stays a placeholder (empty string) in
+`config/landing-zone.example.yaml` until the account is vended. The ECR registry
+that justifies the account does **not** live here — it is the platform tier's job
+([ADR-017](017-platform-tier-extraction.md)) and ships in the `aegis-platform-aws`
+sibling PR.
+
+## Context
+
+The platform tier's release model (platform-aws **ADR-10**) is **build once, promote
+by digest**: the workload image is built one time, and the immutable artifact is
+promoted across environments by its content digest (`name@sha256:...`), never
+rebuilt per environment. Environment differences — replica counts, resource limits,
+ingress host, IAM trust — live in the deploy-repo overlays, not in the artifact.
+The deploy repos pin images by `kustomize images[].digest`; the registry
+(`newName`) is injected at ArgoCD sync time, so the deploy repos carry only
+`name + digest`, not the registry URL.
+
+That model needs **one** registry that **every** cluster account pulls from. The
+cluster accounts that pull are `aegis-staging` and `aegis-prod` (both in the
+Workloads OU). A single shared registry is what makes "promote the same digest"
+true across environments — if staging and prod pulled from different registries,
+the digest would no longer be the single source of identity for a release.
+
+The open fabric-side question is **where that registry account sits**. The account
+taxonomy ([ADR-006](006-account-taxonomy-and-ou-structure.md)) is a deliberate
+subset of the AWS Security Reference Architecture (SRA) with the expansion path
+called out as additive — and ADR-006 explicitly names a `Deployments` OU among the
+full-SRA OUs it deferred:
+
+> Full AWS SRA with `Sandbox`, `PolicyStaging`, `Suspended`, `Exceptions`, and
+> `Deployments` OUs … When the project grows to warrant these OUs … the addition
+> is additive, not a restructure.
+
+The shared-registry requirement is exactly the trigger ADR-006 anticipated. AWS
+SRA places shared deployment/CI artifacts (the central image registry, pipeline
+artifacts) in a dedicated **Deployments** account under a **Deployments** OU,
+separate from the shared-services / infrastructure account that holds the
+control-plane state backend. This ADR takes that additive expansion path.
+
+## Decision
+
+**Add a `Deployments` OU and vend a dedicated `aegis-deployment` account under it.
+The account hosts the single shared release-artifact registry (ECR) that the
+build-once / promote-by-digest model pulls from. The fabric side — OU, account,
+and bootstrap — lives here; the ECR resources live in `aegis-platform-aws`.**
+
+Concretely, this repository:
+
+- Adds the `Deployments` value to the OU enum in `config/schema.json` and an
+  `accounts.deployment` block to `config/landing-zone.example.yaml`
+  (`ou: Deployments`, placeholder id). `deployment` is **not** yet in the schema's
+  `accounts.required` list — it graduates to required when the account is vended,
+  mirroring the existing "empty id until provisioned" pattern (the account `id`
+  pattern already permits the empty string).
+- Adds `terraform/environments/deployment/bootstrap` — the same account-bootstrap
+  shape as `staging/bootstrap`: account alias, the GitHub OIDC identity provider,
+  the `gh-tf-plan` / `gh-tf-apply-baseline` CI roles, and the
+  `aegis-emergency-break-glass` role. This is the landing zone's standard
+  post-vend bootstrap, not new machinery.
+
+What this repository does **not** do, by [ADR-017](017-platform-tier-extraction.md)'s
+tier boundary:
+
+- It does **not** create the ECR registry, its repositories, lifecycle policies,
+  or cross-account pull policy — those are platform-tier resources in
+  `aegis-platform-aws`.
+- It does **not** create the platform-tier CI apply role that provisions ECR
+  (`gh-tf-apply-deployment`) or the scoped workload OIDC push role
+  (`ecr:PutImage`). Those mirror the org's `gh-tf-apply-*` OIDC pattern and ship in
+  the platform-aws PR. The landing zone owns only the **OIDC provider trust
+  anchor** in the deployment account (created by `deployment/bootstrap` above);
+  the per-purpose roles federate against it downstream.
+
+**No SCP change is required.** Both downstream roles are named `gh-tf-apply-deployment`
+and a `gh-tf-*`-prefixed workload push role, and the org SCP
+`deny-iam-privilege-escalation` already globs `arn:aws:iam::*:role/gh-tf-*` in its
+allow-list (see `terraform/environments/management/scps/main.tf`). The new roles
+fall inside the existing carve-out, exactly as
+[ADR-014](014-iam-permission-scope-down.md)/[ADR-015](015-permission-boundary-hardening.md)
+intended the `gh-tf-*` family to. The `Deployments` OU inherits the Root-attached
+SCPs (region-deny, deny-root, deny-iam-user-creation, deny-iam-privilege-escalation)
+the same way every other OU does.
+
+## Alternatives Considered
+
+**Co-locate the registry in `aegis-shared` (Infrastructure OU).** Rejected as a
+category mismatch. `aegis-shared` holds the **control-plane** of the fabric: the
+Terraform state backend, the org-wide IPAM authority, and the GitHub OIDC anchor —
+low-cadence, fabric-lifecycle resources whose blast radius is the whole fabric. The
+release registry is a **data-plane** artifact store on the workload-delivery
+lifecycle: it churns on every release, it is pulled by workload clusters, and a
+mistake there should not share an account boundary (or an apply role, or a PR
+queue) with the Terraform state bucket. Folding the registry into `aegis-shared`
+re-creates the exact lifecycle-coupling that [ADR-017](017-platform-tier-extraction.md)
+extracted the platform tier to avoid, one tier down. AWS SRA separates the
+Deployments account from the shared-services account for this reason; this ADR
+follows that separation.
+
+**A registry per cluster account (one in staging, one in prod).** Rejected — it
+breaks the build-once / promote-by-digest invariant. If each environment pulled
+from its own registry, promoting a release would mean copying the artifact between
+registries, and the digest would no longer be a single, environment-independent
+identity. The whole point of platform-aws ADR-10 is that the **same digest** moves
+across environments; that requires **one** registry the cluster accounts share.
+Per-account registries also multiply the cross-account trust surface and the
+storage cost for no isolation benefit (the artifact is identical by construction).
+
+**Keep the simplified 3-OU taxonomy and hang the account directly off Root.**
+Rejected. ADR-006 attaches SCPs at the OU level precisely so account placement is
+not ad-hoc; a Root-level account outside any OU is the management-account special
+case ([ADR-001](001-landing-zone-scope-boundary.md)), not a pattern to copy for a
+member account. Creating the `Deployments` OU is the additive, SRA-aligned move
+ADR-006 already sanctioned, and it gives the registry account a named home for any
+future Deployments-OU-scoped guardrail.
+
+**Author a bespoke Deployments-OU hardening SCP now** (e.g. deny anything but ECR /
+state / OIDC in the deployment account). Deferred, not rejected. The inherited
+Root SCPs already cap the account (region-deny, no IAM users, no privilege
+escalation), and the account is single-purpose by construction. A tailored
+Deployments-OU SCP — for example constraining the account to ECR + the bootstrap
+IAM surface, or denying image deletes outside a lifecycle policy — is a reasonable
+hardening once the registry's real action surface is known. It is recorded here as
+future work rather than guessed at before the platform-aws ECR PR lands.
+
+## Consequences
+
+- The fabric grows from six accounts / three OUs to **seven accounts / four OUs**.
+  The addition is additive per ADR-006 — no existing account moves OU, no Root SCP
+  changes, the region/IPAM/identity layers are untouched.
+- `config/landing-zone.example.yaml` and `config/schema.json` gain the
+  `deployment` account and the `Deployments` OU value. A forker's live
+  `config/landing-zone.yaml` keeps validating unchanged because `deployment` is not
+  yet `required`; it becomes required when the account is vended (the same
+  graduation the empty-id pattern already encodes).
+- A new Terraform layer `deployment/bootstrap` exists with state key
+  `deployment/bootstrap/terraform.tfstate`. It cannot apply until the account id is
+  filled in — the `check "config_account_id_not_empty"` block fails fast with the
+  Runbook 001 Part 9 pointer, exactly like `staging/bootstrap` and `prod/bootstrap`.
+- The `gh-tf-apply-deployment` and workload push roles land in `aegis-platform-aws`
+  with **zero** SCP change here — the `gh-tf-*` carve-out already covers them. This
+  is the superseding mechanism working as designed: the landing zone reserved the
+  `gh-tf-*` namespace at the SCP, and a new consumer joins it without a fabric
+  amendment.
+- The dependency direction stays one-way (Workload → Platform → Landing Zone): the
+  landing zone hands the platform tier an account + an OIDC trust anchor; the
+  platform tier builds the registry inside it and never reaches back up.
+- Deferred: a bespoke Deployments-OU hardening SCP, sized to the registry's real
+  action surface once the platform-aws ECR PR defines it.
+
+## Related
+
+- [ADR-006](006-account-taxonomy-and-ou-structure.md) — the account/OU taxonomy
+  this ADR extends; ADR-006 explicitly named the `Deployments` OU as a deferred,
+  additive SRA expansion, and this ADR takes that path.
+- [ADR-017](017-platform-tier-extraction.md) — the tier boundary that puts the ECR
+  registry (a platform-tier resource) in `aegis-platform-aws` while the account
+  fabric (OU + account + bootstrap + OIDC anchor) stays here.
+- [ADR-014](014-iam-permission-scope-down.md) / [ADR-015](015-permission-boundary-hardening.md)
+  — the `gh-tf-*` CI-role family and the org SCP `deny-iam-privilege-escalation`
+  whose `gh-tf-*` allow-list glob covers `gh-tf-apply-deployment` with no SCP change.
+- [ADR-001](001-landing-zone-scope-boundary.md) — the scope/blast-radius principles
+  the "don't co-locate in aegis-shared" rejection extends one account outward.
+- **aegis-platform-aws ADR-10** — build once, promote by digest, single shared
+  registry in a dedicated Deployment account; the consumer-side decision this
+  fabric-side ADR fulfils.

--- a/docs/decisions/018-deployments-ou-and-shared-registry-account.md
+++ b/docs/decisions/018-deployments-ou-and-shared-registry-account.md
@@ -21,9 +21,11 @@ by digest**: the workload image is built one time, and the immutable artifact is
 promoted across environments by its content digest (`name@sha256:...`), never
 rebuilt per environment. Environment differences — replica counts, resource limits,
 ingress host, IAM trust — live in the deploy-repo overlays, not in the artifact.
-The deploy repos pin images by `kustomize images[].digest`; the registry
-(`newName`) is injected at ArgoCD sync time, so the deploy repos carry only
-`name + digest`, not the registry URL.
+The deploy repos own the full `kustomize images[]` entry including the digest
+pin; the platform injects the registry as the `aegis.binhsu.org/ecr-repository`
+annotation at ArgoCD sync time (platform-aws ADR-12 — the platform never writes
+`kustomize.images`), so the deploy repos still carry no account-bearing
+registry URL.
 
 That model needs **one** registry that **every** cluster account pulls from. The
 cluster accounts that pull are `aegis-staging` and `aegis-prod` (both in the

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -43,7 +43,7 @@ where alternatives were genuinely weighed.
 | [015](015-permission-boundary-hardening.md) | IAM Permission-Boundary Hardening | Accepted |
 | [016](016-detective-controls.md) | Detective Control — Alert on Failed OIDC Assumption | Accepted |
 | [017](017-platform-tier-extraction.md) | Platform Tier Extracted from the Landing Zone | Accepted |
-| [018](018-deployments-ou-and-shared-registry-account.md) | Deployments OU + `aegis-deployment` Account for the Shared Release-Artifact Registry | Proposed |
+| [018](018-deployments-ou-and-shared-registry-account.md) | Deployments OU + `aegis-deployment` Account for the Shared Release-Artifact Registry | Accepted |
 | [019](019-budgets-iac-and-oidc-fail-closed.md) | Budgets Are IaC and the OIDC Trust Fails Closed | Accepted |
 
 ## Reading orders by audience

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -43,18 +43,19 @@ where alternatives were genuinely weighed.
 | [015](015-permission-boundary-hardening.md) | IAM Permission-Boundary Hardening | Accepted |
 | [016](016-detective-controls.md) | Detective Control — Alert on Failed OIDC Assumption | Accepted |
 | [017](017-platform-tier-extraction.md) | Platform Tier Extracted from the Landing Zone | Accepted |
+| [018](018-deployments-ou-and-shared-registry-account.md) | Deployments OU + `aegis-deployment` Account for the Shared Release-Artifact Registry | Proposed |
 | [019](019-budgets-iac-and-oidc-fail-closed.md) | Budgets Are IaC and the OIDC Trust Fails Closed | Accepted |
 
 ## Reading orders by audience
 
-You do not need to read all 17 ADRs front to back. Pick the path for why you
+You do not need to read all 19 ADRs front to back. Pick the path for why you
 are here. Each list is ordered so the argument builds on itself.
 
 ### Senior platform / infrastructure reviewer
 
 Understand the shape of the account fabric and why it is shaped that way.
 
-`001` → `006` → `008` → `011` → `010` → `003` → `004` → `013` → `007` → `017` → `002` → `012`
+`001` → `006` → `008` → `011` → `010` → `003` → `004` → `013` → `007` → `017` → `018` → `002` → `012`
 
 Scope boundary first, then the account/OU taxonomy, the
 Control-Tower-plus-Terraform tooling split, and how accounts are provisioned

--- a/terraform/environments/deployment/bootstrap/.terraform.lock.hcl
+++ b/terraform/environments/deployment/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.49.0"
+  constraints = "~> 6.40"
+  hashes = [
+    "h1:NPu7dmezTMF2cQ3N1oKA3DbLEU4zc7ZLtgm35MgqI4g=",
+    "h1:gW/1w7xNATTgTXKN9Du926VKZ84YgV6BLJDTPimMYkk=",
+    "zh:11a636bb415bf780f0ad300cab83d687aebdc51381112ae7b29862e0bee43017",
+    "zh:2d6c4bb861c073d9900a2afc39cc1e38492c6996653e53c7a2083b526fb10ae9",
+    "zh:49f7ee4a7488f3d31342c5e9dbb577c40e0847a0cab152a0082e9aeef45f5c0f",
+    "zh:561283c9c9bd36b9d09832e50769b941eb45c43c6ab031f27c8bf78256af4af1",
+    "zh:576bf944e66d097b29fc45b25a5bbc53e7d4e71a486e2cb126304cf77b51fe79",
+    "zh:6c6bf8860773c121b9ca22743f733feea943f890fa3aba8740a59579dea16fc4",
+    "zh:88b963a659e42daac7384a6abb99b3383f9f6c8abad5dedafcd443536b122b84",
+    "zh:947e9404235ca094e39e7f3f464f99436320a168e1607c550e581fbc70553d48",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a9c5a37bd1e5e81e85ad3dc3141f1b453b96e9cb8e500bc15bfb9c488fc95dcc",
+    "zh:b7b8a028fb2eafb98c676f9438808318f7ff0ea76eba03a6653d0940848a31c7",
+    "zh:be29f31827d6d5567aaec26034e6cceb994460446778ba1d0a435fc7ccd8a9f5",
+    "zh:c24c60ecffe3a7d44c762e62a29a802aec604096715ad3110b7ca2207124eb3a",
+    "zh:e2a247c5c7815437969e87cdce1f27f323eea75b97ed53f7605fef05d6406071",
+    "zh:e590ce9aca3f4fd964f7bf908a24dc3bc88e0b03a8554ccc81b9edcc84690670",
+  ]
+}

--- a/terraform/environments/deployment/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/deployment/bootstrap/aegis-emergency-role.tf
@@ -1,0 +1,126 @@
+# -----------------------------------------------------------------------------
+# `aegis-emergency-break-glass` — break-glass recovery role (ADR-015 OQ-1)
+# -----------------------------------------------------------------------------
+# Materializes the `aegis-emergency-*` namespace reserved by ADR-015's SCP
+# allow-list (`deny-iam-privilege-escalation`). This is the deployment-account
+# variant — see `terraform/environments/management/bootstrap/aegis-emergency-
+# role.tf` for the full design narrative and the recovery shape that
+# motivates the role.
+#
+# Scope difference from mgmt: no Organizations / SSO / IdentityStore Sids.
+# Those API surfaces only carry power in mgmt; in member accounts they
+# return empty inventories at best and produce no useful break-glass
+# primitive. The deployment-account permission policy is therefore the IAM /
+# KMS / SSM PS subset.
+#
+# Trust policy: identical pattern to mgmt — local-account PlatformAdmin
+# SSO sessions only, time-bounded to 1 hour.
+#
+# SCP interaction: `aegis-emergency-break-glass` matches `aegis-emergency-*`
+# in ADR-015's SCP allow-list. No SCP change required by this PR.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "aegis_emergency_break_glass" {
+  name                 = "aegis-emergency-break-glass"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OperatorViaPlatformAdminSso"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${local.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
+  # checkov:skip=CKV_AWS_287: Read-shape Sids (IamReadAll, KmsReadAndDecrypt's Describe/List/Get verbs, StsAndTagRead) intentionally use Resource:* for inventory access during break-glass diagnosis. Mutation surface is in IamMutationOnProjectRoles, scoped or trust-policy-gated. ADR-015 OQ-1.
+  # checkov:skip=CKV_AWS_288: Same as 287 — break-glass requires broad read for diagnosis; mutations are scoped. Read-shape data disclosure is the explicit threat model accepted by ADR-015.
+  # checkov:skip=CKV_AWS_289: iam:* is intentionally allowed but scoped to aegis-*/gh-tf-*/github-actions-* prefixes. Permission-management within fixed prefixes is the break-glass contract.
+  # checkov:skip=CKV_AWS_290: Resource:* on read-only Sids is required because the corresponding AWS APIs do not support resource-level ARN constraints. Trust policy (PlatformAdmin SSO only) is the gate.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sids and on AWS APIs without resource-level ARN support.
+  # checkov:skip=CKV2_AWS_40: iam:* on a fixed ARN-prefix scope is the deliberate break-glass design (ADR-015 OQ-1 graduation).
+  name = "emergency-break-glass-scoped"
+  role = aws_iam_role.aegis_emergency_break_glass.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Scoped IAM mutation — the primary break-glass primitive.
+        Sid    = "IamMutationOnProjectRoles"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+        ]
+      },
+      {
+        # IAM read across the account. Diagnosis needs full inventory;
+        # mutations are bounded by IamMutationOnProjectRoles above.
+        Sid    = "IamReadAll"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:Simulate*",
+        ]
+        Resource = "*"
+      },
+      {
+        # KMS read + Decrypt scoped to local-account keys only. Required
+        # for reading SSM PS SecureString values during diagnosis. No
+        # Encrypt / GenerateDataKey — break-glass is read-recovery.
+        Sid    = "KmsReadAndDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Describe*",
+          "kms:List*",
+          "kms:Get*",
+          "kms:Decrypt",
+        ]
+        Resource = "arn:aws:kms:*:${local.account_id}:key/*"
+      },
+      {
+        # SSM PS read on `/aegis/*` paths only. Diagnosis often needs to
+        # confirm a parameter is present and decrypts cleanly. Read-only.
+        Sid    = "SsmReadProject"
+        Effect = "Allow"
+        Action = [
+          "ssm:Get*",
+          "ssm:Describe*",
+          "ssm:List*",
+        ]
+        Resource = "arn:aws:ssm:*:${local.account_id}:parameter/aegis/*"
+      },
+      {
+        # Identity + audit visibility. Read-only; AWS-API-shape Resource:*.
+        Sid    = "StsAndTagRead"
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "tag:Get*",
+          "iam:GenerateCredentialReport",
+          "iam:GenerateServiceLastAccessedDetails",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/deployment/bootstrap/backend.tf
+++ b/terraform/environments/deployment/bootstrap/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "deployment/bootstrap/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/deployment/bootstrap/budgets.tf
+++ b/terraform/environments/deployment/bootstrap/budgets.tf
@@ -1,0 +1,43 @@
+# -----------------------------------------------------------------------------
+# Per-account cost guardrail — AWS Budgets as IaC (ADR-019)
+# -----------------------------------------------------------------------------
+# The deployment account is vended with its budget from day one — the
+# 2026-06-06 cost-incident postmortem flagged member accounts without their
+# own budget (the org-wide budgets in the management account were the only
+# guardrail that fired). This budget tracks this account's own spend; under
+# consolidated billing a member-account budget sees only that account's
+# usage, so no cost filter is needed.
+#
+# New resource — nothing to import. Created on the next CI apply of this
+# layer via `gh-tf-apply-baseline`.
+# -----------------------------------------------------------------------------
+
+locals {
+  # Per-member-account monthly ceiling (USD). Optional config key; defaults
+  # to 10 — the same shape as the org daily tripwire.
+  member_budget_usd = tostring(try(local.config.budget.member_monthly_usd, 10))
+}
+
+resource "aws_budgets_budget" "account_monthly" {
+  name         = "aegis-deployment-monthly-usd${local.member_budget_usd}"
+  budget_type  = "COST"
+  limit_amount = local.member_budget_usd
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+}

--- a/terraform/environments/deployment/bootstrap/config.tf
+++ b/terraform/environments/deployment/bootstrap/config.tf
@@ -1,0 +1,16 @@
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.deployment.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+  tags = merge(local.config.tags, {
+    Environment = "deployment"
+  })
+}
+
+check "exactly_one_primary_region" {
+  assert {
+    condition     = length([for r in local.config.regions : r if r.role == "primary"]) == 1
+    error_message = "config/landing-zone.yaml regions[] must have exactly one entry with role: primary."
+  }
+}

--- a/terraform/environments/deployment/bootstrap/main.tf
+++ b/terraform/environments/deployment/bootstrap/main.tf
@@ -1,0 +1,12 @@
+resource "aws_iam_account_alias" "this" {
+  account_alias = "binhsu-aegis-deployment"
+}
+
+data "aws_caller_identity" "current" {}
+
+check "config_account_id_not_empty" {
+  assert {
+    condition     = local.account_id != ""
+    error_message = "accounts.deployment.id in landing-zone.yaml is empty. Create the account first (Runbook 001 Part 9; account-creation is operator/Control-Tower-gated)."
+  }
+}

--- a/terraform/environments/deployment/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-baseline-role.tf
@@ -140,6 +140,17 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
         Resource = "*"
       },
       {
+        # AWS Budgets mutation — scoped to the project's budget-name prefix.
+        # ADR-019 adds the per-account monthly budget to this layer.
+        # CreateBudget / UpdateBudget / DeleteBudget all map to the condensed
+        # IAM action `budgets:ModifyBudget`; the budgets ARN carries no
+        # region segment.
+        Sid      = "BudgetsScoped"
+        Effect   = "Allow"
+        Action   = "budgets:*"
+        Resource = "arn:aws:budgets::${local.account_id}:budget/aegis-*"
+      },
+      {
         # Read shapes for `terraform plan` after apply (refresh + drift
         # detection). Resource: "*" is acceptable here because every
         # action listed is read-only — metadata disclosure is classified
@@ -161,6 +172,9 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
           "kms:List*",
           "kms:GetKeyRotationStatus",
           "kms:GetKeyPolicy",
+          "budgets:ViewBudget",
+          "budgets:Describe*",
+          "budgets:ListTagsForResource",
           "tag:Get*",
           "sts:GetCallerIdentity",
         ]

--- a/terraform/environments/deployment/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-baseline-role.tf
@@ -1,0 +1,171 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-apply-baseline` — apply role for `terraform-apply-baseline.yml` (ADR-014)
+# -----------------------------------------------------------------------------
+# Apply role for the `ref:refs/heads/main` trigger. The `pull_request` trigger
+# assumes its own read-only role, `gh-tf-plan`. These two are the only CI roles.
+#
+# Scope: the deployment account's only landing-zone Terraform is
+# `deployment/bootstrap` itself — the account alias, the GitHub OIDC provider,
+# and the gh-tf-* / aegis-emergency-* roles. The permission policy below is
+# therefore exactly IAM-on-project-prefixes + account alias + cross-account
+# Terraform state. The ECR registry and the platform-aws ECR/push roles
+# (`gh-tf-apply-deployment`, the workload `ecr:PutImage` push role) are NOT in
+# this layer's scope — they live in the aegis-platform-aws sibling PR (ADR-018).
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_apply_baseline" {
+  name = "gh-tf-apply-baseline"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
+          # Rename-proof: the immutable repository_id (StringEquals above) is the
+          # binding; the sub wildcards the repo NAME so a repo rename cannot break
+          # OIDC auth (the failure this trust restructure fixes).
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
+  # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Simulate* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-014.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-014. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
+  # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-*/github-actions-*/gh-tf-*) plus the OIDC provider and account alias. Permission-management within a fixed prefix is the apply contract for the deployment baseline role.
+  # checkov:skip=CKV_AWS_290: Service-namespace wildcard `tag:*` is needed because the AWS tagging API does not support resource-level ARN constraints on write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on the account-alias actions (AWS rejects resource-level ARNs there). Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations. Full IAM privileges on a fixed ARN-prefix is the deliberate apply-baseline design (ADR-014 §Decision).
+  name = "apply-baseline-scoped"
+  role = aws_iam_role.gh_tf_apply_baseline.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # IAM mutation — scoped to project-prefixed resources plus the
+        # OIDC provider. Covers aegis-* roles, github-actions-* (terraform CI
+        # roles), and gh-tf-* (this very layer's role family — supports
+        # in-place updates). Account alias management is a separate Sid
+        # below because AWS IAM does not accept resource-level ARNs on the
+        # alias actions.
+        Sid    = "IamScoped"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+          "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com",
+        ]
+      },
+      {
+        # Account alias — account-level operations. AWS IAM rejects any
+        # resource-level ARN on these actions ("account-alias/*" is NOT
+        # in the IAM-allowed-resource-path list); Resource: "*" is the
+        # only accepted shape. The trust policy `sub: ref:refs/heads/main`
+        # plus branch protection on main is the gate; the action set is
+        # narrowed to alias-only verbs (no other iam:* leaks through).
+        Sid    = "AccountAliasManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateAccountAlias",
+          "iam:DeleteAccountAlias",
+          "iam:ListAccountAliases",
+        ]
+        Resource = "*"
+      },
+      {
+        # State bucket cross-account read + write. State bucket lives in
+        # the shared account; this account's state object is read/written
+        # via cross-account bucket policy.
+        Sid    = "StateBucketCrossAccount"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketVersioning",
+        ]
+        Resource = [
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}",
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*",
+        ]
+      },
+      {
+        # State KMS — key lives in shared. Gated to S3 service usage so
+        # the role can decrypt state objects but not invoke KMS directly.
+        Sid    = "StateKmsViaS3Only"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey",
+        ]
+        Resource = "arn:aws:kms:${local.primary_region}:${local.config.accounts.shared.id}:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "s3.${local.primary_region}.amazonaws.com"
+          }
+        }
+      },
+      {
+        # Universal tagging — no service supports `tag:*` with a
+        # resource-level ARN; service-namespace scoping is the tightest
+        # contract.
+        Sid      = "TagApi"
+        Effect   = "Allow"
+        Action   = "tag:*"
+        Resource = "*"
+      },
+      {
+        # Read shapes for `terraform plan` after apply (refresh + drift
+        # detection). Resource: "*" is acceptable here because every
+        # action listed is read-only — metadata disclosure is classified
+        # as not-secret per CLAUDE.md threat model.
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "s3:GetBucket*",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetObjectLockConfiguration",
+          "s3:ListAllMyBuckets",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/deployment/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-plan-role.tf
@@ -1,0 +1,179 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-plan` — read-only role for `terraform-plan.yml` on PRs (ADR-014)
+# -----------------------------------------------------------------------------
+# Permission character: read-only AWS metadata + state-object read +
+# state-lock writes scoped to *.tflock + KMS via S3 service condition.
+#
+# Trust policy is keyed on the OIDC `sub` claim `pull_request` only — the
+# `main` trigger assumes its own apply role, `gh-tf-apply-baseline`. See
+# ADR-014 for the full identity-by-trigger split.
+#
+# This role purposefully cannot mutate any AWS resource other than the
+# Terraform state lockfile suffix. A leaked OIDC token from a fork-PR-OIDC
+# attack can at most run `terraform plan` and produce metadata disclosure
+# (which CLAUDE.md classifies as not-secret). This is the unlocking move
+# for closing fork-PR-OIDC as a meaningful blast-radius source.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_plan" {
+  name = "gh-tf-plan"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
+          # Rename-proof: the immutable repository_id (StringEquals above) is the
+          # binding; the sub wildcards the repo NAME so a repo rename cannot break
+          # OIDC auth (the failure this trust restructure fixes).
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:pull_request"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_plan" {
+  # checkov:skip=CKV_AWS_287: Read-only API surface (Get*/List*/Describe*) requires Resource:* — restrictable per-ARN scoping is not meaningful for inventory-style API calls. The policy's deny floor is mutation prevention, enforced via state-lock-suffix scoping (Sid WriteStateLockSuffixOnly) and the absence of any Create/Update/Delete actions. See ADR-014 §Decision and §Appendix A.2.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — data exfiltration via read-only metadata is the explicit threat model accepted by ADR-014. AWS account IDs, role ARNs, and similar metadata are classified non-secret per CLAUDE.md "What is NOT a secret" clause; the policy intentionally allows their disclosure to a fork-PR-OIDC-leaked token because the alternative (per-resource read scoping) is operationally infeasible for the breadth of reads `terraform plan` performs.
+  # checkov:skip=CKV_AWS_355: Resource:* on the ReadOnlyAwsApiSurface Sid is by design — every action in that statement is read-shape (Get*/List*/Describe*/Simulate*). No mutating action uses Resource:* in this policy.
+  name = "plan-readonly"
+  role = aws_iam_role.gh_tf_plan.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadStateObject"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:GetObjectVersion"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*"
+      },
+      {
+        Sid      = "ListStateBucket"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}"
+      },
+      {
+        Sid      = "WriteStateLockSuffixOnly"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:DeleteObject"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*.tflock"
+      },
+      {
+        # OQ-3 worst-case guard: `terraform plan -refresh=true` may write the
+        # state object during refresh. Allow PutObject on the state-key suffix
+        # to absorb that worst case. PR-1 will empirically observe whether
+        # plan-refresh writes state under our backend; if no, this statement
+        # tightens or is removed in a follow-up PR.
+        Sid      = "WriteStateOnRefreshGuard"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*.tfstate"
+      },
+      {
+        # KMS decryption gated by service condition. Two ViaService entries:
+        # - `s3.<region>.amazonaws.com` — for cross-account state-bucket
+        #   reads (state KMS lives in shared account)
+        # - `ssm.<region>.amazonaws.com` — for SSM PS SecureString reads
+        #   (each account's local KMS key encrypts /aegis/<env>/* secrets)
+        # Resource: "*" is bounded by the ViaService condition; without
+        # it the role cannot invoke KMS directly.
+        Sid      = "KmsForStateAndSsm"
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt", "kms:Encrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = "arn:aws:kms:*:*:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = [
+              "s3.${local.primary_region}.amazonaws.com",
+              "ssm.${local.primary_region}.amazonaws.com",
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "ec2:Describe*",
+          "eks:Describe*",
+          "eks:List*",
+          "s3:GetBucket*",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetObjectLockConfiguration",
+          "s3:ListAllMyBuckets",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "organizations:Describe*",
+          "organizations:List*",
+          # IAM Identity Center (formerly AWS SSO) — IAM service prefix
+          # is `sso:` even though the CLI verb is `aws sso-admin <command>`.
+          # Using `sso-admin:` here returns AccessDenied on every action.
+          "sso:Describe*",
+          "sso:List*",
+          "sso:Get*",
+          "identitystore:Describe*",
+          "identitystore:List*",
+          "identitystore:Get*",
+          "ssm:Describe*",
+          "ssm:Get*",
+          "ssm:List*",
+          "logs:Describe*",
+          "logs:List*",
+          "logs:Get*",
+          "sqs:Get*",
+          "sqs:List*",
+          "events:Describe*",
+          "events:List*",
+          "ram:Get*",
+          "ram:List*",
+          "ec2:DescribeIpam*",
+          "ec2:GetIpam*",
+          "fis:Get*",
+          "fis:List*",
+          "cognito-idp:Describe*",
+          "cognito-idp:List*",
+          "cognito-idp:Get*",
+          "cloudfront:Get*",
+          "cloudfront:List*",
+          "acm:Describe*",
+          "acm:List*",
+          "route53:Get*",
+          "route53:List*",
+          "ecr:Describe*",
+          "ecr:Get*",
+          "ecr:List*",
+          "elasticloadbalancing:Describe*",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/deployment/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-plan-role.tf
@@ -169,6 +169,11 @@ resource "aws_iam_role_policy" "gh_tf_plan" {
           "ecr:Get*",
           "ecr:List*",
           "elasticloadbalancing:Describe*",
+          # ADR-019 budgets-as-IaC — plan-tier refresh of the
+          # aws_budgets_budget resources (and their import-block reads).
+          "budgets:ViewBudget",
+          "budgets:Describe*",
+          "budgets:ListTagsForResource",
           "tag:Get*",
           "sts:GetCallerIdentity",
         ]

--- a/terraform/environments/deployment/bootstrap/oidc-github.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github.tf
@@ -31,4 +31,16 @@ resource "aws_iam_openid_connect_provider" "github" {
   url             = local.github_oidc_url
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  lifecycle {
+    # Fail closed (ADR-019). The immutable repository_id StringEquals claim is
+    # the ONLY repo binding in the gh-tf-* trust policies — the StringLike sub
+    # claim wildcards the repo name (`repo:<org>/*`) for rename-proofing.
+    # Without infra_repo_id, ANY repo under the GitHub owner could mint a
+    # main-branch token and assume the CI roles. Refuse to create that trust.
+    precondition {
+      condition     = local.github_infra_repo_id != null
+      error_message = "github.infra_repo_id is unset in config/landing-zone.yaml. Set it — get the numeric id via: gh api repos/<owner>/<repo> --jq .id — the OIDC trust will not be created owner-wide (ADR-019)."
+    }
+  }
 }

--- a/terraform/environments/deployment/bootstrap/oidc-github.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github.tf
@@ -1,0 +1,34 @@
+# -----------------------------------------------------------------------------
+# GitHub OIDC Federation — deployment account CI access
+# -----------------------------------------------------------------------------
+# Provides the OIDC provider that the gh-tf-* CI roles federate against. Each
+# role's trust + permission policy lives in its own .tf file (oidc-github-*-
+# role.tf). The two landing-zone CI roles are `gh-tf-plan` and
+# `gh-tf-apply-baseline` — they bootstrap THIS layer (alias, OIDC provider,
+# the gh-tf-* / aegis-emergency-* roles).
+#
+# The shared release-artifact registry (ECR) itself, and the platform-aws CI
+# apply role that provisions it (`gh-tf-apply-deployment`) plus the scoped
+# workload OIDC push role (`ecr:PutImage`), are NOT created here — they live
+# in the aegis-platform-aws sibling PR (this repo owns the account fabric +
+# the OIDC trust anchor only, per ADR-017). Both downstream roles match the
+# org SCP `gh-tf-*` carve-out, so no SCP change is required (ADR-018).
+# -----------------------------------------------------------------------------
+
+locals {
+  github_org        = local.config.github.org
+  github_infra_repo = local.config.github.infra_repo
+  github_oidc_url   = "https://token.actions.githubusercontent.com"
+
+  github_infra_repo_id = try(local.config.github.infra_repo_id, null)
+
+  github_oidc_infra_repo_id_claim = local.github_infra_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_infra_repo_id
+  } : {}
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = local.github_oidc_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}

--- a/terraform/environments/deployment/bootstrap/outputs.tf
+++ b/terraform/environments/deployment/bootstrap/outputs.tf
@@ -1,0 +1,23 @@
+output "account_id" {
+  description = "Deployment account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "account_alias" {
+  description = "IAM account alias"
+  value       = aws_iam_account_alias.this.account_alias
+}
+
+output "github_oidc_provider_arn" {
+  description = "GitHub OIDC identity provider ARN"
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+
+# -----------------------------------------------------------------------------
+# Break-glass recovery role — ADR-015 OQ-1 graduation
+# -----------------------------------------------------------------------------
+
+output "aegis_emergency_break_glass_role_arn" {
+  description = "ARN of the aegis-emergency-break-glass role for SSO PlatformAdmin assume during break-glass recovery"
+  value       = aws_iam_role.aegis_emergency_break_glass.arn
+}

--- a/terraform/environments/deployment/bootstrap/providers.tf
+++ b/terraform/environments/deployment/bootstrap/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/deployment/bootstrap/versions.tf
+++ b/terraform/environments/deployment/bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fabric-side phase of **platform-aws ADR-10** (*build once, promote by digest, single shared registry in a dedicated Deployment account*). Adds a new **Deployments OU** and an **`aegis-deployment`** account to host the one shared release-artifact registry (ECR) that `aegis-staging` (251774439261) and `aegis-prod` (506221082337) both pull from **by digest** (`name@sha256:...`). A single registry is what makes "promote the same digest across environments" true.

New repo ADR: [`docs/decisions/018-deployments-ou-and-shared-registry-account.md`](docs/decisions/018-deployments-ou-and-shared-registry-account.md) — **Status: Proposed**.

This is the additive SRA expansion [ADR-006](docs/decisions/006-account-taxonomy-and-ou-structure.md) anticipated (it explicitly named a deferred `Deployments` OU). Per [ADR-017](docs/decisions/017-platform-tier-extraction.md), the landing zone owns the **account fabric + the OIDC trust anchor only**.

## This is a PROPOSAL — nothing is applied

- **Account creation is operator / Control-Tower-gated.** No account is created by this PR.
- The `aegis-deployment` **account id is a placeholder** (empty string in the example template) until the account is vended. `deployment` is intentionally **not** in the schema's `accounts.required` yet — it graduates to required at vend time, mirroring the existing empty-id pattern. The operator's live (gitignored) `config/landing-zone.yaml` keeps validating unchanged.
- `terraform/environments/deployment/bootstrap` cannot apply until the id is filled in — `check "config_account_id_not_empty"` fails fast with the Runbook 001 pointer.
- **No `terraform apply`, no AWS mutation, no account/OU creation was run.**

## What's here (fabric side only)

| Area | Change |
|---|---|
| `config/landing-zone.example.yaml` | `accounts.deployment` (`ou: Deployments`, placeholder id) |
| `config/schema.json` | `Deployments` added to OU enum; `deployment` added to `accounts.properties` (not `required`) |
| `terraform/environments/deployment/bootstrap/` | New layer mirroring `staging/bootstrap`: alias, GitHub OIDC provider, `gh-tf-plan` / `gh-tf-apply-baseline`, `aegis-emergency-break-glass` |
| `README.md` | 6→7 accounts, 3→4 OUs, Deployments node in topology Mermaid, phase-5 row, ADR table (also backfills missing **017**), dir tree |
| `docs/architecture.md` | Deployments OU + `aegis-deployment` in the account-topology diagram; state-key convention note |
| `docs/decisions/018-...md` | New ADR (Proposed) |
| `docs/decisions/README.md` | Index + senior reading order |

## What is NOT here (lives in the aegis-platform-aws sibling PR)

- The **ECR registry**, its repositories, lifecycle policies, and the cross-account pull policy — platform-tier resources (ADR-017).
- The platform-tier CI apply role **`gh-tf-apply-deployment`** (Terraform/ECR) and the scoped workload **`ecr:PutImage`** push role. They federate against the OIDC provider this PR creates in the deployment account.

## No SCP change required

Both downstream roles match the org SCP `deny-iam-privilege-escalation` allow-list glob `arn:aws:iam::*:role/gh-tf-*` (see `terraform/environments/management/scps/main.tf`). They fall in the **existing carve-out** — zero SCP change. A bespoke Deployments-OU hardening SCP is **deferred** (recorded in ADR-018) until the platform-aws ECR PR defines the registry's real action surface.

## Validation (offline, honest)

- `terraform fmt -check -recursive terraform/` → **clean** (exit 0).
- `terraform validate` (`init -backend=false`) on `deployment/bootstrap` → **Success** when the `deployment` key is present in config; fails fast on the missing key by design (the operator's live config has no `deployment` account yet — that's the operator-gated step). Tested with a temporary in-place config block, then the live config was restored byte-identical.
- `config/schema.json` parses; both the example template and a temp live-config **validate** against the updated schema (`scripts/validate-config.py` → `valid`).
- Mermaid blocks: subgraph/end **balanced** in both README and architecture.md. `mmdc` render could **not** run — no local Chromium for puppeteer (environment, not a diagram syntax error; it fails identically on a trivial 2-node diagram and on the untouched pre-existing blocks). GitHub will render them.

Related: this repo ADR-018, [ADR-006](docs/decisions/006-account-taxonomy-and-ou-structure.md), [ADR-017](docs/decisions/017-platform-tier-extraction.md), [ADR-014](docs/decisions/014-iam-permission-scope-down.md)/[ADR-015](docs/decisions/015-permission-boundary-hardening.md); **platform-aws ADR-10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Deployments OU and a shared deployment account with a deployment/bootstrap infrastructure layer.
  * Provisioned CI-friendly bootstrap capabilities: OIDC-backed roles for plan/apply, emergency recovery role, state backend, budgets, and provider configuration.
  * CI workflows updated to include the new deployment bootstrap environment.

* **Documentation**
  * Updated README, architecture docs, ADR index, and schema/config examples to reflect the 7-account topology and Deployments OU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->