### PR TITLE
feat(scp): drop the ACK-IAM privilege-escalation carve-out (ADR-21 §A)

### DIFF
--- a/terraform/environments/management/scps/main.tf
+++ b/terraform/environments/management/scps/main.tf
@@ -173,18 +173,13 @@ resource "aws_organizations_policy_attachment" "deny_leave_org" {
 #     profiles for nodes. Karpenter's own policy already scopes these by tag
 #     and resource ARN; the SCP exception unblocks the legitimate code path
 #     without weakening Karpenter's own boundary.
-#   - aegis-platform-aws-ack-iam-* — the ACK IAM controller (AWS Controllers for
-#     Kubernetes) provisions per-workload IAM roles from `Role`/`Policy` CRDs
-#     declared in each workload's deploy repo (aegis-platform-aws ADR-07: workload
-#     self-ownership). Without this carve-out the controller cannot
-#     `iam:CreateRole` at all. The controller's own IAM policy is scoped to the
-#     `/aegis-workload/` IAM path (aegis-platform-aws irsa-ack-iam.tf), so it can
-#     only manage workload roles, never platform/CI/break-glass identities —
-#     the carve-out unblocks ACK while this SCP still caps escalation-to-Admin.
-#     PREFIX glob (region is the suffix, e.g. aegis-platform-aws-ack-iam-eu-central-1),
-#     unlike Karpenter's suffix glob. Forward-declaration: the role does not
-#     exist until the next platform bootstrap (the platform-tier EKS cluster is
-#     currently destroyed), so pre-permitting it is harmless. E2E PENDING.
+#   (Removed 2026-06-19, ADR-21 §A) aegis-platform-aws-ack-iam-* was the
+#     in-cluster Crossplane/ACK IAM controller's carve-out. That controller is
+#     retired (aegis-platform-aws #117 deletes crossplane.tf + irsa-ack-iam.tf +
+#     the aegis-xrds chart). Engine IAM is now a Terraform-owned role created by
+#     the gh-tf-* apply role (already allow-listed above) and delivered via EKS
+#     Pod Identity; no in-cluster principal calls iam:CreateRole anymore, so the
+#     carve-out is removed to re-tighten the wall.
 #
 # Service-Linked Roles (`iam:CreateServiceLinkedRole`) are intentionally
 # NOT in the deny list — AWS auto-creates SLRs for many services
@@ -236,7 +231,6 @@ resource "aws_organizations_policy" "deny_iam_privilege_escalation" {
               "arn:aws:iam::*:role/gh-tf-*",
               "arn:aws:iam::*:role/aegis-emergency-*",
               "arn:aws:iam::*:role/*-karpenter-controller",
-              "arn:aws:iam::*:role/aegis-platform-aws-ack-iam-*",
             ]
           }
         }


### PR DESCRIPTION
Paired landing-zone change for aegis-platform-aws #117 (engine IAM → EKS Pod Identity). With Crossplane retired, nothing in-cluster calls iam:CreateRole, so the aegis-platform-aws-ack-iam-* exemption in deny-iam-privilege-escalation is obsolete. The new Terraform-owned engine role is created by the already-allow-listed gh-tf-* role and only grants s3 model-read. Removing the carve-out re-tightens the privilege-escalation wall with no functional loss.

Safe to apply now (staging/prod torn down — no live Crossplane role to strand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened IAM privilege-escalation security restrictions by removing an outdated policy exception, tightening access controls for member accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->