### PR TITLE
ci: enable CodeRabbit quality gate (request-changes + pre-merge checks)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# CodeRabbit quality gate. Pre-merge checks in `error` mode + request-changes
+# workflow hold the `CodeRabbit` status non-success until findings are resolved,
+# which the branch ruleset enforces as a required check before merge to main.
+reviews:
+  request_changes_workflow: true
+  pre_merge_checks:
+    override_requested_reviewers_only: true
+    title:
+      mode: "error"
+    description:
+      mode: "warning"
+    docstrings:
+      mode: "off"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,11 @@
 # yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
-# CodeRabbit quality gate. Pre-merge checks in `error` mode + request-changes
-# workflow hold the `CodeRabbit` status non-success until findings are resolved,
-# which the branch ruleset enforces as a required check before merge to main.
+# CodeRabbit quality gate.
+#  - request_changes_workflow: CodeRabbit submits a Changes-Requested review when a
+#    pre-merge check (error mode) fails or review findings are unresolved. That review
+#    blocks merge via the branch ruleset's pull_request rule, counts toward the required
+#    approval, and auto-flips to Approved once the issues are resolved.
+#  - The separate `CodeRabbit` required status check is a completion gate (review ran);
+#    it stays success and does not itself block on findings.
 reviews:
   request_changes_workflow: true
   pre_merge_checks:


### PR DESCRIPTION
Org-wide CodeRabbit enforcement rollout (piloted on aegis-greeter PR #11/#12).

Adds `.coderabbit.yaml`: request_changes_workflow + pre_merge_checks (title=error, description=warning). The branch ruleset already requires the `CodeRabbit` status; this upgrades it to a finding-based quality gate via CodeRabbit's Changes-Requested review (which counts toward the required approval and auto-clears on fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened pre-merge quality checks: title checks now block merges, descriptions emit warnings.
  * Enabled review-request changes and limited who can override pre-merge review checks.
  * Disabled automated docstring checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->