### PR TITLE
fix(deployment): Terraform-manage gh-tf-apply-deployment trust so destroy-platform can assume it

### DIFF
--- a/terraform/environments/deployment/bootstrap/oidc-github-apply-deployment-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-apply-deployment-role.tf
@@ -1,0 +1,99 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-apply-deployment` — cross-account Terraform/ECR role for the shared
+# release registry (ADR-018 / aegis-platform-aws ADR-10).
+# -----------------------------------------------------------------------------
+# The platform-aws CI manages the shared ECR registry that lives in THIS
+# deployment account. It does so through a second AWS provider (the `aws.deployment`
+# alias in aegis-platform-aws terraform/envs/platform/deployment-ecr.tf) that
+# ASSUMES this role. On APPLY the platform runner is `gh-tf-apply-platform`; on
+# DESTROY (infra-ops.yml destroy-platform) the runner is `gh-tf-destroy-platform`.
+# BOTH must be able to assume this role or the `aws.deployment` provider cannot
+# configure and the operation aborts before it touches the shared registry.
+#
+# WHY HERE (landing-zone deployment/bootstrap), NOT in the platform state:
+#   - This role lives in the DEPLOYMENT account (162975888022). The default
+#     provider of this layer already targets that account, alongside the OIDC
+#     provider + the other gh-tf-* roles it seeds. Right account, right tier.
+#   - It CANNOT live in aegis-platform-aws envs/platform: that state is exactly
+#     what `destroy-platform` tears down, and that state ASSUMES this role to
+#     configure its provider. A role cannot create the role it assumes
+#     (chicken-egg), and a destroy would delete it mid-teardown (the self-delete
+#     class ADR-13 eliminated for the platform CI roles).
+#   - Previously the role was hand-seeded via break-glass and its trust policy
+#     was patched by hand (`aws iam update-assume-role-policy`, ws3-bring-up.md
+#     Phase 1b). That trust referenced ONLY gh-tf-apply-platform, so a
+#     destroy-platform run assuming gh-tf-destroy-platform got AssumeRole
+#     AccessDenied — the cross-account teardown gap this file closes. Making the
+#     role + trust Terraform-managed is the hardening follow-up named in
+#     ws3-bring-up.md Phase 1b ("make gh-tf-apply-deployment Terraform-managed
+#     (landing zone) so the trust is reproducible and never dangles again").
+#
+# SCP: the `gh-tf-*` name falls under the org-root deny-iam-privilege-escalation
+# carve-out (ADR-018), so creating it from gh-tf-apply-baseline is not SCP-denied
+# and no SCP change is required.
+#
+# PERMISSIONS: AdministratorAccess, matching the role's seeded reality (it manages
+# ECR repositories + cross-account repository/lifecycle policies + the scoped
+# workload push roles in deployment-ecr.tf). Tightening to an ECR/IAM-scoped policy
+# is deferred hardening, symmetric with the gh-tf-apply-platform admin attachment
+# in aegis-platform-aws.
+# -----------------------------------------------------------------------------
+
+locals {
+  # Platform accounts whose CI owns the shared-registry resources in THIS
+  # account (deployment-ecr.tf single-owner gate). Today only STAGING carries
+  # `deployment_account_id` in aegis-platform-aws/accounts.json, so only its
+  # apply/destroy roles assume gh-tf-apply-deployment. Add prod's id here IF
+  # registry ownership ever moves (keep it in lock-step with the
+  # `deployment_account_id` field in accounts.json — both sides must agree).
+  deployment_owning_platform_account_ids = [
+    local.config.accounts.staging.id,
+  ]
+
+  # Both platform CI roles must assume this role: gh-tf-apply-platform on apply,
+  # gh-tf-destroy-platform on destroy (infra-ops.yml destroy-platform). Omitting
+  # the destroy role is the bug this file fixes — destroy could not configure the
+  # `aws.deployment` provider and aborted before deleting the shared-registry
+  # resources it owns.
+  deployment_trusted_platform_role_arns = flatten([
+    for acct in local.deployment_owning_platform_account_ids : [
+      "arn:aws:iam::${acct}:role/gh-tf-apply-platform",
+      "arn:aws:iam::${acct}:role/gh-tf-destroy-platform",
+    ]
+  ])
+}
+
+resource "aws_iam_role" "gh_tf_apply_deployment" {
+  name = "gh-tf-apply-deployment"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          # Account-role principals (not the OIDC provider): the platform CI has
+          # already federated into its OWN account via OIDC, then makes a plain
+          # sts:AssumeRole hop into THIS account through the `aws.deployment`
+          # provider's assume_role block. So the trusted principal is the
+          # platform role ARN, and the action is sts:AssumeRole (not
+          # AssumeRoleWithWebIdentity).
+          AWS = local.deployment_trusted_platform_role_arns
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "gh_tf_apply_deployment_admin" {
+  role       = aws_iam_role.gh_tf_apply_deployment.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+output "gh_tf_apply_deployment_role_arn" {
+  description = "ARN of the cross-account Terraform/ECR role the platform CI assumes to manage the shared release registry (ADR-018)."
+  value       = aws_iam_role.gh_tf_apply_deployment.arn
+}


### PR DESCRIPTION
## Root cause

`destroy-platform` (infra-ops.yml, staging account 251774439261, run 27849482171) failed with:

```
Error: Cannot assume IAM Role
IAM Role (arn:aws:iam::162975888022:role/gh-tf-apply-deployment) cannot be assumed
... AccessDenied: ... is not authorized to perform sts:AssumeRole on .../gh-tf-apply-deployment
```

The platform env's `deployment-ecr.tf` configures an `aws.deployment` provider that assumes `gh-tf-apply-deployment` in the deployment account. On **apply** the platform runner is `gh-tf-apply-platform`; on **destroy** it is `gh-tf-destroy-platform`. The `gh-tf-apply-deployment` role was hand-seeded via break-glass and its trust policy was patched by hand (ws3-bring-up.md Phase 1b) to permit **only** `gh-tf-apply-platform`. So a destroy run — assuming `gh-tf-destroy-platform` — could not configure the `aws.deployment` provider and aborted before deleting the staging shared-registry resources.

## Fix (Option A — cross-account trust, in the LZ deployment/bootstrap seed layer)

New `oidc-github-apply-deployment-role.tf` Terraform-manages `gh-tf-apply-deployment` (role + AdministratorAccess attachment + trust). The trust now permits **both** platform CI roles:

- `gh-tf-apply-platform` — platform APPLY
- `gh-tf-destroy-platform` — platform DESTROY (the role that got AccessDenied)

This is the hardening follow-up named in ws3-bring-up.md Phase 1b ("make gh-tf-apply-deployment Terraform-managed so the trust is reproducible and never dangles again"). The trusted-account set is config-driven (`deployment_owning_platform_account_ids` = staging only today, the single registry owner per `accounts.json`; add prod only if ownership moves).

### Why this locus, not the platform state
- The role lives in the deployment account — this layer's default provider already targets it.
- It can NOT live in `aegis-platform-aws/envs/platform`: that state is what `destroy-platform` tears down and it *assumes* this role to configure its provider (chicken-egg + self-delete, the class ADR-13 removed for the platform CI roles).

## Validation
- `terraform fmt -check` clean
- `terraform validate` (backendless init) — Success

## Sequencing
Apply this LZ layer (via `gh-tf-apply-baseline`, the LZ CI apply role on merge to main) **before** re-running `destroy-platform`. The role already exists (6/12 survivor) with the correct admin attachment, so the apply is a trust-policy update in place (plus state adoption) — no new permissions on the role identity, only the resource-side trust widens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment environment infrastructure configuration with a new cross-account IAM role setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->