### PR TITLE
docs(claude): drop 6/12 keystone routing block — window closed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,5 @@
 # AWS Landing Zone Lab — AI Operational Rules
 
-> ⚠️ **ACTIVE until 2026-06-12 — aegis multi-account joint-strike.** Canonical plan:
-> `aegis-platform-aws/docs/runbooks/2026-06-12-joint-strike.md`. Read it before touching
-> org OIDC providers, the `gh-tf-*` SCP glob, or the shared registry account for this
-> campaign. (Remove after the window.)
-
 > 📍 **Cross-project rules now live in `~/.claude/CLAUDE.md`** (auto-loads for every repo):
 > language · date · bash · safety (a)(h)(i)(k)(m) · externalize-decisions · pre-push-diff ·
 > non-host-install · reusable-PII · AWS-tech-blog tone · subagent-delegation · no-hallucination.


### PR DESCRIPTION
## Summary

- Removes the `⚠️ ACTIVE until 2026-06-12` joint-strike routing block from `CLAUDE.md`
- The 6/12 window closed today; the runbook is done
- No functional change — purely a stale guidance block removal

## Test plan

- [ ] Confirm `CLAUDE.md` no longer contains `joint-strike` or `2026-06-12` routing text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development documentation to clarify cross-project configuration loading behavior.

**Note:** No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->