### PR TITLE
feat(fabric): LZ-baseline S1 — security + logarchive TF environments

### DIFF
--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -74,9 +74,9 @@ jobs:
           # bootstrap row (foundation-first, SCPs-last ordering, see comment
           # above).
           - env: security/bootstrap
-            account_id: "<SECURITY_ACCOUNT_ID>"
+            account_id: "763879260536"
           - env: logarchive/bootstrap
-            account_id: "<LOGARCHIVE_ACCOUNT_ID>"
+            account_id: "118907880354"
           - env: management/scps
             account_id: "186052668286"
 

--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -17,6 +17,8 @@ on:
       - 'terraform/environments/deployment/bootstrap/**'
       - 'terraform/environments/staging/bootstrap/**'
       - 'terraform/environments/prod/bootstrap/**'
+      - 'terraform/environments/security/bootstrap/**'
+      - 'terraform/environments/logarchive/bootstrap/**'
       - 'config/**'
 
   # Manual safety valve. Use when:
@@ -65,6 +67,16 @@ jobs:
             account_id: "251774439261"
           - env: prod/bootstrap
             account_id: "506221082337"
+          # Account IDs not yet known to this PR — config/landing-zone.yaml is
+          # gitignored and not populated with real security/logarchive account
+          # IDs at authoring time (#303). Replace before merge; see the PR body.
+          # Placed before management/scps like every other member-account
+          # bootstrap row (foundation-first, SCPs-last ordering, see comment
+          # above).
+          - env: security/bootstrap
+            account_id: "<SECURITY_ACCOUNT_ID>"
+          - env: logarchive/bootstrap
+            account_id: "<LOGARCHIVE_ACCOUNT_ID>"
           - env: management/scps
             account_id: "186052668286"
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -47,6 +47,13 @@ jobs:
             account_id: "251774439261"
           - env: prod/bootstrap
             account_id: "506221082337"
+          # Account IDs not yet known to this PR — config/landing-zone.yaml is
+          # gitignored and not populated with real security/logarchive account
+          # IDs at authoring time (#303). Replace before merge; see the PR body.
+          - env: security/bootstrap
+            account_id: "<SECURITY_ACCOUNT_ID>"
+          - env: logarchive/bootstrap
+            account_id: "<LOGARCHIVE_ACCOUNT_ID>"
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -51,9 +51,9 @@ jobs:
           # gitignored and not populated with real security/logarchive account
           # IDs at authoring time (#303). Replace before merge; see the PR body.
           - env: security/bootstrap
-            account_id: "<SECURITY_ACCOUNT_ID>"
+            account_id: "763879260536"
           - env: logarchive/bootstrap
-            account_id: "<LOGARCHIVE_ACCOUNT_ID>"
+            account_id: "118907880354"
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/terraform/environments/logarchive/bootstrap/.terraform.lock.hcl
+++ b/terraform/environments/logarchive/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.40"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/environments/logarchive/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/logarchive/bootstrap/aegis-emergency-role.tf
@@ -1,0 +1,126 @@
+# -----------------------------------------------------------------------------
+# `aegis-emergency-break-glass` — break-glass recovery role (ADR-015 OQ-1)
+# -----------------------------------------------------------------------------
+# Materializes the `aegis-emergency-*` namespace reserved by ADR-015's SCP
+# allow-list (`deny-iam-privilege-escalation`). This is the logarchive-account
+# variant — see `terraform/environments/management/bootstrap/aegis-emergency-
+# role.tf` for the full design narrative and the recovery shape that
+# motivates the role.
+#
+# Scope difference from mgmt: no Organizations / SSO / IdentityStore Sids.
+# Those API surfaces only carry power in mgmt; in member accounts they
+# return empty inventories at best and produce no useful break-glass
+# primitive. The logarchive-account permission policy is therefore the IAM /
+# KMS / SSM PS subset.
+#
+# Trust policy: identical pattern to mgmt — local-account PlatformAdmin
+# SSO sessions only, time-bounded to 1 hour.
+#
+# SCP interaction: `aegis-emergency-break-glass` matches `aegis-emergency-*`
+# in ADR-015's SCP allow-list. No SCP change required by this PR.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "aegis_emergency_break_glass" {
+  name                 = "aegis-emergency-break-glass"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OperatorViaPlatformAdminSso"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${local.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
+  # checkov:skip=CKV_AWS_287: Read-shape Sids (IamReadAll, KmsReadAndDecrypt's Describe/List/Get verbs, StsAndTagRead) intentionally use Resource:* for inventory access during break-glass diagnosis. Mutation surface is in IamMutationOnProjectRoles, scoped or trust-policy-gated. ADR-015 OQ-1.
+  # checkov:skip=CKV_AWS_288: Same as 287 — break-glass requires broad read for diagnosis; mutations are scoped. Read-shape data disclosure is the explicit threat model accepted by ADR-015.
+  # checkov:skip=CKV_AWS_289: iam:* is intentionally allowed but scoped to aegis-*/gh-tf-*/github-actions-* prefixes. Permission-management within fixed prefixes is the break-glass contract.
+  # checkov:skip=CKV_AWS_290: Resource:* on read-only Sids is required because the corresponding AWS APIs do not support resource-level ARN constraints. Trust policy (PlatformAdmin SSO only) is the gate.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sids and on AWS APIs without resource-level ARN support.
+  # checkov:skip=CKV2_AWS_40: iam:* on a fixed ARN-prefix scope is the deliberate break-glass design (ADR-015 OQ-1 graduation).
+  name = "emergency-break-glass-scoped"
+  role = aws_iam_role.aegis_emergency_break_glass.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Scoped IAM mutation — the primary break-glass primitive.
+        Sid    = "IamMutationOnProjectRoles"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+        ]
+      },
+      {
+        # IAM read across the account. Diagnosis needs full inventory;
+        # mutations are bounded by IamMutationOnProjectRoles above.
+        Sid    = "IamReadAll"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:Simulate*",
+        ]
+        Resource = "*"
+      },
+      {
+        # KMS read + Decrypt scoped to local-account keys only. Required
+        # for reading SSM PS SecureString values during diagnosis. No
+        # Encrypt / GenerateDataKey — break-glass is read-recovery.
+        Sid    = "KmsReadAndDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Describe*",
+          "kms:List*",
+          "kms:Get*",
+          "kms:Decrypt",
+        ]
+        Resource = "arn:aws:kms:*:${local.account_id}:key/*"
+      },
+      {
+        # SSM PS read on `/aegis/*` paths only. Diagnosis often needs to
+        # confirm a parameter is present and decrypts cleanly. Read-only.
+        Sid    = "SsmReadProject"
+        Effect = "Allow"
+        Action = [
+          "ssm:Get*",
+          "ssm:Describe*",
+          "ssm:List*",
+        ]
+        Resource = "arn:aws:ssm:*:${local.account_id}:parameter/aegis/*"
+      },
+      {
+        # Identity + audit visibility. Read-only; AWS-API-shape Resource:*.
+        Sid    = "StsAndTagRead"
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "tag:Get*",
+          "iam:GenerateCredentialReport",
+          "iam:GenerateServiceLastAccessedDetails",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/logarchive/bootstrap/backend.tf
+++ b/terraform/environments/logarchive/bootstrap/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "logarchive/bootstrap/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/logarchive/bootstrap/config.tf
+++ b/terraform/environments/logarchive/bootstrap/config.tf
@@ -1,0 +1,16 @@
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.logarchive.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+  tags = merge(local.config.tags, {
+    Environment = "logarchive"
+  })
+}
+
+check "exactly_one_primary_region" {
+  assert {
+    condition     = length([for r in local.config.regions : r if r.role == "primary"]) == 1
+    error_message = "config/landing-zone.yaml regions[] must have exactly one entry with role: primary."
+  }
+}

--- a/terraform/environments/logarchive/bootstrap/iam-survivor-import.tf
+++ b/terraform/environments/logarchive/bootstrap/iam-survivor-import.tf
@@ -1,0 +1,63 @@
+# ============================================================================
+# One-time adoption (logarchive account cold-start) of the IAM roles this
+# bootstrap layer manages, in case they were seeded outside Terraform.
+#
+# WHY: `logarchive/bootstrap` is a BRAND NEW Terraform environment (#303) — the
+# account has never had Terraform managing it. The normal cold-start path is
+# a first LOCAL `terraform apply` under break-glass credentials (see the PR
+# body for #303 / issue #303's manual-seed runbook), which CREATEs the three
+# roles below fresh — no import needed.
+#
+# This file exists as the ESCAPE HATCH for the other case: an operator who
+# manually pre-created the three roles (console/CLI) before Terraform ever
+# ran in this account — e.g. to unblock CI faster, or because AWSControl
+# TowerExecution was used to hand-seed them. A plain `terraform apply` would
+# then fail EntityAlreadyExists trying to CREATE a role that already exists.
+# These config-driven import blocks ADOPT the existing roles into state
+# instead. After import, apply UPDATEs each role in place to match the
+# declared config (a no-op if the live policy already matches) — no recreate,
+# no manual `terraform import` / state surgery. Same precedent as prod/
+# bootstrap's iam-survivor-import.tf (#278) and #15
+# (oidc-github-apply-deployment-role.tf in the deployment account).
+#
+# GATE: the import is TOGGLEABLE, OFF by default, gated on
+# var.adopt_seeded_iam_roles via a for_each toggle: when false (the normal
+# fresh-account path), toset([]) generates no import block; when true, each
+# block adopts its survivor.
+#
+# ONE-TIME: set var.adopt_seeded_iam_roles=true only for a logarchive-account
+# apply where the roles were hand-seeded ahead of Terraform. Once this
+# account's bootstrap state reflects the roles (adopted or freshly created),
+# REMOVE this file and the variable in a later cleanup PR — an import block
+# whose target is already in state is a no-op, so leaving it is harmless but
+# it has served its single purpose.
+#
+# NOT IMPORTED — the attached inline role policies (aegis_emergency_break_glass,
+# gh_tf_apply_baseline, gh_tf_plan) are Put*-idempotent: apply converges them
+# onto the adopted roles without their own import blocks.
+# ============================================================================
+
+# Role name = import id for aws_iam_role. Each `to` address is confirmed present
+# in this layer (aegis-emergency-role.tf / oidc-github-baseline-role.tf /
+# oidc-github-plan-role.tf).
+
+# break-glass recovery role (ADR-015 OQ-1)
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["break_glass"]) : toset([])
+  to       = aws_iam_role.aegis_emergency_break_glass
+  id       = "aegis-emergency-break-glass"
+}
+
+# baseline apply role for terraform-apply-baseline.yml (ADR-014)
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["apply_baseline"]) : toset([])
+  to       = aws_iam_role.gh_tf_apply_baseline
+  id       = "gh-tf-apply-baseline"
+}
+
+# read-only plan role for terraform-plan.yml on PRs (ADR-014)
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["plan"]) : toset([])
+  to       = aws_iam_role.gh_tf_plan
+  id       = "gh-tf-plan"
+}

--- a/terraform/environments/logarchive/bootstrap/iam-survivor-import.tf
+++ b/terraform/environments/logarchive/bootstrap/iam-survivor-import.tf
@@ -1,24 +1,33 @@
 # ============================================================================
-# One-time adoption (logarchive account cold-start) of the IAM roles this
+# One-time adoption (logarchive account cold-start) of the resources this
 # bootstrap layer manages, in case they were seeded outside Terraform.
 #
-# WHY: `logarchive/bootstrap` is a BRAND NEW Terraform environment (#303) — the
-# account has never had Terraform managing it. The normal cold-start path is
-# a first LOCAL `terraform apply` under break-glass credentials (see the PR
-# body for #303 / issue #303's manual-seed runbook), which CREATEs the three
-# roles below fresh — no import needed.
+# WHY: `logarchive/bootstrap` is a BRAND NEW Terraform environment (#303) —
+# the account has never had Terraform managing it. The normal cold-start
+# path is a first LOCAL `terraform apply` under break-glass credentials (see
+# the PR body for #303 / issue #303's manual-seed runbook), which CREATEs
+# all eight resources below fresh — no import needed.
 #
 # This file exists as the ESCAPE HATCH for the other case: an operator who
-# manually pre-created the three roles (console/CLI) before Terraform ever
-# ran in this account — e.g. to unblock CI faster, or because AWSControl
-# TowerExecution was used to hand-seed them. A plain `terraform apply` would
-# then fail EntityAlreadyExists trying to CREATE a role that already exists.
-# These config-driven import blocks ADOPT the existing roles into state
-# instead. After import, apply UPDATEs each role in place to match the
-# declared config (a no-op if the live policy already matches) — no recreate,
-# no manual `terraform import` / state surgery. Same precedent as prod/
-# bootstrap's iam-survivor-import.tf (#278) and #15
+# manually pre-created the resources (console/CLI, or a local `terraform
+# apply` under AWSControlTowerExecution whose state was then discarded)
+# before Terraform's S3 backend ever ran in this account — e.g. to unblock
+# CI faster. A plain `terraform apply` against the (empty) S3 state would
+# then fail EntityAlreadyExists trying to CREATE a resource that already
+# exists. These config-driven import blocks ADOPT the existing resources
+# into state instead. After import, apply UPDATEs each resource in place to
+# match the declared config (a no-op if the live resource already matches) —
+# no recreate, no manual `terraform import` / state surgery. Same precedent
+# as prod/bootstrap's iam-survivor-import.tf (#278) and #15
 # (oidc-github-apply-deployment-role.tf in the deployment account).
+#
+# SCOPE: covers all eight resources this layer creates in a member account —
+# the account alias, the GitHub OIDC provider, the three gh-tf-*/aegis-
+# emergency-* roles, and their three inline role policies. The role policies
+# are Put*-idempotent (PutRolePolicy upserts, no EntityAlreadyExists) so they
+# are technically safe to leave un-imported, but importing them too avoids a
+# spurious "will be created" noise in the first plan/apply against adopted
+# roles.
 #
 # GATE: the import is TOGGLEABLE, OFF by default, gated on
 # var.adopt_seeded_iam_roles via a for_each toggle: when false (the normal
@@ -26,20 +35,17 @@
 # block adopts its survivor.
 #
 # ONE-TIME: set var.adopt_seeded_iam_roles=true only for a logarchive-account
-# apply where the roles were hand-seeded ahead of Terraform. Once this
-# account's bootstrap state reflects the roles (adopted or freshly created),
+# apply where these resources were hand-seeded ahead of Terraform. Once this
+# account's bootstrap state reflects them (adopted or freshly created),
 # REMOVE this file and the variable in a later cleanup PR — an import block
 # whose target is already in state is a no-op, so leaving it is harmless but
 # it has served its single purpose.
-#
-# NOT IMPORTED — the attached inline role policies (aegis_emergency_break_glass,
-# gh_tf_apply_baseline, gh_tf_plan) are Put*-idempotent: apply converges them
-# onto the adopted roles without their own import blocks.
 # ============================================================================
 
-# Role name = import id for aws_iam_role. Each `to` address is confirmed present
-# in this layer (aegis-emergency-role.tf / oidc-github-baseline-role.tf /
-# oidc-github-plan-role.tf).
+# ---- IAM roles --------------------------------------------------------------
+# Role name = import id for aws_iam_role. Each `to` address is confirmed
+# present in this layer (aegis-emergency-role.tf / oidc-github-baseline-
+# role.tf / oidc-github-plan-role.tf).
 
 # break-glass recovery role (ADR-015 OQ-1)
 import {
@@ -60,4 +66,57 @@ import {
   for_each = var.adopt_seeded_iam_roles ? toset(["plan"]) : toset([])
   to       = aws_iam_role.gh_tf_plan
   id       = "gh-tf-plan"
+}
+
+# ---- IAM inline role policies -----------------------------------------------
+# Import id shape for aws_iam_role_policy is "ROLE_NAME:POLICY_NAME" — both
+# halves read verbatim off the `name` / `role` arguments in each resource
+# (aegis-emergency-role.tf / oidc-github-baseline-role.tf / oidc-github-plan-
+# role.tf). Not strictly required (PutRolePolicy upserts, no
+# EntityAlreadyExists) but importing keeps the first plan clean.
+
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["break_glass_policy"]) : toset([])
+  to       = aws_iam_role_policy.aegis_emergency_break_glass
+  id       = "aegis-emergency-break-glass:emergency-break-glass-scoped"
+}
+
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["apply_baseline_policy"]) : toset([])
+  to       = aws_iam_role_policy.gh_tf_apply_baseline
+  id       = "gh-tf-apply-baseline:apply-baseline-scoped"
+}
+
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["plan_policy"]) : toset([])
+  to       = aws_iam_role_policy.gh_tf_plan
+  id       = "gh-tf-plan:plan-readonly"
+}
+
+# ---- Account-global singletons ----------------------------------------------
+# Unlike the roles above, these two import ids are NOT stable literals across
+# accounts — they must resolve per-account, so each uses a dynamic or
+# per-account-config expression rather than a hardcoded string shared with
+# another environment's copy of this file.
+
+# GitHub OIDC identity provider (oidc-github.tf). Import id is the provider
+# ARN, which embeds this account's id — resolved via the `data.aws_caller_
+# identity.current` already declared in main.tf, so no new data source is
+# needed. The provider "path" segment reuses `local.github_oidc_url`
+# (oidc-github.tf) via the same `replace(..., "https://", "")` idiom the
+# trust policies already use, so it can never drift from the resource's own
+# `url` argument.
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["oidc_provider"]) : toset([])
+  to       = aws_iam_openid_connect_provider.github
+  id       = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(local.github_oidc_url, "https://", "")}"
+}
+
+# IAM account alias (main.tf). Import id is the alias string itself; this
+# reuses the exact literal `aws_iam_account_alias.this` is configured with
+# in main.tf for this account.
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["account_alias"]) : toset([])
+  to       = aws_iam_account_alias.this
+  id       = "binhsu-aegis-logarchive"
 }

--- a/terraform/environments/logarchive/bootstrap/main.tf
+++ b/terraform/environments/logarchive/bootstrap/main.tf
@@ -1,0 +1,12 @@
+resource "aws_iam_account_alias" "this" {
+  account_alias = "binhsu-aegis-logarchive"
+}
+
+data "aws_caller_identity" "current" {}
+
+check "config_account_id_not_empty" {
+  assert {
+    condition     = local.account_id != ""
+    error_message = "accounts.logarchive.id in landing-zone.yaml is empty. Create the account first (Runbook 001 Part 9)."
+  }
+}

--- a/terraform/environments/logarchive/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/logarchive/bootstrap/oidc-github-baseline-role.tf
@@ -1,0 +1,175 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-apply-baseline` — apply role for `terraform-apply-baseline.yml` (ADR-014)
+# -----------------------------------------------------------------------------
+# Apply role for the `ref:refs/heads/main` trigger. The `pull_request` trigger
+# assumes its own read-only role, `gh-tf-plan`. These two are the only CI roles.
+#
+# Scope: the logarchive account's only landing-zone Terraform is
+# `logarchive/bootstrap` itself — the account alias, the GitHub OIDC
+# provider, and the gh-tf-* / aegis-emergency-* roles. The permission policy
+# below is therefore exactly IAM-on-project-prefixes + account alias +
+# cross-account Terraform state.
+#
+# Scope note (LZ-baseline S1, #303, epic #302 D2): THIN environment by
+# design — logarchive owns no application resources here. CloudTrail /
+# Config log buckets stay Control-Tower-owned; this layer never creates or
+# manages them. No detective-service mutation permissions either — this
+# account is a log destination, not a detective-service delegated admin.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_apply_baseline" {
+  name = "gh-tf-apply-baseline"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
+          # Rename-proof: the immutable repository_id (StringEquals above) is the
+          # binding; the sub wildcards the repo NAME so a repo rename cannot break
+          # OIDC auth (the failure this trust restructure fixes).
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
+  # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Simulate* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-014.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-014. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
+  # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-*/github-actions-*/gh-tf-*) plus the OIDC provider and account alias. Permission-management within a fixed prefix is the apply contract for the logarchive baseline role.
+  # checkov:skip=CKV_AWS_290: Service-namespace wildcard `tag:*` is needed because the AWS tagging API does not support resource-level ARN constraints on write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on the account-alias actions (AWS rejects resource-level ARNs there). Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations. Full IAM privileges on a fixed ARN-prefix is the deliberate apply-baseline design (ADR-014 §Decision).
+  name = "apply-baseline-scoped"
+  role = aws_iam_role.gh_tf_apply_baseline.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # IAM mutation — scoped to project-prefixed resources plus the
+        # OIDC provider. Covers aegis-* roles, github-actions-* (terraform CI
+        # roles), and gh-tf-* (this very layer's role family — supports
+        # in-place updates). Account alias management is a separate Sid
+        # below because AWS IAM does not accept resource-level ARNs on the
+        # alias actions.
+        Sid    = "IamScoped"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+          "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com",
+        ]
+      },
+      {
+        # Account alias — account-level operations. AWS IAM rejects any
+        # resource-level ARN on these actions ("account-alias/*" is NOT
+        # in the IAM-allowed-resource-path list); Resource: "*" is the
+        # only accepted shape. The trust policy `sub: ref:refs/heads/main`
+        # plus branch protection on main is the gate; the action set is
+        # narrowed to alias-only verbs (no other iam:* leaks through).
+        Sid    = "AccountAliasManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateAccountAlias",
+          "iam:DeleteAccountAlias",
+          "iam:ListAccountAliases",
+        ]
+        Resource = "*"
+      },
+      {
+        # State bucket cross-account read + write. State bucket lives in
+        # the shared account; this account's state object is read/written
+        # via cross-account bucket policy.
+        Sid    = "StateBucketCrossAccount"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketVersioning",
+        ]
+        Resource = [
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}",
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*",
+        ]
+      },
+      {
+        # State KMS — key lives in shared. Gated to S3 service usage so
+        # the role can decrypt state objects but not invoke KMS directly.
+        Sid    = "StateKmsViaS3Only"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey",
+        ]
+        Resource = "arn:aws:kms:${local.primary_region}:${local.config.accounts.shared.id}:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "s3.${local.primary_region}.amazonaws.com"
+          }
+        }
+      },
+      {
+        # Universal tagging — no service supports `tag:*` with a
+        # resource-level ARN; service-namespace scoping is the tightest
+        # contract.
+        Sid      = "TagApi"
+        Effect   = "Allow"
+        Action   = "tag:*"
+        Resource = "*"
+      },
+      {
+        # Read shapes for `terraform plan` after apply (refresh + drift
+        # detection). Resource: "*" is acceptable here because every
+        # action listed is read-only — metadata disclosure is classified
+        # as not-secret per CLAUDE.md threat model.
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "s3:GetBucket*",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetObjectLockConfiguration",
+          "s3:ListAllMyBuckets",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/logarchive/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/logarchive/bootstrap/oidc-github-plan-role.tf
@@ -1,0 +1,185 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-plan` — read-only role for `terraform-plan.yml` on PRs (ADR-014)
+# -----------------------------------------------------------------------------
+# Permission character: read-only AWS metadata + state-object read +
+# state-lock writes scoped to *.tflock + KMS via S3 service condition.
+#
+# Trust policy is keyed on the OIDC `sub` claim `pull_request` only — the
+# `main` trigger assumes its own apply role, `gh-tf-apply-baseline`. See
+# ADR-014 for the full identity-by-trigger split.
+#
+# This role purposefully cannot mutate any AWS resource other than the
+# Terraform state lockfile suffix. A leaked OIDC token from a fork-PR-OIDC
+# attack can at most run `terraform plan` and produce metadata disclosure
+# (which CLAUDE.md classifies as not-secret). This is the unlocking move
+# for closing fork-PR-OIDC as a meaningful blast-radius source.
+#
+# Scope note (LZ-baseline S1, #303): this is the plain member-account subset —
+# IAM-prefix reads, state bucket, KMS-via-S3, tagging, generic read-only API
+# surface. No GuardDuty / Security Hub read shapes yet; those land with the
+# detective-service permissions in #305/#306 once this account owns those
+# resources.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_plan" {
+  name = "gh-tf-plan"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
+          # Rename-proof: the immutable repository_id (StringEquals above) is the
+          # binding; the sub wildcards the repo NAME so a repo rename cannot break
+          # OIDC auth (the failure this trust restructure fixes).
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:pull_request"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_plan" {
+  # checkov:skip=CKV_AWS_287: Read-only API surface (Get*/List*/Describe*) requires Resource:* — restrictable per-ARN scoping is not meaningful for inventory-style API calls. The policy's deny floor is mutation prevention, enforced via state-lock-suffix scoping (Sid WriteStateLockSuffixOnly) and the absence of any Create/Update/Delete actions. See ADR-014 §Decision and §Appendix A.2.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — data exfiltration via read-only metadata is the explicit threat model accepted by ADR-014. AWS account IDs, role ARNs, and similar metadata are classified non-secret per CLAUDE.md "What is NOT a secret" clause; the policy intentionally allows their disclosure to a fork-PR-OIDC-leaked token because the alternative (per-resource read scoping) is operationally infeasible for the breadth of reads `terraform plan` performs.
+  # checkov:skip=CKV_AWS_355: Resource:* on the ReadOnlyAwsApiSurface Sid is by design — every action in that statement is read-shape (Get*/List*/Describe*/Simulate*). No mutating action uses Resource:* in this policy.
+  name = "plan-readonly"
+  role = aws_iam_role.gh_tf_plan.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadStateObject"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:GetObjectVersion"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*"
+      },
+      {
+        Sid      = "ListStateBucket"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}"
+      },
+      {
+        Sid      = "WriteStateLockSuffixOnly"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:DeleteObject"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*.tflock"
+      },
+      {
+        # OQ-3 worst-case guard: `terraform plan -refresh=true` may write the
+        # state object during refresh. Allow PutObject on the state-key suffix
+        # to absorb that worst case. PR-1 will empirically observe whether
+        # plan-refresh writes state under our backend; if no, this statement
+        # tightens or is removed in a follow-up PR.
+        Sid      = "WriteStateOnRefreshGuard"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*.tfstate"
+      },
+      {
+        # KMS decryption gated by service condition. Two ViaService entries:
+        # - `s3.<region>.amazonaws.com` — for cross-account state-bucket
+        #   reads (state KMS lives in shared account)
+        # - `ssm.<region>.amazonaws.com` — for SSM PS SecureString reads
+        #   (each account's local KMS key encrypts /aegis/<env>/* secrets)
+        # Resource: "*" is bounded by the ViaService condition; without
+        # it the role cannot invoke KMS directly.
+        Sid      = "KmsForStateAndSsm"
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt", "kms:Encrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = "arn:aws:kms:*:*:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = [
+              "s3.${local.primary_region}.amazonaws.com",
+              "ssm.${local.primary_region}.amazonaws.com",
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "ec2:Describe*",
+          "eks:Describe*",
+          "eks:List*",
+          "s3:GetBucket*",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetObjectLockConfiguration",
+          "s3:ListAllMyBuckets",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "organizations:Describe*",
+          "organizations:List*",
+          # IAM Identity Center (formerly AWS SSO) — IAM service prefix
+          # is `sso:` even though the CLI verb is `aws sso-admin <command>`.
+          # Using `sso-admin:` here returns AccessDenied on every action.
+          "sso:Describe*",
+          "sso:List*",
+          "sso:Get*",
+          "identitystore:Describe*",
+          "identitystore:List*",
+          "identitystore:Get*",
+          "ssm:Describe*",
+          "ssm:Get*",
+          "ssm:List*",
+          "logs:Describe*",
+          "logs:List*",
+          "logs:Get*",
+          "sqs:Get*",
+          "sqs:List*",
+          "events:Describe*",
+          "events:List*",
+          "ram:Get*",
+          "ram:List*",
+          "ec2:DescribeIpam*",
+          "ec2:GetIpam*",
+          "fis:Get*",
+          "fis:List*",
+          "cognito-idp:Describe*",
+          "cognito-idp:List*",
+          "cognito-idp:Get*",
+          "cloudfront:Get*",
+          "cloudfront:List*",
+          "acm:Describe*",
+          "acm:List*",
+          "route53:Get*",
+          "route53:List*",
+          "ecr:Describe*",
+          "ecr:Get*",
+          "ecr:List*",
+          "elasticloadbalancing:Describe*",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/logarchive/bootstrap/oidc-github.tf
+++ b/terraform/environments/logarchive/bootstrap/oidc-github.tf
@@ -1,0 +1,40 @@
+# -----------------------------------------------------------------------------
+# GitHub OIDC Federation — logarchive account CI access
+# -----------------------------------------------------------------------------
+# Provides the OIDC provider that the gh-tf-* CI roles federate against. Each
+# role's trust + permission policy lives in its own .tf file (oidc-github-*-
+# role.tf). The two CI roles are `gh-tf-plan` and `gh-tf-apply-baseline`.
+#
+# Legacy `github-actions-terraform` (Admin) was removed by ADR-014 PR-7
+# cleanup; see incidents.md §Incident 12 for the rollout narrative.
+# -----------------------------------------------------------------------------
+
+locals {
+  github_org        = local.config.github.org
+  github_infra_repo = local.config.github.infra_repo
+  github_oidc_url   = "https://token.actions.githubusercontent.com"
+
+  github_infra_repo_id = try(local.config.github.infra_repo_id, null)
+
+  github_oidc_infra_repo_id_claim = local.github_infra_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_infra_repo_id
+  } : {}
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = local.github_oidc_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  lifecycle {
+    # Fail closed (ADR-019). The immutable repository_id StringEquals claim is
+    # the ONLY repo binding in the gh-tf-* trust policies — the StringLike sub
+    # claim wildcards the repo name (`repo:<org>/*`) for rename-proofing.
+    # Without infra_repo_id, ANY repo under the GitHub owner could mint a
+    # main-branch token and assume the CI roles. Refuse to create that trust.
+    precondition {
+      condition     = local.github_infra_repo_id != null
+      error_message = "github.infra_repo_id is unset in config/landing-zone.yaml. Set it — get the numeric id via: gh api repos/<owner>/<repo> --jq .id — the OIDC trust will not be created owner-wide (ADR-019)."
+    }
+  }
+}

--- a/terraform/environments/logarchive/bootstrap/outputs.tf
+++ b/terraform/environments/logarchive/bootstrap/outputs.tf
@@ -1,0 +1,23 @@
+output "account_id" {
+  description = "Logarchive account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "account_alias" {
+  description = "IAM account alias"
+  value       = aws_iam_account_alias.this.account_alias
+}
+
+output "github_oidc_provider_arn" {
+  description = "GitHub OIDC identity provider ARN"
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+
+# -----------------------------------------------------------------------------
+# Break-glass recovery role — ADR-015 OQ-1 graduation
+# -----------------------------------------------------------------------------
+
+output "aegis_emergency_break_glass_role_arn" {
+  description = "ARN of the aegis-emergency-break-glass role for SSO PlatformAdmin assume during break-glass recovery"
+  value       = aws_iam_role.aegis_emergency_break_glass.arn
+}

--- a/terraform/environments/logarchive/bootstrap/providers.tf
+++ b/terraform/environments/logarchive/bootstrap/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/logarchive/bootstrap/variables.tf
+++ b/terraform/environments/logarchive/bootstrap/variables.tf
@@ -1,0 +1,6 @@
+# ---- One-time IAM survivor adoption (logarchive account cold-start) ---------
+variable "adopt_seeded_iam_roles" {
+  description = "ONE-TIME logarchive-account cold-start toggle. logarchive/bootstrap is a brand new Terraform environment; the normal path creates the break-glass + CI IAM roles fresh via a first local apply under break-glass credentials. Set true ONLY if those three roles were instead hand-seeded (console/CLI) ahead of Terraform, so iam-survivor-import.tf ADOPTs the survivors into state instead of failing EntityAlreadyExists. Default false: the normal fresh-create path, so the import targets must not be generated. Remove the variable + iam-survivor-import.tf in a later cleanup PR once this account's bootstrap state is reconciled."
+  type        = bool
+  default     = false
+}

--- a/terraform/environments/logarchive/bootstrap/versions.tf
+++ b/terraform/environments/logarchive/bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+}

--- a/terraform/environments/security/bootstrap/.terraform.lock.hcl
+++ b/terraform/environments/security/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.40"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/terraform/environments/security/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/security/bootstrap/aegis-emergency-role.tf
@@ -1,0 +1,126 @@
+# -----------------------------------------------------------------------------
+# `aegis-emergency-break-glass` — break-glass recovery role (ADR-015 OQ-1)
+# -----------------------------------------------------------------------------
+# Materializes the `aegis-emergency-*` namespace reserved by ADR-015's SCP
+# allow-list (`deny-iam-privilege-escalation`). This is the security-account
+# variant — see `terraform/environments/management/bootstrap/aegis-emergency-
+# role.tf` for the full design narrative and the recovery shape that
+# motivates the role.
+#
+# Scope difference from mgmt: no Organizations / SSO / IdentityStore Sids.
+# Those API surfaces only carry power in mgmt; in member accounts they
+# return empty inventories at best and produce no useful break-glass
+# primitive. The security-account permission policy is therefore the IAM /
+# KMS / SSM PS subset.
+#
+# Trust policy: identical pattern to mgmt — local-account PlatformAdmin
+# SSO sessions only, time-bounded to 1 hour.
+#
+# SCP interaction: `aegis-emergency-break-glass` matches `aegis-emergency-*`
+# in ADR-015's SCP allow-list. No SCP change required by this PR.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "aegis_emergency_break_glass" {
+  name                 = "aegis-emergency-break-glass"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OperatorViaPlatformAdminSso"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${local.account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${local.account_id}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
+  # checkov:skip=CKV_AWS_287: Read-shape Sids (IamReadAll, KmsReadAndDecrypt's Describe/List/Get verbs, StsAndTagRead) intentionally use Resource:* for inventory access during break-glass diagnosis. Mutation surface is in IamMutationOnProjectRoles, scoped or trust-policy-gated. ADR-015 OQ-1.
+  # checkov:skip=CKV_AWS_288: Same as 287 — break-glass requires broad read for diagnosis; mutations are scoped. Read-shape data disclosure is the explicit threat model accepted by ADR-015.
+  # checkov:skip=CKV_AWS_289: iam:* is intentionally allowed but scoped to aegis-*/gh-tf-*/github-actions-* prefixes. Permission-management within fixed prefixes is the break-glass contract.
+  # checkov:skip=CKV_AWS_290: Resource:* on read-only Sids is required because the corresponding AWS APIs do not support resource-level ARN constraints. Trust policy (PlatformAdmin SSO only) is the gate.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sids and on AWS APIs without resource-level ARN support.
+  # checkov:skip=CKV2_AWS_40: iam:* on a fixed ARN-prefix scope is the deliberate break-glass design (ADR-015 OQ-1 graduation).
+  name = "emergency-break-glass-scoped"
+  role = aws_iam_role.aegis_emergency_break_glass.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Scoped IAM mutation — the primary break-glass primitive.
+        Sid    = "IamMutationOnProjectRoles"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+        ]
+      },
+      {
+        # IAM read across the account. Diagnosis needs full inventory;
+        # mutations are bounded by IamMutationOnProjectRoles above.
+        Sid    = "IamReadAll"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:Simulate*",
+        ]
+        Resource = "*"
+      },
+      {
+        # KMS read + Decrypt scoped to local-account keys only. Required
+        # for reading SSM PS SecureString values during diagnosis. No
+        # Encrypt / GenerateDataKey — break-glass is read-recovery.
+        Sid    = "KmsReadAndDecrypt"
+        Effect = "Allow"
+        Action = [
+          "kms:Describe*",
+          "kms:List*",
+          "kms:Get*",
+          "kms:Decrypt",
+        ]
+        Resource = "arn:aws:kms:*:${local.account_id}:key/*"
+      },
+      {
+        # SSM PS read on `/aegis/*` paths only. Diagnosis often needs to
+        # confirm a parameter is present and decrypts cleanly. Read-only.
+        Sid    = "SsmReadProject"
+        Effect = "Allow"
+        Action = [
+          "ssm:Get*",
+          "ssm:Describe*",
+          "ssm:List*",
+        ]
+        Resource = "arn:aws:ssm:*:${local.account_id}:parameter/aegis/*"
+      },
+      {
+        # Identity + audit visibility. Read-only; AWS-API-shape Resource:*.
+        Sid    = "StsAndTagRead"
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "tag:Get*",
+          "iam:GenerateCredentialReport",
+          "iam:GenerateServiceLastAccessedDetails",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/security/bootstrap/backend.tf
+++ b/terraform/environments/security/bootstrap/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "security/bootstrap/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/security/bootstrap/config.tf
+++ b/terraform/environments/security/bootstrap/config.tf
@@ -1,0 +1,16 @@
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.security.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+  tags = merge(local.config.tags, {
+    Environment = "security"
+  })
+}
+
+check "exactly_one_primary_region" {
+  assert {
+    condition     = length([for r in local.config.regions : r if r.role == "primary"]) == 1
+    error_message = "config/landing-zone.yaml regions[] must have exactly one entry with role: primary."
+  }
+}

--- a/terraform/environments/security/bootstrap/iam-survivor-import.tf
+++ b/terraform/environments/security/bootstrap/iam-survivor-import.tf
@@ -1,0 +1,63 @@
+# ============================================================================
+# One-time adoption (security account cold-start) of the IAM roles this
+# bootstrap layer manages, in case they were seeded outside Terraform.
+#
+# WHY: `security/bootstrap` is a BRAND NEW Terraform environment (#303) — the
+# account has never had Terraform managing it. The normal cold-start path is
+# a first LOCAL `terraform apply` under break-glass credentials (see the PR
+# body for #303 / issue #303's manual-seed runbook), which CREATEs the three
+# roles below fresh — no import needed.
+#
+# This file exists as the ESCAPE HATCH for the other case: an operator who
+# manually pre-created the three roles (console/CLI) before Terraform ever
+# ran in this account — e.g. to unblock CI faster, or because AWSControl
+# TowerExecution was used to hand-seed them. A plain `terraform apply` would
+# then fail EntityAlreadyExists trying to CREATE a role that already exists.
+# These config-driven import blocks ADOPT the existing roles into state
+# instead. After import, apply UPDATEs each role in place to match the
+# declared config (a no-op if the live policy already matches) — no recreate,
+# no manual `terraform import` / state surgery. Same precedent as prod/
+# bootstrap's iam-survivor-import.tf (#278) and #15
+# (oidc-github-apply-deployment-role.tf in the deployment account).
+#
+# GATE: the import is TOGGLEABLE, OFF by default, gated on
+# var.adopt_seeded_iam_roles via a for_each toggle: when false (the normal
+# fresh-account path), toset([]) generates no import block; when true, each
+# block adopts its survivor.
+#
+# ONE-TIME: set var.adopt_seeded_iam_roles=true only for a security-account
+# apply where the roles were hand-seeded ahead of Terraform. Once this
+# account's bootstrap state reflects the roles (adopted or freshly created),
+# REMOVE this file and the variable in a later cleanup PR — an import block
+# whose target is already in state is a no-op, so leaving it is harmless but
+# it has served its single purpose.
+#
+# NOT IMPORTED — the attached inline role policies (aegis_emergency_break_glass,
+# gh_tf_apply_baseline, gh_tf_plan) are Put*-idempotent: apply converges them
+# onto the adopted roles without their own import blocks.
+# ============================================================================
+
+# Role name = import id for aws_iam_role. Each `to` address is confirmed present
+# in this layer (aegis-emergency-role.tf / oidc-github-baseline-role.tf /
+# oidc-github-plan-role.tf).
+
+# break-glass recovery role (ADR-015 OQ-1)
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["break_glass"]) : toset([])
+  to       = aws_iam_role.aegis_emergency_break_glass
+  id       = "aegis-emergency-break-glass"
+}
+
+# baseline apply role for terraform-apply-baseline.yml (ADR-014)
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["apply_baseline"]) : toset([])
+  to       = aws_iam_role.gh_tf_apply_baseline
+  id       = "gh-tf-apply-baseline"
+}
+
+# read-only plan role for terraform-plan.yml on PRs (ADR-014)
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["plan"]) : toset([])
+  to       = aws_iam_role.gh_tf_plan
+  id       = "gh-tf-plan"
+}

--- a/terraform/environments/security/bootstrap/iam-survivor-import.tf
+++ b/terraform/environments/security/bootstrap/iam-survivor-import.tf
@@ -1,24 +1,33 @@
 # ============================================================================
-# One-time adoption (security account cold-start) of the IAM roles this
+# One-time adoption (security account cold-start) of the resources this
 # bootstrap layer manages, in case they were seeded outside Terraform.
 #
 # WHY: `security/bootstrap` is a BRAND NEW Terraform environment (#303) — the
 # account has never had Terraform managing it. The normal cold-start path is
 # a first LOCAL `terraform apply` under break-glass credentials (see the PR
-# body for #303 / issue #303's manual-seed runbook), which CREATEs the three
-# roles below fresh — no import needed.
+# body for #303 / issue #303's manual-seed runbook), which CREATEs all eight
+# resources below fresh — no import needed.
 #
 # This file exists as the ESCAPE HATCH for the other case: an operator who
-# manually pre-created the three roles (console/CLI) before Terraform ever
-# ran in this account — e.g. to unblock CI faster, or because AWSControl
-# TowerExecution was used to hand-seed them. A plain `terraform apply` would
-# then fail EntityAlreadyExists trying to CREATE a role that already exists.
-# These config-driven import blocks ADOPT the existing roles into state
-# instead. After import, apply UPDATEs each role in place to match the
-# declared config (a no-op if the live policy already matches) — no recreate,
-# no manual `terraform import` / state surgery. Same precedent as prod/
-# bootstrap's iam-survivor-import.tf (#278) and #15
+# manually pre-created the resources (console/CLI, or a local `terraform
+# apply` under AWSControlTowerExecution whose state was then discarded)
+# before Terraform's S3 backend ever ran in this account — e.g. to unblock
+# CI faster. A plain `terraform apply` against the (empty) S3 state would
+# then fail EntityAlreadyExists trying to CREATE a resource that already
+# exists. These config-driven import blocks ADOPT the existing resources
+# into state instead. After import, apply UPDATEs each resource in place to
+# match the declared config (a no-op if the live resource already matches) —
+# no recreate, no manual `terraform import` / state surgery. Same precedent
+# as prod/bootstrap's iam-survivor-import.tf (#278) and #15
 # (oidc-github-apply-deployment-role.tf in the deployment account).
+#
+# SCOPE: covers all eight resources this layer creates in a member account —
+# the account alias, the GitHub OIDC provider, the three gh-tf-*/aegis-
+# emergency-* roles, and their three inline role policies. The role policies
+# are Put*-idempotent (PutRolePolicy upserts, no EntityAlreadyExists) so they
+# are technically safe to leave un-imported, but importing them too avoids a
+# spurious "will be created" noise in the first plan/apply against adopted
+# roles.
 #
 # GATE: the import is TOGGLEABLE, OFF by default, gated on
 # var.adopt_seeded_iam_roles via a for_each toggle: when false (the normal
@@ -26,20 +35,17 @@
 # block adopts its survivor.
 #
 # ONE-TIME: set var.adopt_seeded_iam_roles=true only for a security-account
-# apply where the roles were hand-seeded ahead of Terraform. Once this
-# account's bootstrap state reflects the roles (adopted or freshly created),
+# apply where these resources were hand-seeded ahead of Terraform. Once this
+# account's bootstrap state reflects them (adopted or freshly created),
 # REMOVE this file and the variable in a later cleanup PR — an import block
 # whose target is already in state is a no-op, so leaving it is harmless but
 # it has served its single purpose.
-#
-# NOT IMPORTED — the attached inline role policies (aegis_emergency_break_glass,
-# gh_tf_apply_baseline, gh_tf_plan) are Put*-idempotent: apply converges them
-# onto the adopted roles without their own import blocks.
 # ============================================================================
 
-# Role name = import id for aws_iam_role. Each `to` address is confirmed present
-# in this layer (aegis-emergency-role.tf / oidc-github-baseline-role.tf /
-# oidc-github-plan-role.tf).
+# ---- IAM roles --------------------------------------------------------------
+# Role name = import id for aws_iam_role. Each `to` address is confirmed
+# present in this layer (aegis-emergency-role.tf / oidc-github-baseline-
+# role.tf / oidc-github-plan-role.tf).
 
 # break-glass recovery role (ADR-015 OQ-1)
 import {
@@ -60,4 +66,57 @@ import {
   for_each = var.adopt_seeded_iam_roles ? toset(["plan"]) : toset([])
   to       = aws_iam_role.gh_tf_plan
   id       = "gh-tf-plan"
+}
+
+# ---- IAM inline role policies -----------------------------------------------
+# Import id shape for aws_iam_role_policy is "ROLE_NAME:POLICY_NAME" — both
+# halves read verbatim off the `name` / `role` arguments in each resource
+# (aegis-emergency-role.tf / oidc-github-baseline-role.tf / oidc-github-plan-
+# role.tf). Not strictly required (PutRolePolicy upserts, no
+# EntityAlreadyExists) but importing keeps the first plan clean.
+
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["break_glass_policy"]) : toset([])
+  to       = aws_iam_role_policy.aegis_emergency_break_glass
+  id       = "aegis-emergency-break-glass:emergency-break-glass-scoped"
+}
+
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["apply_baseline_policy"]) : toset([])
+  to       = aws_iam_role_policy.gh_tf_apply_baseline
+  id       = "gh-tf-apply-baseline:apply-baseline-scoped"
+}
+
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["plan_policy"]) : toset([])
+  to       = aws_iam_role_policy.gh_tf_plan
+  id       = "gh-tf-plan:plan-readonly"
+}
+
+# ---- Account-global singletons ----------------------------------------------
+# Unlike the roles above, these two import ids are NOT stable literals across
+# accounts — they must resolve per-account, so each uses a dynamic or
+# per-account-config expression rather than a hardcoded string shared with
+# another environment's copy of this file.
+
+# GitHub OIDC identity provider (oidc-github.tf). Import id is the provider
+# ARN, which embeds this account's id — resolved via the `data.aws_caller_
+# identity.current` already declared in main.tf, so no new data source is
+# needed. The provider "path" segment reuses `local.github_oidc_url`
+# (oidc-github.tf) via the same `replace(..., "https://", "")` idiom the
+# trust policies already use, so it can never drift from the resource's own
+# `url` argument.
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["oidc_provider"]) : toset([])
+  to       = aws_iam_openid_connect_provider.github
+  id       = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(local.github_oidc_url, "https://", "")}"
+}
+
+# IAM account alias (main.tf). Import id is the alias string itself; this
+# reuses the exact literal `aws_iam_account_alias.this` is configured with
+# in main.tf for this account.
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["account_alias"]) : toset([])
+  to       = aws_iam_account_alias.this
+  id       = "binhsu-aegis-security"
 }

--- a/terraform/environments/security/bootstrap/main.tf
+++ b/terraform/environments/security/bootstrap/main.tf
@@ -1,0 +1,12 @@
+resource "aws_iam_account_alias" "this" {
+  account_alias = "binhsu-aegis-security"
+}
+
+data "aws_caller_identity" "current" {}
+
+check "config_account_id_not_empty" {
+  assert {
+    condition     = local.account_id != ""
+    error_message = "accounts.security.id in landing-zone.yaml is empty. Create the account first (Runbook 001 Part 9)."
+  }
+}

--- a/terraform/environments/security/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/security/bootstrap/oidc-github-baseline-role.tf
@@ -1,0 +1,174 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-apply-baseline` — apply role for `terraform-apply-baseline.yml` (ADR-014)
+# -----------------------------------------------------------------------------
+# Apply role for the `ref:refs/heads/main` trigger. The `pull_request` trigger
+# assumes its own read-only role, `gh-tf-plan`. These two are the only CI roles.
+#
+# Scope: the security account's only landing-zone Terraform is
+# `security/bootstrap` itself — the account alias, the GitHub OIDC provider,
+# and the gh-tf-* / aegis-emergency-* roles. The permission policy below is
+# therefore exactly IAM-on-project-prefixes + account alias + cross-account
+# Terraform state.
+#
+# Scope note (LZ-baseline S1, #303): this is the plain member-account subset —
+# no detective-service (GuardDuty / Security Hub) mutation permissions yet.
+# Those land in #304/#305/#306 once this layer (or a sibling `security/
+# detective` layer, per epic #302 D5) owns those resources.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_apply_baseline" {
+  name = "gh-tf-apply-baseline"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
+          # Rename-proof: the immutable repository_id (StringEquals above) is the
+          # binding; the sub wildcards the repo NAME so a repo rename cannot break
+          # OIDC auth (the failure this trust restructure fixes).
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
+  # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Simulate* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-014.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-014. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
+  # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-*/github-actions-*/gh-tf-*) plus the OIDC provider and account alias. Permission-management within a fixed prefix is the apply contract for the security baseline role.
+  # checkov:skip=CKV_AWS_290: Service-namespace wildcard `tag:*` is needed because the AWS tagging API does not support resource-level ARN constraints on write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on the account-alias actions (AWS rejects resource-level ARNs there). Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations. Full IAM privileges on a fixed ARN-prefix is the deliberate apply-baseline design (ADR-014 §Decision).
+  name = "apply-baseline-scoped"
+  role = aws_iam_role.gh_tf_apply_baseline.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # IAM mutation — scoped to project-prefixed resources plus the
+        # OIDC provider. Covers aegis-* roles, github-actions-* (terraform CI
+        # roles), and gh-tf-* (this very layer's role family — supports
+        # in-place updates). Account alias management is a separate Sid
+        # below because AWS IAM does not accept resource-level ARNs on the
+        # alias actions.
+        Sid    = "IamScoped"
+        Effect = "Allow"
+        Action = "iam:*"
+        Resource = [
+          "arn:aws:iam::${local.account_id}:role/aegis-*",
+          "arn:aws:iam::${local.account_id}:role/github-actions-*",
+          "arn:aws:iam::${local.account_id}:role/gh-tf-*",
+          "arn:aws:iam::${local.account_id}:policy/aegis-*",
+          "arn:aws:iam::${local.account_id}:oidc-provider/token.actions.githubusercontent.com",
+        ]
+      },
+      {
+        # Account alias — account-level operations. AWS IAM rejects any
+        # resource-level ARN on these actions ("account-alias/*" is NOT
+        # in the IAM-allowed-resource-path list); Resource: "*" is the
+        # only accepted shape. The trust policy `sub: ref:refs/heads/main`
+        # plus branch protection on main is the gate; the action set is
+        # narrowed to alias-only verbs (no other iam:* leaks through).
+        Sid    = "AccountAliasManagement"
+        Effect = "Allow"
+        Action = [
+          "iam:CreateAccountAlias",
+          "iam:DeleteAccountAlias",
+          "iam:ListAccountAliases",
+        ]
+        Resource = "*"
+      },
+      {
+        # State bucket cross-account read + write. State bucket lives in
+        # the shared account; this account's state object is read/written
+        # via cross-account bucket policy.
+        Sid    = "StateBucketCrossAccount"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketVersioning",
+        ]
+        Resource = [
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}",
+          "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*",
+        ]
+      },
+      {
+        # State KMS — key lives in shared. Gated to S3 service usage so
+        # the role can decrypt state objects but not invoke KMS directly.
+        Sid    = "StateKmsViaS3Only"
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey",
+        ]
+        Resource = "arn:aws:kms:${local.primary_region}:${local.config.accounts.shared.id}:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "s3.${local.primary_region}.amazonaws.com"
+          }
+        }
+      },
+      {
+        # Universal tagging — no service supports `tag:*` with a
+        # resource-level ARN; service-namespace scoping is the tightest
+        # contract.
+        Sid      = "TagApi"
+        Effect   = "Allow"
+        Action   = "tag:*"
+        Resource = "*"
+      },
+      {
+        # Read shapes for `terraform plan` after apply (refresh + drift
+        # detection). Resource: "*" is acceptable here because every
+        # action listed is read-only — metadata disclosure is classified
+        # as not-secret per CLAUDE.md threat model.
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "s3:GetBucket*",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetObjectLockConfiguration",
+          "s3:ListAllMyBuckets",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/security/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/security/bootstrap/oidc-github-plan-role.tf
@@ -1,0 +1,185 @@
+# -----------------------------------------------------------------------------
+# `gh-tf-plan` — read-only role for `terraform-plan.yml` on PRs (ADR-014)
+# -----------------------------------------------------------------------------
+# Permission character: read-only AWS metadata + state-object read +
+# state-lock writes scoped to *.tflock + KMS via S3 service condition.
+#
+# Trust policy is keyed on the OIDC `sub` claim `pull_request` only — the
+# `main` trigger assumes its own apply role, `gh-tf-apply-baseline`. See
+# ADR-014 for the full identity-by-trigger split.
+#
+# This role purposefully cannot mutate any AWS resource other than the
+# Terraform state lockfile suffix. A leaked OIDC token from a fork-PR-OIDC
+# attack can at most run `terraform plan` and produce metadata disclosure
+# (which CLAUDE.md classifies as not-secret). This is the unlocking move
+# for closing fork-PR-OIDC as a meaningful blast-radius source.
+#
+# Scope note (LZ-baseline S1, #303): this is the plain member-account subset —
+# IAM-prefix reads, state bucket, KMS-via-S3, tagging, generic read-only API
+# surface. No GuardDuty / Security Hub read shapes yet; those land with the
+# detective-service permissions in #305/#306 once this account owns those
+# resources.
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_role" "gh_tf_plan" {
+  name = "gh-tf-plan"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = merge(
+            {
+              "${replace(local.github_oidc_url, "https://", "")}:aud" = "sts.amazonaws.com"
+            },
+            local.github_oidc_infra_repo_id_claim,
+          )
+          # Rename-proof: the immutable repository_id (StringEquals above) is the
+          # binding; the sub wildcards the repo NAME so a repo rename cannot break
+          # OIDC auth (the failure this trust restructure fixes).
+          StringLike = {
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:pull_request"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "gh_tf_plan" {
+  # checkov:skip=CKV_AWS_287: Read-only API surface (Get*/List*/Describe*) requires Resource:* — restrictable per-ARN scoping is not meaningful for inventory-style API calls. The policy's deny floor is mutation prevention, enforced via state-lock-suffix scoping (Sid WriteStateLockSuffixOnly) and the absence of any Create/Update/Delete actions. See ADR-014 §Decision and §Appendix A.2.
+  # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — data exfiltration via read-only metadata is the explicit threat model accepted by ADR-014. AWS account IDs, role ARNs, and similar metadata are classified non-secret per CLAUDE.md "What is NOT a secret" clause; the policy intentionally allows their disclosure to a fork-PR-OIDC-leaked token because the alternative (per-resource read scoping) is operationally infeasible for the breadth of reads `terraform plan` performs.
+  # checkov:skip=CKV_AWS_355: Resource:* on the ReadOnlyAwsApiSurface Sid is by design — every action in that statement is read-shape (Get*/List*/Describe*/Simulate*). No mutating action uses Resource:* in this policy.
+  name = "plan-readonly"
+  role = aws_iam_role.gh_tf_plan.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadStateObject"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:GetObjectVersion"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*"
+      },
+      {
+        Sid      = "ListStateBucket"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}"
+      },
+      {
+        Sid      = "WriteStateLockSuffixOnly"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:DeleteObject"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*.tflock"
+      },
+      {
+        # OQ-3 worst-case guard: `terraform plan -refresh=true` may write the
+        # state object during refresh. Allow PutObject on the state-key suffix
+        # to absorb that worst case. PR-1 will empirically observe whether
+        # plan-refresh writes state under our backend; if no, this statement
+        # tightens or is removed in a follow-up PR.
+        Sid      = "WriteStateOnRefreshGuard"
+        Effect   = "Allow"
+        Action   = ["s3:PutObject"]
+        Resource = "arn:aws:s3:::${local.config.organization.name}-terraform-state-${local.config.accounts.shared.id}/*.tfstate"
+      },
+      {
+        # KMS decryption gated by service condition. Two ViaService entries:
+        # - `s3.<region>.amazonaws.com` — for cross-account state-bucket
+        #   reads (state KMS lives in shared account)
+        # - `ssm.<region>.amazonaws.com` — for SSM PS SecureString reads
+        #   (each account's local KMS key encrypts /aegis/<env>/* secrets)
+        # Resource: "*" is bounded by the ViaService condition; without
+        # it the role cannot invoke KMS directly.
+        Sid      = "KmsForStateAndSsm"
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt", "kms:Encrypt", "kms:GenerateDataKey", "kms:DescribeKey"]
+        Resource = "arn:aws:kms:*:*:key/*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = [
+              "s3.${local.primary_region}.amazonaws.com",
+              "ssm.${local.primary_region}.amazonaws.com",
+            ]
+          }
+        }
+      },
+      {
+        Sid    = "ReadOnlyAwsApiSurface"
+        Effect = "Allow"
+        Action = [
+          "iam:Get*",
+          "iam:List*",
+          "iam:SimulatePrincipalPolicy",
+          "ec2:Describe*",
+          "eks:Describe*",
+          "eks:List*",
+          "s3:GetBucket*",
+          "s3:GetEncryptionConfiguration",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetReplicationConfiguration",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetObjectLockConfiguration",
+          "s3:ListAllMyBuckets",
+          "kms:Describe*",
+          "kms:List*",
+          "kms:GetKeyRotationStatus",
+          "kms:GetKeyPolicy",
+          "organizations:Describe*",
+          "organizations:List*",
+          # IAM Identity Center (formerly AWS SSO) — IAM service prefix
+          # is `sso:` even though the CLI verb is `aws sso-admin <command>`.
+          # Using `sso-admin:` here returns AccessDenied on every action.
+          "sso:Describe*",
+          "sso:List*",
+          "sso:Get*",
+          "identitystore:Describe*",
+          "identitystore:List*",
+          "identitystore:Get*",
+          "ssm:Describe*",
+          "ssm:Get*",
+          "ssm:List*",
+          "logs:Describe*",
+          "logs:List*",
+          "logs:Get*",
+          "sqs:Get*",
+          "sqs:List*",
+          "events:Describe*",
+          "events:List*",
+          "ram:Get*",
+          "ram:List*",
+          "ec2:DescribeIpam*",
+          "ec2:GetIpam*",
+          "fis:Get*",
+          "fis:List*",
+          "cognito-idp:Describe*",
+          "cognito-idp:List*",
+          "cognito-idp:Get*",
+          "cloudfront:Get*",
+          "cloudfront:List*",
+          "acm:Describe*",
+          "acm:List*",
+          "route53:Get*",
+          "route53:List*",
+          "ecr:Describe*",
+          "ecr:Get*",
+          "ecr:List*",
+          "elasticloadbalancing:Describe*",
+          "tag:Get*",
+          "sts:GetCallerIdentity",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/terraform/environments/security/bootstrap/oidc-github.tf
+++ b/terraform/environments/security/bootstrap/oidc-github.tf
@@ -1,0 +1,40 @@
+# -----------------------------------------------------------------------------
+# GitHub OIDC Federation — security account CI access
+# -----------------------------------------------------------------------------
+# Provides the OIDC provider that the gh-tf-* CI roles federate against. Each
+# role's trust + permission policy lives in its own .tf file (oidc-github-*-
+# role.tf). The two CI roles are `gh-tf-plan` and `gh-tf-apply-baseline`.
+#
+# Legacy `github-actions-terraform` (Admin) was removed by ADR-014 PR-7
+# cleanup; see incidents.md §Incident 12 for the rollout narrative.
+# -----------------------------------------------------------------------------
+
+locals {
+  github_org        = local.config.github.org
+  github_infra_repo = local.config.github.infra_repo
+  github_oidc_url   = "https://token.actions.githubusercontent.com"
+
+  github_infra_repo_id = try(local.config.github.infra_repo_id, null)
+
+  github_oidc_infra_repo_id_claim = local.github_infra_repo_id != null ? {
+    "${replace(local.github_oidc_url, "https://", "")}:repository_id" = local.github_infra_repo_id
+  } : {}
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = local.github_oidc_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+
+  lifecycle {
+    # Fail closed (ADR-019). The immutable repository_id StringEquals claim is
+    # the ONLY repo binding in the gh-tf-* trust policies — the StringLike sub
+    # claim wildcards the repo name (`repo:<org>/*`) for rename-proofing.
+    # Without infra_repo_id, ANY repo under the GitHub owner could mint a
+    # main-branch token and assume the CI roles. Refuse to create that trust.
+    precondition {
+      condition     = local.github_infra_repo_id != null
+      error_message = "github.infra_repo_id is unset in config/landing-zone.yaml. Set it — get the numeric id via: gh api repos/<owner>/<repo> --jq .id — the OIDC trust will not be created owner-wide (ADR-019)."
+    }
+  }
+}

--- a/terraform/environments/security/bootstrap/outputs.tf
+++ b/terraform/environments/security/bootstrap/outputs.tf
@@ -1,0 +1,23 @@
+output "account_id" {
+  description = "Security account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "account_alias" {
+  description = "IAM account alias"
+  value       = aws_iam_account_alias.this.account_alias
+}
+
+output "github_oidc_provider_arn" {
+  description = "GitHub OIDC identity provider ARN"
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+
+# -----------------------------------------------------------------------------
+# Break-glass recovery role — ADR-015 OQ-1 graduation
+# -----------------------------------------------------------------------------
+
+output "aegis_emergency_break_glass_role_arn" {
+  description = "ARN of the aegis-emergency-break-glass role for SSO PlatformAdmin assume during break-glass recovery"
+  value       = aws_iam_role.aegis_emergency_break_glass.arn
+}

--- a/terraform/environments/security/bootstrap/providers.tf
+++ b/terraform/environments/security/bootstrap/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/security/bootstrap/variables.tf
+++ b/terraform/environments/security/bootstrap/variables.tf
@@ -1,0 +1,6 @@
+# ---- One-time IAM survivor adoption (security account cold-start) ---------
+variable "adopt_seeded_iam_roles" {
+  description = "ONE-TIME security-account cold-start toggle. security/bootstrap is a brand new Terraform environment; the normal path creates the break-glass + CI IAM roles fresh via a first local apply under break-glass credentials. Set true ONLY if those three roles were instead hand-seeded (console/CLI) ahead of Terraform, so iam-survivor-import.tf ADOPTs the survivors into state instead of failing EntityAlreadyExists. Default false: the normal fresh-create path, so the import targets must not be generated. Remove the variable + iam-survivor-import.tf in a later cleanup PR once this account's bootstrap state is reconciled."
+  type        = bool
+  default     = false
+}

--- a/terraform/environments/security/bootstrap/versions.tf
+++ b/terraform/environments/security/bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+}


### PR DESCRIPTION
Implements #303 (S1 of the detective-baseline epic #302). Creates the two missing Security-OU account environments so they become CI-governable — the prerequisite for GuardDuty/SecurityHub delegated-admin (S2–S4).

### What
- `terraform/environments/security/bootstrap/` + `logarchive/bootstrap/` — file-for-file identical to `prod/bootstrap` (alias + OIDC provider + gh-tf-plan/apply-baseline/break-glass roles + gated iam-survivor-import). logarchive is thin per D2 (no log buckets — CT owns them).
- Matrix rows + paths added to plan/apply workflows with the real account IDs.

### ⚠️ Cold-account seed required BEFORE CI apply
These accounts have no `gh-tf-*` roles yet, so CI OIDC can't assume them until seeded once. Run with break-glass/management creds:

```bash
# security (763879260536) and logarchive (118907880354), via AWSControlTowerExecution
aws sts assume-role --role-arn arn:aws:iam::763879260536:role/AWSControlTowerExecution \
  --role-session-name lz-s1-bootstrap --profile aegis-management-admin > /tmp/sec.json
export AWS_ACCESS_KEY_ID=$(jq -r .Credentials.AccessKeyId /tmp/sec.json) \
       AWS_SECRET_ACCESS_KEY=$(jq -r .Credentials.SecretAccessKey /tmp/sec.json) \
       AWS_SESSION_TOKEN=$(jq -r .Credentials.SessionToken /tmp/sec.json)
cd terraform/environments/security/bootstrap && terraform init && terraform apply
unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
# repeat for logarchive (118907880354)
```

### Validation
- `terraform validate` (backend=false) green in both dirs; `fmt -check -recursive` clean.
- Note: the `plan` matrix jobs for these two envs will stay RED until the seed creates the gh-tf-plan role — expected, not a code fault.

### Deviation flagged for Bin
ADR-019 put logarchive's budget in `management/bootstrap` because logarchive had no TF env; that rationale is now stale. Budget migration NOT done here — separate decision.

Part of epic #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Terraform bootstrap support for the new **security** and **logarchive** environments.
  * Introduced GitHub OIDC access, plan/apply roles, and a break-glass recovery role for both environments.
  * Added environment outputs such as account details, OIDC provider ARN, and recovery role ARN.

* **Bug Fixes**
  * Expanded workflow triggers so Terraform plan/apply runs cover the new bootstrap directories.

* **Chores**
  * Added provider lock files and backend/provider configuration for the new environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->