### PR TITLE
feat(budgets): budget resources + import adoption (ADR-019, step 2/2)

### DIFF
--- a/terraform/environments/management/bootstrap/budgets.tf
+++ b/terraform/environments/management/bootstrap/budgets.tf
@@ -1,0 +1,116 @@
+# -----------------------------------------------------------------------------
+# Cost guardrails — AWS Budgets as IaC (ADR-019)
+# -----------------------------------------------------------------------------
+# The org-wide budgets `aegis-daily-usd10` and `aegis-monthly-usd30` were
+# created in the console during runbook 001 Part 3.5 — before any Terraform
+# exists in a fresh account — and were the only guardrail that fired in the
+# 2026-06-06 cost incident. ADR-019 brings them under Terraform.
+#
+# The `import` blocks adopt the live console budgets on the first apply after
+# this file lands (no collision, no recreate). They assume runbook 001 §3.5
+# already ran — which it has on any account bootstrapped by this repo, because
+# §3.5 precedes the first `terraform apply`. A fork that skipped §3.5 must
+# either create the two budgets first or delete the import blocks and let
+# Terraform create them. Once the budgets are in state the import blocks are
+# no-ops and can be removed in a later cleanup.
+#
+# These budgets live in the management (payer) account, so they see the
+# consolidated org-wide spend. The logarchive member budget also lives here —
+# scoped by a LinkedAccount cost filter — because the logarchive account is
+# Control-Tower-managed and has no Terraform environment of its own (see
+# ADR-019 Consequences).
+# -----------------------------------------------------------------------------
+
+locals {
+  # Per-member-account monthly ceiling (USD). Optional config key; defaults
+  # to 10 — the same shape as the org daily tripwire.
+  member_budget_usd = tostring(try(local.config.budget.member_monthly_usd, 10))
+}
+
+import {
+  to = aws_budgets_budget.org_daily
+  id = "${local.account_id}:aegis-daily-usd10"
+}
+
+import {
+  to = aws_budgets_budget.org_monthly
+  id = "${local.account_id}:aegis-monthly-usd30"
+}
+
+resource "aws_budgets_budget" "org_daily" {
+  name         = "aegis-daily-usd10"
+  budget_type  = "COST"
+  limit_amount = tostring(local.config.budget.daily_usd)
+  limit_unit   = "USD"
+  time_unit    = "DAILY"
+
+  # Runbook 001 §3.5.3: a single 80%-of-actual alert. The daily budget is the
+  # fast circuit breaker — a day past this threshold means a runaway resource.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+}
+
+resource "aws_budgets_budget" "org_monthly" {
+  name         = "aegis-monthly-usd30"
+  budget_type  = "COST"
+  limit_amount = tostring(local.config.budget.monthly_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  # Runbook 001 §3.5.2 created this from the console "monthly cost budget"
+  # template and did not pin thresholds; the code standardizes on 80% + 100%
+  # of actual. The first apply after import reconciles the console template's
+  # notification set to these two (in-place update, not a recreate).
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+}
+
+# Per-account monthly budget for aegis-logarchive. New resource (the account
+# had none — one of the gaps the 2026-06-06 postmortem flagged). Unlike the
+# org budgets above it is filtered to a single linked account.
+resource "aws_budgets_budget" "member_monthly_logarchive" {
+  name         = "aegis-logarchive-monthly-usd${local.member_budget_usd}"
+  budget_type  = "COST"
+  limit_amount = local.member_budget_usd
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_filter {
+    name   = "LinkedAccount"
+    values = [local.config.accounts.logarchive.id]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+}

--- a/terraform/environments/management/bootstrap/budgets.tf
+++ b/terraform/environments/management/bootstrap/budgets.tf
@@ -25,6 +25,19 @@ locals {
   # Per-member-account monthly ceiling (USD). Optional config key; defaults
   # to 10 — the same shape as the org daily tripwire.
   member_budget_usd = tostring(try(local.config.budget.member_monthly_usd, 10))
+
+  # Empty on a fork where the account is not vended yet — gates the
+  # logarchive budget below (empty LinkedAccount filter fails the apply).
+  logarchive_account_id = try(local.config.accounts.logarchive.id, "")
+}
+
+# Loud-skip tripwire for the count gate below: a plan against a config with
+# no logarchive id WARNS instead of silently planning one budget fewer.
+check "logarchive_budget_present" {
+  assert {
+    condition     = local.logarchive_account_id != ""
+    error_message = "accounts.logarchive.id is empty — the aegis-logarchive member budget is SKIPPED this apply. Vend/record the account id in config/landing-zone.yaml and re-apply (ADR-019)."
+  }
 }
 
 import {
@@ -86,7 +99,14 @@ resource "aws_budgets_budget" "org_monthly" {
 # Per-account monthly budget for aegis-logarchive. New resource (the account
 # had none — one of the gaps the 2026-06-06 postmortem flagged). Unlike the
 # org budgets above it is filtered to a single linked account.
+#
+# count-gated on the account id: the schema permits an empty id (the account
+# may not be vended yet on a fresh fork), and an empty LinkedAccount filter
+# fails the apply. The skip is NOT silent — the check block below warns on
+# every plan until the id is set (ADR-019: no invisible missing guardrails).
 resource "aws_budgets_budget" "member_monthly_logarchive" {
+  count = local.logarchive_account_id != "" ? 1 : 0
+
   name         = "aegis-logarchive-monthly-usd${local.member_budget_usd}"
   budget_type  = "COST"
   limit_amount = local.member_budget_usd
@@ -95,7 +115,7 @@ resource "aws_budgets_budget" "member_monthly_logarchive" {
 
   cost_filter {
     name   = "LinkedAccount"
-    values = [local.config.accounts.logarchive.id]
+    values = [local.logarchive_account_id]
   }
 
   notification {

--- a/terraform/environments/shared/bootstrap/budgets.tf
+++ b/terraform/environments/shared/bootstrap/budgets.tf
@@ -1,0 +1,42 @@
+# -----------------------------------------------------------------------------
+# Per-account cost guardrail — AWS Budgets as IaC (ADR-019)
+# -----------------------------------------------------------------------------
+# The shared account had no budget of its own — one of the gaps the
+# 2026-06-06 cost-incident postmortem flagged (the org-wide budgets in the
+# management account were the only guardrail that fired). This budget tracks
+# this account's own spend; under consolidated billing a member-account
+# budget sees only that account's usage, so no cost filter is needed.
+#
+# New resource — nothing to import. Created on the next CI apply of this
+# layer via `gh-tf-apply-baseline`.
+# -----------------------------------------------------------------------------
+
+locals {
+  # Per-member-account monthly ceiling (USD). Optional config key; defaults
+  # to 10 — the same shape as the org daily tripwire.
+  member_budget_usd = tostring(try(local.config.budget.member_monthly_usd, 10))
+}
+
+resource "aws_budgets_budget" "account_monthly" {
+  name         = "aegis-shared-monthly-usd${local.member_budget_usd}"
+  budget_type  = "COST"
+  limit_amount = local.member_budget_usd
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+}

--- a/terraform/environments/staging/bootstrap/budgets.tf
+++ b/terraform/environments/staging/bootstrap/budgets.tf
@@ -1,0 +1,42 @@
+# -----------------------------------------------------------------------------
+# Per-account cost guardrail — AWS Budgets as IaC (ADR-019)
+# -----------------------------------------------------------------------------
+# The staging account had no budget of its own — one of the gaps the
+# 2026-06-06 cost-incident postmortem flagged (the org-wide budgets in the
+# management account were the only guardrail that fired). This budget tracks
+# this account's own spend; under consolidated billing a member-account
+# budget sees only that account's usage, so no cost filter is needed.
+#
+# New resource — nothing to import. Created on the next CI apply of this
+# layer via `gh-tf-apply-baseline`.
+# -----------------------------------------------------------------------------
+
+locals {
+  # Per-member-account monthly ceiling (USD). Optional config key; defaults
+  # to 10 — the same shape as the org daily tripwire.
+  member_budget_usd = tostring(try(local.config.budget.member_monthly_usd, 10))
+}
+
+resource "aws_budgets_budget" "account_monthly" {
+  name         = "aegis-staging-monthly-usd${local.member_budget_usd}"
+  budget_type  = "COST"
+  limit_amount = local.member_budget_usd
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = local.config.budget.alert_emails
+  }
+}


### PR DESCRIPTION
Step 2 of 2 for ADR-019 — the budget resources, now that #258's apply landed the read/write permissions on the CI roles.

- `management/bootstrap/budgets.tf`: `aegis-daily-usd10` + `aegis-monthly-usd30` with **import blocks** (adopt, don't collide) + the LinkedAccount-filtered logarchive budget.
- `staging/bootstrap/budgets.tf` + `shared/bootstrap/budgets.tf`: new $10 monthly per-account budgets (80%/100% actual).
- Expected plan: management = **2 to import** + 2 to add (logarchive budget + notification reconcile shows as in-place change); staging/shared = 1 to add each.
- Tags: covered by each env's provider `default_tags` (no per-resource tags needed).

Verification: fmt + validate clean ×3 dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented AWS cost budgets across management, shared, and staging environments.
  * Adopted existing console daily and monthly org budgets for management.
  * Added optional per-linked-account budget for the log-archive account (created only if configured).
  * Added configurable member monthly default (USD 10).
  * Added 80% and 100% ACTUAL spend alerts delivered to configured email recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->