### PR TITLE
fix(ci): always report Plan staging/network so non-network PRs are mergeable

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -32,6 +32,12 @@ jobs:
         # Account-fabric layers only — Organizations / SCPs / Identity Center,
         # account bootstrap, and the org-wide IPAM. Every layer uses a
         # full-literal S3 backend, so `terraform init` needs no extra config.
+        #
+        # Optional `paths` key: when set, the job detects whether the PR
+        # touched those paths. If not, it short-circuits to green without
+        # running `terraform plan` — so the required-status-check is ALWAYS
+        # reported, but a real plan only fires when the layer is affected.
+        # Rows WITHOUT `paths` always run a full plan (no short-circuit).
         include:
           - env: management/bootstrap
             account_id: "186052668286"
@@ -45,13 +51,68 @@ jobs:
             account_id: "162975888022"
           - env: staging/bootstrap
             account_id: "251774439261"
+          - env: staging/network
+            account_id: "251774439261"
+            # Only run the real plan when staging/network files or the shared
+            # config change; otherwise short-circuit to green so the required
+            # status check is satisfied without a real AWS plan call.
+            paths: "terraform/environments/staging/network/ config/"
           - env: prod/bootstrap
             account_id: "506221082337"
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          # Need full history to compare with the base branch for path detection.
+          fetch-depth: 0
+
+      # -----------------------------------------------------------------------
+      # Path-change detection (only runs when matrix.paths is set).
+      # Compares the PR head against the merge base to decide whether any
+      # file under the watched paths changed. Sets output `changed` = true/false.
+      # -----------------------------------------------------------------------
+      - name: Detect path changes
+        id: paths
+        if: matrix.paths != ''
+        env:
+          WATCH_PATHS: ${{ matrix.paths }}
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          CHANGED="false"
+          for p in $WATCH_PATHS; do
+            if git diff --name-only "$BASE" "$HEAD" -- "$p" | grep -q .; then
+              CHANGED="true"
+              break
+            fi
+          done
+          echo "changed=${CHANGED}" >> "$GITHUB_OUTPUT"
+          echo "Watched paths: ${WATCH_PATHS}"
+          echo "Changes detected: ${CHANGED}"
+
+      # Short-circuit: post a green "no changes to this layer" status and exit
+      # without touching AWS when no relevant paths changed.
+      - name: Skip — no relevant path changes
+        if: matrix.paths != '' && steps.paths.outputs.changed == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          MATRIX_ENV: ${{ matrix.env }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          ACTOR: ${{ github.actor }}
+        with:
+          script: |
+            const matrixEnv = process.env.MATRIX_ENV || '';
+            const headRef   = process.env.HEAD_REF   || '';
+            const actor     = process.env.ACTOR      || '';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### ✅ Terraform Plan: \`${matrixEnv}\`\n\n**Result:** No changes to this layer — plan skipped.\n\n*Triggered by @${actor} on \`${headRef}\`*`,
+            });
 
       - name: Write config
+        if: matrix.paths == '' || steps.paths.outputs.changed == 'true'
         run: |
           mkdir -p config
           cat <<'EOFCONFIG' > config/landing-zone.yaml
@@ -59,20 +120,24 @@ jobs:
           EOFCONFIG
 
       - uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        if: matrix.paths == '' || steps.paths.outputs.changed == 'true'
         with:
           role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/gh-tf-plan
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        if: matrix.paths == '' || steps.paths.outputs.changed == 'true'
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
       - name: Terraform Init
+        if: matrix.paths == '' || steps.paths.outputs.changed == 'true'
         working-directory: terraform/environments/${{ matrix.env }}
         run: terraform init -input=false
 
       - name: Terraform Plan
         working-directory: terraform/environments/${{ matrix.env }}
+        if: matrix.paths == '' || steps.paths.outputs.changed == 'true'
         id: plan
         # -lock-timeout=10m serializes concurrent plans that hit the same state
         # file (Dependabot bulk rebases — see Incident 10).
@@ -81,6 +146,7 @@ jobs:
 
       - name: Determine plan status
         id: status
+        if: matrix.paths == '' || steps.paths.outputs.changed == 'true'
         run: |
           if [ "${{ steps.plan.outcome }}" == "failure" ]; then
             echo "icon=❌" >> "$GITHUB_OUTPUT"
@@ -95,7 +161,7 @@ jobs:
 
       - name: Comment Plan on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        if: github.event_name == 'pull_request'
+        if: (matrix.paths == '' || steps.paths.outputs.changed == 'true') && github.event_name == 'pull_request'
         env:
           # Pass user-controlled strings through env rather than direct
           # template interpolation — plan output can contain backticks or
@@ -137,5 +203,5 @@ jobs:
             });
 
       - name: Fail if plan errored
-        if: steps.plan.outcome == 'failure'
+        if: (matrix.paths == '' || steps.paths.outputs.changed == 'true') && steps.plan.outcome == 'failure'
         run: exit 1

--- a/terraform/environments/staging/network/backend.tf
+++ b/terraform/environments/staging/network/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "staging/network/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/staging/network/config.tf
+++ b/terraform/environments/staging/network/config.tf
@@ -1,0 +1,17 @@
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.staging.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+  tags = merge(local.config.tags, {
+    Environment = "staging"
+    Layer       = "network"
+  })
+}
+
+check "exactly_one_primary_region" {
+  assert {
+    condition     = length([for r in local.config.regions : r if r.role == "primary"]) == 1
+    error_message = "config/landing-zone.yaml regions[] must have exactly one entry with role: primary."
+  }
+}

--- a/terraform/environments/staging/network/main.tf
+++ b/terraform/environments/staging/network/main.tf
@@ -1,0 +1,10 @@
+# staging/network — VPC, subnets, and Transit Gateway attachments for the
+# staging account.
+#
+# This layer is intentionally empty until the network topology is designed
+# (tracked in GitHub Issues). The environment file exists now so that the
+# CI required-status-check `Plan staging/network` can report on every PR
+# (the check is gated by path filter in the workflow — see
+# .github/workflows/terraform-plan.yml).
+
+data "aws_caller_identity" "current" {}

--- a/terraform/environments/staging/network/providers.tf
+++ b/terraform/environments/staging/network/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/staging/network/versions.tf
+++ b/terraform/environments/staging/network/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The ruleset `main-protection` lists `Plan staging/network` as a required status check. However:

1. `terraform/environments/staging/network/` did not exist.
2. The `terraform-plan.yml` matrix had no `staging/network` entry.
3. Therefore the check was **never reported** — not pending, not failed, simply absent.
4. GitHub's "strict required status check" treats an absent check as unsatisfied → **every PR that did not touch staging/network files hit "base branch policy prohibits the merge"** with no escape short of `--admin` override.

## Fix

**Workflow-level fix (Option A — path-change detection pattern):**

- Add `terraform/environments/staging/network/` as a minimal placeholder Terraform environment (`backend.tf`, `providers.tf`, `versions.tf`, `config.tf`, `main.tf`). The environment is intentionally nearly empty — it exists to give the CI job something to `terraform init` + `plan` against.
- Add `staging/network` to the `terraform-plan.yml` matrix with an optional `paths` key.
- Add a **path-change detection step**: on PRs that do not touch `terraform/environments/staging/network/` or `config/`, the job posts a green "plan skipped — no relevant changes" comment and exits success. All subsequent AWS steps are gated on `steps.paths.outputs.changed == 'true'`.
- When staging/network files **are** changed, the full `terraform init` + `terraform plan` executes as normal — the gate is real.
- All other matrix rows are unchanged; they always run a full plan.

## What changes

| File | Change |
|---|---|
| `.github/workflows/terraform-plan.yml` | Add `staging/network` matrix row + `paths` field; add `fetch-depth: 0`; add path-detection + short-circuit steps; gate AWS steps on `changed == true` |
| `terraform/environments/staging/network/backend.tf` | S3 backend in shared-account state bucket |
| `terraform/environments/staging/network/versions.tf` | Provider constraints matching other staging layers |
| `terraform/environments/staging/network/config.tf` | Reads `landing-zone.yaml`, resolves account/region/tags |
| `terraform/environments/staging/network/providers.tf` | AWS provider scoped to staging account |
| `terraform/environments/staging/network/main.tf` | Placeholder with explanatory comment |

## Test plan

- [ ] Open a PR that touches only non-network files (e.g. an IAM change) — `Plan staging/network` should appear green with "plan skipped" comment; PR should be mergeable once other checks pass.
- [ ] Open a PR that modifies `terraform/environments/staging/network/` — `Plan staging/network` should run a real `terraform plan` against AWS.
- [ ] Verify no regression: all other `Plan <env>` checks (management/bootstrap, scps, shared/*, staging/bootstrap, prod/bootstrap) still run normally on every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBsAfKpGhq8iuXSBhWWNef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Terraform planning workflow to skip unnecessary plan runs when specific infrastructure paths are unchanged, reducing CI/CD overhead
  * Established staging network environment infrastructure with state backend, provider configuration, and validation checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->