### PR TITLE
chore(ci): pin remaining GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Run Checkov
         id: checkov
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: results.sarif
           category: checkov

--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -69,7 +69,7 @@ jobs:
             account_id: "186052668286"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Write config
         run: |

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -49,7 +49,7 @@ jobs:
             account_id: "506221082337"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Write config
         run: |
@@ -94,7 +94,7 @@ jobs:
           fi
 
       - name: Comment Plan on PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: github.event_name == 'pull_request'
         env:
           # Pass user-controlled strings through env rather than direct


### PR DESCRIPTION
## Summary

- Pin `actions/checkout@v6` → `df4cb1c069e1874edd31b4311f1884172cec0e10` in all three workflows
- Pin `github/codeql-action/upload-sarif@v4` → `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` in `checkov.yml`
- Pin `actions/github-script@v9` → `3a2844b7e9c422d3c10d287c895573f7108da1b3` in `terraform-plan.yml`
- Already-pinned actions (`aws-actions/configure-aws-credentials`, `hashicorp/setup-terraform`, `bridgecrewio/checkov-action`) left untouched

## Test plan

- [ ] `grep -rnE "uses: .*@v[0-9]" .github/workflows/` returns empty (verified locally)
- [ ] Checkov scan CI passes on this PR
- [ ] Terraform plan CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Sn3xxJMZjUqNkZuc8WfYi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions configurations across multiple CI/CD workflows, including security scanning, Terraform planning, and deployment processes, for improved stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->