### PR TITLE
fix(deployment): import break-glass-seeded gh-tf-apply-deployment role (#15, unblocks baseline apply)

### DIFF
--- a/terraform/environments/deployment/bootstrap/oidc-github-apply-deployment-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-apply-deployment-role.tf
@@ -63,6 +63,23 @@ locals {
   ])
 }
 
+# ---------------------------------------------------------------------------
+# Import blocks — adopt the break-glass-seeded role so Terraform can manage
+# it going forward (root cause: EntityAlreadyExists on baseline apply, #15).
+# These blocks are safe to leave in place; after a successful apply+state
+# reconcile they become no-ops. Remove them once the role is confirmed in
+# state (i.e. a subsequent plan shows "No changes").
+# ---------------------------------------------------------------------------
+import {
+  to = aws_iam_role.gh_tf_apply_deployment
+  id = "gh-tf-apply-deployment"
+}
+
+import {
+  to = aws_iam_role_policy_attachment.gh_tf_apply_deployment_admin
+  id = "gh-tf-apply-deployment/arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
 resource "aws_iam_role" "gh_tf_apply_deployment" {
   name = "gh-tf-apply-deployment"
 


### PR DESCRIPTION
## Problem

Baseline apply run [27861755562](https://github.com/BinHsu/aegis-landing-zone-aws/actions/runs/27861755562) failed with:

```
Error: creating IAM Role (gh-tf-apply-deployment): ... 409 EntityAlreadyExists: Role with name gh-tf-apply-deployment already exists.
```

PR #274 (merged to main) made `gh-tf-apply-deployment` Terraform-managed for the first time. Because the role was hand-seeded via break-glass on 2026-06-10 (chicken-and-egg: SCP gates IAM writes to `gh-tf-*`), it already exists in the deployment account — so Terraform tried to CREATE it and got a 409.

## Fix

Add two TF 1.5+ config-driven `import` blocks in `oidc-github-apply-deployment-role.tf` so the next apply ADOPTS the existing role and its AdministratorAccess attachment into state rather than attempting creation:

```hcl
import {
  to = aws_iam_role.gh_tf_apply_deployment
  id = "gh-tf-apply-deployment"
}

import {
  to = aws_iam_role_policy_attachment.gh_tf_apply_deployment_admin
  id = "gh-tf-apply-deployment/arn:aws:iam::aws:policy/AdministratorAccess"
}
```

## Live resource confirmed (pre-merge)

- **Role ARN**: `arn:aws:iam::162975888022:role/gh-tf-apply-deployment`
- **Path**: `/` (matches TF declaration)
- **Current trust**: single principal `arn:aws:iam::251774439261:role/gh-tf-apply-platform` (break-glass seeded)
- **Attached policy**: `AdministratorAccess` — attachment import block included
- **Inline policies**: none

## What apply will do after merge

1. Import both resources into state (no AWS mutation).
2. UPDATE the trust policy from the single hand-seeded principal to the dual-principal declared in TF (`gh-tf-apply-platform` + `gh-tf-destroy-platform`). This is the intended reconciliation from PR #274 — closes the cross-account destroy gap.
3. Remaining `deployment/bootstrap` resources that the failed apply never reached (OIDC provider, other `gh-tf-*` roles, budgets, emergency role) will be created normally in the same run.

## Partial state from failed apply (run 27861755562)

The apply failed on the **first IAM Role create** (`gh-tf-apply-deployment`). No other deployment/bootstrap resources were written — the error was the very first resource action, so no partial state cleanup is needed. All other resources in this layer will be created fresh by the re-apply.

## Test plan

- [ ] Merge triggers `Apply deployment/bootstrap` CI run
- [ ] Plan phase shows `import` actions for `aws_iam_role.gh_tf_apply_deployment` and `aws_iam_role_policy_attachment.gh_tf_apply_deployment_admin`, plus `create` for remaining bootstrap resources
- [ ] Apply completes green — no 409 on the role, trust policy updated to dual-principal
- [ ] Subsequent plan shows "No changes" (import blocks are no-ops once reconciled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBsAfKpGhq8iuXSBhWWNef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to manage existing deployment resources through state management, enabling better control over pre-existing cloud infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->