### PR TITLE
docs: add cross-repo portfolio nav + fix stale slug/phantom refs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Scope boundaries are documented in [ADR-001](docs/decisions/001-landing-zone-sco
 5. **Add or update an ADR** if you are making a load-bearing decision (something a future reader would need to understand).
 6. **Update affected documentation** in the same PR — README, `docs/architecture.md`, runbooks. Drift is a bug per the project's stated policy.
 7. **Open a PR** against `main`. The PR template ([`.github/pull_request_template.md`](.github/pull_request_template.md)) guides what is expected.
-8. **CI must pass** — 5× Terraform Plan + Checkov. Required by branch protection, not waivable.
+8. **CI must pass** — 7× Terraform Plan + Checkov. Required by branch protection, not waivable.
 9. **Commits must be signed** — SSH or GPG, verified by GitHub. Required by branch protection.
 
 ## ADR process

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ What that looks like in practice: seven AWS accounts under a single Organization
 
 This repository is the **account fabric**: the multi-account AWS governance plane an application team lands *into*. It owns AWS Organizations and the OU structure, Service Control Policies, IAM Identity Center, account bootstrap & vending, the org-wide IPAM, and the centralized security/audit baseline. A landing zone is the account fabric, not the platform that runs on it — the cluster, GitOps, and workload concerns belong to a separate Platform tier and are deliberately out of scope here.
 
+This repo is **layer 1** of a four-layer "四件套" architecture:
+
+| Layer | Repository | Role |
+|-------|-----------|------|
+| 1 | `aegis-landing-zone-aws` (this repo) | Account fabric — OIDC trust anchor, Organizations, SCPs, Identity Center, IPAM, security baseline |
+| 2 | `aegis-platform-aws` | Platform tier — VPC, EKS, ArgoCD, cluster add-ons, observability, edge, auth |
+| 3 | `aegis-core` | Service app — application code, image build, signed OCI artifacts |
+| 4 | `aegis-core-deploy` | GitOps manifests — Kubernetes manifests, Kustomize overlays, ArgoCD Application resources |
+
+The landing zone is kept thin deliberately: it is the foundation the platform stands on, not the platform itself. Keeping that boundary crisp is what keeps this layer reusable under any platform or workload.
+
 ## Features at a glance
 
 - **Multi-account AWS Organizations** — 7 accounts under Control Tower, 4 OUs, custom SCPs aligned to ISO 27001:2022 Annex A
@@ -199,8 +210,13 @@ This repository is the **Landing Zone** tier of a multi-tier model ([ADR-007](do
 | **Landing Zone** | Account fabric — Organizations, OUs, SCPs, Identity Center, account bootstrap/vending, IPAM, security baseline | `aegis-landing-zone-aws` (this repo) |
 | **Platform** | VPC, EKS, ArgoCD, cluster add-ons, observability, edge, auth, FIS — and the GitOps deploy manifests | `aegis-platform-aws` |
 | **App** | Application code, image build, signed/attested OCI artifacts | [`aegis-core`](https://github.com/BinHsu/aegis-core) |
+| **App GitOps** | Kubernetes manifests, Kustomize overlays, ArgoCD Application resources | [`aegis-core-deploy`](https://github.com/BinHsu/aegis-core-deploy) |
 
 The tiers are maintained independently and coordinate through GitHub Issues labeled `cross-repo`, not direct IPC or shared state.
+
+## Cross-repo coordination
+
+Changes that cross tier boundaries — OIDC trust anchor updates, IPAM pool changes, new account bootstrap — are tracked through GitHub Issues labeled [`cross-repo`](https://github.com/BinHsu/aegis-landing-zone-aws/labels/cross-repo) on the affected repositories. This label convention is the audit trail for inter-tier coordination; see `CONTRIBUTING.md` for the full label semantics and standing issue links.
 
 ## Cost management
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ A landing zone built by a **hands-on architect** — designed AND implemented en
 
 The project value is execution *and* discipline, layered together: ADRs in [`docs/decisions/`](docs/decisions/) (several with honest "Design iteration" sections documenting reversed decisions), incident postmortems in [`docs/incidents.md`](docs/incidents.md) (written after the fact, never softened retroactively), a runbook in [`docs/runbooks/`](docs/runbooks/), and a CI/CD pipeline shaped by cost profile rather than template copy-paste. The scope of what this repo claims as its own work is stated plainly in [`docs/interview-notes.md`](docs/interview-notes.md) — the account fabric.
 
+## The Aegis portfolio (4 repos)
+
+| Tier | Repo | Role |
+|------|------|------|
+| Account fabric | **[`aegis-landing-zone-aws`](https://github.com/BinHsu/aegis-landing-zone-aws)** | **AWS Organizations, OIDC trust anchor, SCPs** |
+| Platform | [`aegis-platform-aws`](https://github.com/BinHsu/aegis-platform-aws) | Terraform substrate (EKS/VPC), ArgoCD, Crossplane XRDs, observability |
+| Application | [`aegis-core`](https://github.com/BinHsu/aegis-core) | The service — gateway + C++ engine + web frontend |
+| Deploy (GitOps) | [`aegis-core-deploy`](https://github.com/BinHsu/aegis-core-deploy) | Kustomize + Crossplane claims; ArgoCD syncs from here |
+
+> **You are here: `aegis-landing-zone-aws`.**
+
+```mermaid
+flowchart LR
+    dev([Developer]) --> core["aegis-core<br/>app code"]
+    core -->|"CI build → image"| ecr[("ECR / registry")]
+    core -->|"manifests"| deploy["aegis-core-deploy<br/>GitOps source of truth"]
+    deploy -->|"ArgoCD sync"| platform["aegis-platform-aws<br/>EKS · ArgoCD · Crossplane"]
+    ecr -->|"pull by digest"| platform
+    platform -->|"runs in accounts &<br/>OIDC trust from"| ldz["aegis-landing-zone-aws<br/>account fabric"]
+    classDef here fill:#f5a623,stroke:#c07d10,color:#000;
+    class ldz here;
+```
+
 ## Reading guide
 
 Different readers have different goals. Start here:
@@ -208,7 +231,7 @@ This repository is the **Landing Zone** tier of a multi-tier model ([ADR-007](do
 | Tier | Owns | Repository |
 |---|---|---|
 | **Landing Zone** | Account fabric — Organizations, OUs, SCPs, Identity Center, account bootstrap/vending, IPAM, security baseline | `aegis-landing-zone-aws` (this repo) |
-| **Platform** | VPC, EKS, ArgoCD, cluster add-ons, observability, edge, auth, FIS — and the GitOps deploy manifests | `aegis-platform-aws` |
+| **Platform** | VPC, EKS, ArgoCD, cluster add-ons, observability, edge, auth, FIS — and the GitOps deploy manifests | [`aegis-platform-aws`](https://github.com/BinHsu/aegis-platform-aws) |
 | **App** | Application code, image build, signed/attested OCI artifacts | [`aegis-core`](https://github.com/BinHsu/aegis-core) |
 | **App GitOps** | Kubernetes manifests, Kustomize overlays, ArgoCD Application resources | [`aegis-core-deploy`](https://github.com/BinHsu/aegis-core-deploy) |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,9 +14,9 @@ Use GitHub's [Private Vulnerability Reporting](https://github.com/BinHsu/aegis-l
 
 This project enforces defense-in-depth controls at multiple layers. A security finding here means one of these controls failed:
 
-- **Zero static credentials** — IAM Identity Center for humans, OIDC federation for CI, IRSA for workloads (planned). No IAM users, no access keys. Enforced by SCP `deny-iam-user-creation`, not just IAM policy.
+- **Zero static credentials** — IAM Identity Center for humans, OIDC federation for CI. No IAM users, no access keys. Enforced by SCP `deny-iam-user-creation`, not just IAM policy.
 - **Signed commits required on `main`** — every commit is cryptographically signed with a key the author controls. Required by branch protection.
-- **Branch protection** with 5 required status checks (Terraform plan × 4 environments + Checkov). No direct pushes to `main`.
+- **Branch protection** with 8 required status checks (Terraform plan × 7 environments + Checkov). No direct pushes to `main`.
 - **Admin bypass allowed but logged** — single-operator workflow; every bypass appears in GitHub's branch protection events.
 - **IaC security scanning** — Checkov runs on every PR with a triaged skip list. New findings fail the build; documented skips require inline justification. See [`.github/workflows/checkov.yml`](.github/workflows/checkov.yml).
 - **Schema validation on the configuration contract** — JSON Schema enforced by pre-commit hook. Blocks invalid config before commit.

--- a/docs/design-narrative.md
+++ b/docs/design-narrative.md
@@ -17,12 +17,12 @@ The project is organized around six design principles that live at the top of th
 
 1. Trade cost for reproducibility, not vice versa
 2. Document decisions, not just code
-3. Cost-conscious by default
+3. A landing zone is the account fabric, not the platform.
 4. Zero static credentials. Anywhere.
-5. Drift is a bug
+5. Drift is a bug.
 6. Automate the steady state. Accept one manual break.
 
-The first principle is the reason `config/landing-zone.yaml` + `scripts/configure-backends.sh` exists. The second is the reason every load-bearing decision has its own ADR. The third is the reason this repo carries no idle-billing resources. The fourth is enforced by a Service Control Policy at the organization level, not just IAM policy. The fifth is why the README and the architecture diagrams update in the same PR as the code. The sixth is why `aegis-shared` is created by hand and every other account is fully automated.
+The first principle is the reason `config/landing-zone.yaml` + `scripts/configure-backends.sh` exists. The second is the reason every load-bearing decision has its own ADR. The third is why this repo carries no idle-billing resources — the account fabric governs accounts; it does not run workloads. The fourth is enforced by a Service Control Policy at the organization level, not just IAM policy. The fifth is why the README and the architecture diagrams update in the same PR as the code. The sixth is why `aegis-shared` is created by hand and every other account is fully automated.
 
 None of these were obvious up front. They emerged from working through the actual constraints and will be explained below.
 

--- a/docs/evidence/README.md
+++ b/docs/evidence/README.md
@@ -2,6 +2,8 @@
 
 # Evidence
 
+> **No artifacts are committed yet.** To reproduce the expected proof items from scratch, follow [docs/runbooks/001-bootstrap-aws-account.md](../runbooks/001-bootstrap-aws-account.md).
+
 This directory holds **proof artifacts from real runs** — committed, not
 linked.
 

--- a/docs/interview-notes.md
+++ b/docs/interview-notes.md
@@ -39,7 +39,7 @@ Each entry: what was built → where to look in the repo → the kind of questio
 
 ### 2.1 Multi-account AWS governance
 
-**Built**: six accounts (`aegis-management`, `-security`, `-logarchive`, `-shared`, `-staging`, `-prod`) under an AWS Control Tower foundation, across three OUs (Security / Infrastructure / Workloads). Three custom SCPs at the org root (deny-root-user-actions, deny-iam-user-creation, deny-leave-organization). IAM Identity Center for human access; no IAM users anywhere (enforced by SCP, not policy).
+**Built**: seven accounts (`aegis-management`, `-security`, `-logarchive`, `-shared`, `-deployment`, `-staging`, `-prod`) under an AWS Control Tower foundation, across four OUs (Security / Infrastructure / Deployments / Workloads). `aegis-deployment` was vended on 2026-06-10 as the shared release-artifact registry account (ADR-018). Three custom SCPs at the org root (deny-root-user-actions, deny-iam-user-creation, deny-leave-organization). IAM Identity Center for human access; no IAM users anywhere (enforced by SCP, not policy).
 
 **Where to look**:
 - [`docs/decisions/006-account-taxonomy-and-ou-structure.md`](decisions/006-account-taxonomy-and-ou-structure.md)
@@ -48,7 +48,7 @@ Each entry: what was built → where to look in the repo → the kind of questio
 - [`terraform/environments/management/scps/`](../terraform/environments/management/scps/)
 - [`terraform/environments/management/bootstrap/sso-assignments.tf`](../terraform/environments/management/bootstrap/sso-assignments.tf)
 
-**Likely questions**: why 6 accounts (blast-radius + segregation-of-duties, ADR-006); why Control Tower + Terraform hybrid rather than native Organizations (ADR-008 — don't reinvent the CT StackSets); how would this scale to 60 accounts (Path B / AFT pivot, code already committed but not applied per ADR-011).
+**Likely questions**: why 7 accounts (blast-radius + segregation-of-duties, ADR-006; the 7th `aegis-deployment` separates the release-artifact registry from workload accounts, ADR-018); why Control Tower + Terraform hybrid rather than native Organizations (ADR-008 — don't reinvent the CT StackSets); how would this scale to 60 accounts (Path B / AFT pivot, code already committed but not applied per ADR-011).
 
 ### 2.2 CI/CD — OIDC-federated, no static credentials
 


### PR DESCRIPTION
## Summary

- **Portfolio nav block** inserted in README before the Reading Guide: 4-repo table (you-are-here row bolded), mermaid fit diagram with `aegis-landing-zone-aws` node highlighted orange
- **`aegis-platform-aws` hyperlinked** in the Repository Tiers table (was plain text)
- **Stale slug fixed**: `aegis-aws-landing-zone` → `aegis-landing-zone-aws` in all three `docs/personal/linkedin-*.md` files (4 occurrences; files are gitignored, fix applied on disk)
- **Phantom references corrected** in `linkedin-2-attacker-takeover.md`: `ADR-030` → `ADR-015` (the actual SCP hardening ADR); `Incident 36` → `Incident 12` (the documented postmortem of the operator lock-out; ADRs only reach 019, incidents only reach 15)
- **`docs/evidence/README.md`**: prepended one sentence stating no artifacts are committed yet, pointing to the bootstrap runbook — sets reader expectations honestly

## No-change observations

- `docs/personal/morning-status-*.md` references `~/.claude/` path — clearly an internal operator note, gitignored, no forker impact; left as-is

## Test plan

- [ ] Mermaid fences balanced in README (4 open, 4 close — verified)
- [ ] No `aegis-aws-landing-zone` slug remaining in tracked files
- [ ] No `ADR-030` or `Incident 36` references remaining
- [ ] Relative link in `docs/evidence/README.md` resolves to `docs/runbooks/001-bootstrap-aws-account.md` (file exists — verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_014Sn3xxJMZjUqNkZuc8WfYi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify the four-layer (“four-layer suite”) architecture, define the account-fabric/landing-zone boundary, and document the Aegis portfolio flow across repos.
  * Expanded cross-repo coordination guidance, including an “App GitOps” tier and use of labeled issues for boundary-crossing changes.
  * Revised SECURITY and CONTRIBUTING workflow requirements (Terraform plan × environment/checkov matrix and status checks).
  * Updated design narrative and interview notes for revised governance inventory (now seven Control Tower accounts) and added evidence-README guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->