### PR TITLE
docs: codify cold-account bootstrap (scripts/cold-start-bootstrap.sh + runbook 002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ All ADRs are **Accepted**.
 ## Runbooks
 
 - [001 — Bootstrap AWS Account](docs/runbooks/001-bootstrap-aws-account.md): Step-by-step from zero to SSO-authenticated CLI — Control Tower setup, KMS key policy, Identity Center, Account Factory for member accounts, GitHub repo configuration, signed commits, and the gotchas encountered.
+- [002 — Cold Account Bootstrap (Seed + Adopt)](docs/runbooks/002-cold-account-bootstrap.md): The two-phase procedure for a brand-new member account's first apply — seed the CI IAM roles with local state under `AWSControlTowerExecution`, then adopt them into the real S3 state with a split-credential (ambient backend + temporary provider override) apply. Run via `scripts/cold-start-bootstrap.sh`.
 
 ## Repository tiers
 
@@ -284,12 +285,13 @@ aegis-landing-zone-aws/
 │   ├── configure-github.sh        # Upload config to GitHub secret
 │   ├── validate-config.py         # JSON Schema validator (pre-commit)
 │   ├── install-tools.sh           # Install the pinned local toolchain
+│   ├── cold-start-bootstrap.sh    # Seed + adopt CI IAM roles into a cold account
 │   ├── teardown/                  # hard-teardown-landing-zone.sh (project-end)
 │   └── emergency/                 # nuke-workload-account.sh
 ├── docs/
 │   ├── architecture.md            # Mermaid diagrams
 │   ├── decisions/                 # Architecture Decision Records (ADRs)
-│   ├── runbooks/                  # Operational runbook
+│   ├── runbooks/                  # Operational runbooks
 │   ├── improvements/              # Known gaps + productionization roadmap
 │   ├── principles/                # Cross-cutting discipline docs
 │   └── evidence/                  # Apply / verification evidence

--- a/docs/runbooks/002-cold-account-bootstrap.md
+++ b/docs/runbooks/002-cold-account-bootstrap.md
@@ -1,0 +1,221 @@
+# Runbook 002. Cold Account Bootstrap (Seed + Adopt)
+
+This runbook documents how to bring up the CI bootstrap IAM roles in a brand-new
+member account — the one apply that cannot run through GitHub Actions, because
+GitHub Actions needs those exact roles to exist first. It supersedes an
+error-message pointer to a non-existent "Runbook 001 Part 9" that shipped in
+`security/bootstrap` and `logarchive/bootstrap` (Runbook 001's actual Part 9 is
+*Provision Remaining Accounts (staging + prod)*, which does not cover this
+procedure). Use `scripts/cold-start-bootstrap.sh` for every step below; do not
+run the underlying Terraform/AWS CLI commands by hand — the script's identity
+checks and traps are the safety net.
+
+## When to use this
+
+Any time a NEW member account gets its first Terraform bootstrap layer —
+`security` and `logarchive` (#303) were the first cases, and any future member
+account will hit the same chicken-and-egg on its first apply. If the
+environment's Terraform code does not yet exist under
+`terraform/environments/<env-dir>/bootstrap/`, this runbook does not apply yet —
+scaffold the environment first (mirror an existing `bootstrap/` layer, see #303).
+
+## The problem
+
+### 1. Chicken-and-egg: CI needs roles that do not exist yet
+
+Every environment's `bootstrap/` layer creates three roles GitHub Actions
+assumes via OIDC — `gh-tf-plan` (read-only, on pull requests),
+`gh-tf-apply-baseline` (on merge to `main`, per ADR-014) — plus
+`aegis-emergency-break-glass` (ADR-015), the GitHub OIDC provider, and the
+account alias. Eight resources in total.
+
+CI's `terraform-plan.yml` / `terraform-apply-baseline.yml` workflows assume one
+of those roles to run. On a cold account, none of them exist — CI has nothing
+to assume, so the account's very first apply cannot run in CI. It has to run
+from a human operator's local credentials.
+
+### 2. The state bucket will not accept the only role a human can use
+
+The only path a human has *into* a freshly Control-Tower-vended member account
+is `AWSControlTowerExecution` (assumed from the management account). But the
+Terraform state bucket's policy only grants write access to `gh-tf-*` roles,
+`aegis-emergency-*` roles, and the `PlatformAdmin-SSO` permission set —
+`AWSControlTowerExecution` is deliberately not on that list, so a normal
+S3-backed `terraform apply` run under CT-exec fails on state access before it
+ever creates a resource.
+
+### 3. The resolution: seed with local state, then adopt into S3 state
+
+The procedure is two phases against the same account:
+
+- **SEED** — `terraform apply` under `AWSControlTowerExecution`, with
+  `backend.tf` moved aside so state is local and throwaway. This actually
+  creates the eight resources in the account. Local state is fine here
+  because nothing durable needs to survive this phase — the resources
+  themselves are the durable output, not the state file.
+- **ADOPT** — a **split-credential** apply: the Terraform **backend**
+  authenticates as the operator's ambient `PlatformAdmin` profile (who *can*
+  write the S3 state bucket), while the Terraform **provider** (the thing that
+  actually talks to the target account's resources) temporarily assumes
+  `AWSControlTowerExecution` via a generated override file. Run with
+  `-var=adopt_seeded_iam_roles=true`, which flips the environment's
+  `iam-survivor-import.tf` from *create* to *import* for the eight resources
+  SEED just created — so ADOPT's plan is exactly eight imports and (ideally)
+  no other changes.
+
+After ADOPT, the S3 state matches reality. The committed default of
+`var.adopt_seeded_iam_roles` is `false`, so the next ordinary CI apply
+(`gh-tf-apply-baseline`, real S3 state, `adopt_seeded_iam_roles=false`) plans
+against the now-populated state and shows no changes — green, with zero manual
+steps from that point on.
+
+This is the same precedent as `prod/bootstrap`'s `iam-survivor-import.tf`
+(#278) and the `deployment` account's
+`oidc-github-apply-deployment-role.tf` (#15); `security`/`logarchive` (#303)
+are simply the first pair of accounts where the seed+adopt ceremony had to run
+against a truly cold account rather than one break-glass-created resource.
+
+## Prerequisites
+
+- `aws sso login --sso-session aegis` already run.
+- The target environment's Terraform code already committed at
+  `terraform/environments/<env-dir>/bootstrap/`, including a
+  `var.adopt_seeded_iam_roles`-gated `iam-survivor-import.tf` (see
+  `terraform/environments/prod/bootstrap/iam-survivor-import.tf` for the
+  pattern).
+- An AWS CLI profile (default `aegis-management-admin`) that can assume
+  `AWSControlTowerExecution` into the target account and holds
+  `PlatformAdmin` rights against the state bucket.
+- `aws` CLI v2, `jq`, `python3` with `pyyaml`, `terraform >= 1.10` on `PATH`.
+- `accounts.<env-dir>.id` populated in `config/landing-zone.yaml`, or pass
+  `--account-id` explicitly.
+
+## Procedure
+
+### Phase 1 — Seed
+
+```
+./scripts/cold-start-bootstrap.sh --env-dir security --mode seed
+```
+
+The script:
+
+1. Prints the source profile's identity, then assumes
+   `AWSControlTowerExecution` into the target account and **verifies the
+   assumed identity's account id matches the expected account** before
+   touching any Terraform state — a typo'd `--account-id` or a stale
+   `config/landing-zone.yaml` value fails here, not mid-apply.
+2. Moves `backend.tf` aside (`backend.tf.seedbak`) so `terraform init` uses
+   local state. The committed `.terraform.lock.hcl` is left untouched — only
+   the `.terraform/` cache and any prior local state are cleared.
+3. Runs `terraform plan` and shows it in full.
+4. Prompts interactively: `Apply SEED to <env-dir> (<account>)? Type 'yes' to
+   proceed:`. Anything other than `yes` skips the apply.
+5. On confirmation, applies, lists the `gh-tf-*` / `aegis-emergency-*` roles
+   now present in the account, and deletes the throwaway local state.
+6. Restores `backend.tf` via a trap that fires on **any** exit — success,
+   `Ctrl-C`, or an unhandled error — so the environment is never left without
+   its backend.
+
+Run this once per environment. Repeat for each new cold account (e.g. run
+again with `--env-dir logarchive`).
+
+### Phase 2 — Adopt
+
+```
+./scripts/cold-start-bootstrap.sh --env-dir security --mode adopt
+```
+
+The script:
+
+1. Re-verifies `AWSControlTowerExecution` still resolves to the expected
+   account (independent of Phase 1 — this is a separate invocation, possibly
+   run later or by someone else).
+2. Prints the ambient profile's identity (this is what the S3 backend will
+   authenticate as).
+3. Writes `cold_start_adopt_override.tf` — a Terraform **override file**
+   (matches the `*_override.tf` naming convention Terraform recognizes
+   specially: it *merges* into the committed `provider "aws" {}` block rather
+   than declaring a conflicting second one) that adds an `assume_role` for
+   `AWSControlTowerExecution`. This file is temporary and is deleted by a trap
+   on any exit — it is never committed.
+4. Runs `terraform init` against the real S3 backend under the ambient
+   profile, then `terraform plan -var=adopt_seeded_iam_roles=true` — expect
+   exactly eight imports and no other changes.
+5. Prompts interactively for confirmation, same pattern as Seed.
+6. On confirmation, applies (imports land in S3 state) and prints
+   `terraform state list` to confirm all eight resources are now tracked.
+
+### Both in one run
+
+```
+./scripts/cold-start-bootstrap.sh --env-dir security --mode both
+```
+
+Runs Seed immediately followed by Adopt against the same account — useful when
+one operator is doing both phases back to back in a single sitting.
+
+### Verification
+
+After Adopt, confirm the state converges with no manual step from CI's point
+of view:
+
+```
+cd terraform/environments/security/bootstrap
+terraform plan   # ordinary run, adopt_seeded_iam_roles defaults to false
+```
+
+Expect **no changes**. If CI already has a PR open against this environment,
+its `terraform-plan.yml` run should also show no diff once merged and
+`terraform-apply-baseline.yml` runs the real (adopt=false) apply.
+
+## Gotchas
+
+- **Do not run Adopt before Seed.** Adopt's plan expects the eight resources
+  to already exist in the account; running it first produces an empty import
+  set and then a normal (failing) create attempt under the wrong credentials.
+- **`--profile` must be able to do both things Adopt needs**: assume
+  `AWSControlTowerExecution` into the target account, *and* hold
+  `PlatformAdmin`-level rights on the shared account's state bucket. A
+  narrower profile that can only do one half fails at `terraform init` or at
+  the assume-role verification step, not silently.
+- **A stale `cold_start_adopt_override.tf` or `backend.tf.seedbak` left in a
+  bootstrap directory** (from a prior run killed with `kill -9`, which no
+  trap can catch) blocks the next run. The script's own EXIT/INT/TERM trap
+  cleans these up on every normal exit and on `Ctrl-C`; if one is still
+  present, delete it manually before re-running.
+
+## Cross-references
+
+- Issue [#309](https://github.com/BinHsu/aegis-landing-zone-aws/issues/309) —
+  future ADR to eliminate this manual ceremony entirely with an AFT-style
+  (AWS Account Factory for Terraform) pattern: a management-level bootstrap
+  role that can assume into a newly-enrolled account *and* write the S3 state
+  bucket in one CI run, retiring `iam-survivor-import.tf` and
+  `var.adopt_seeded_iam_roles` once cold-start no longer needs them.
+- Issue [#303](https://github.com/BinHsu/aegis-landing-zone-aws/issues/303) —
+  the `security`/`logarchive` environment creation this runbook's procedure
+  was first exercised against.
+- `terraform/environments/prod/bootstrap/iam-survivor-import.tf` (#278) — the
+  precedent for the `var.adopt_seeded_iam_roles` import-gating pattern this
+  runbook's Adopt phase relies on.
+- [ADR-014](../decisions/014-iam-permission-scope-down.md) — the
+  `gh-tf-plan` / `gh-tf-apply-baseline` two-role OIDC trust split these
+  scripts seed and adopt.
+- [ADR-015](../decisions/015-permission-boundary-hardening.md) — the
+  `aegis-emergency-break-glass` role.
+- [Runbook 001](001-bootstrap-aws-account.md) — the from-zero project
+  bootstrap this runbook assumes is already complete (management account,
+  Control Tower, state bucket, SSO).
+
+## What's Next
+
+With Seed and Adopt complete for an environment:
+
+- The account's `gh-tf-plan`, `gh-tf-apply-baseline`, and
+  `aegis-emergency-break-glass` roles exist and are tracked in the real S3
+  state.
+- CI (`terraform-plan.yml` on PRs, `terraform-apply-baseline.yml` on merge to
+  `main`) can operate on this environment with zero further manual steps.
+- `var.adopt_seeded_iam_roles` stays at its committed default (`false`) —
+  nothing to revert; it was only ever set via `-var` for the one Adopt run.

--- a/scripts/cold-start-bootstrap.sh
+++ b/scripts/cold-start-bootstrap.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# ============================================================================
+# cold-start-bootstrap.sh — seed + adopt the CI bootstrap IAM roles into a
+# brand-new (cold) member account's Terraform bootstrap layer
+# ============================================================================
+#
+# WHY THIS EXISTS (chicken-and-egg):
+#   A new member account's bootstrap layer creates the roles GitHub Actions
+#   CI needs to operate on that account: gh-tf-plan, gh-tf-apply-baseline,
+#   aegis-emergency-break-glass (+ the GitHub OIDC provider + account alias).
+#   CI can only assume roles that already exist, so the FIRST apply against a
+#   cold account cannot run through CI — there is nothing yet for it to
+#   assume. It has to run from a human's local credentials.
+#
+#   The Terraform state bucket only allows gh-tf-*, aegis-emergency-*, and
+#   PlatformAdmin-SSO principals to write state — and AWSControlTowerExecution
+#   (the only role a human can assume INTO a fresh Control-Tower-vended
+#   account) is deliberately NOT on that allow-list. A normal S3-backed
+#   `terraform apply` under CT-exec therefore fails on state access before it
+#   ever gets to create a resource.
+#
+#   This script resolves both constraints in two phases, run against the
+#   SAME account:
+#
+#     SEED  — apply with LOCAL (throwaway) state, under CT-exec credentials,
+#             to create the 8 resources for real in the account. backend.tf
+#             is moved aside for the duration (Terraform's backend block
+#             cannot be parameterized) and restored on exit no matter how the
+#             script terminates.
+#
+#     ADOPT — apply with the REAL S3 state, backend authenticated as the
+#             ambient AWS profile (PlatformAdmin, who CAN write state), but
+#             the PROVIDER (resource operations) temporarily assumes CT-exec
+#             via a generated `*_override.tf` so it can read/import the
+#             resources SEED just created. `-var=adopt_seeded_iam_roles=true`
+#             switches the environment's `iam-survivor-import.tf` from
+#             CREATE-fresh to IMPORT-existing, so nothing collides
+#             (EntityAlreadyExists).
+#
+#   After ADOPT, the S3 state matches reality and var.adopt_seeded_iam_roles
+#   reverts to its committed default (false) on the next plan — an ordinary
+#   CI apply (gh-tf-apply-baseline, real S3 state, adopt=false) then sees no
+#   diff.
+#
+# See docs/runbooks/002-cold-account-bootstrap.md for the full narrative and
+# a worked example, and issue #309 for the tracked future work to eliminate
+# this manual step (AFT-style CI-native cold-account bootstrap).
+#
+# USAGE:
+#   scripts/cold-start-bootstrap.sh --env-dir <name> --mode <seed|adopt|both> \
+#       [--account-id <12-digit-id>] [--profile <aws-profile-name>]
+#
+#   --env-dir     Directory name under terraform/environments/<env-dir>/bootstrap
+#                 (also the accounts.<env-dir> key in config/landing-zone.yaml,
+#                 unless --account-id overrides it). Example: security, logarchive.
+#   --mode        seed  - create the 8 resources via CT-exec + local state.
+#                 adopt - import the 8 resources into S3 state via the ambient
+#                         profile's backend + a temporary CT-exec provider
+#                         override.
+#                 both  - seed then adopt in one run, same account.
+#   --account-id  12-digit AWS account id. Optional — defaults to
+#                 accounts.<env-dir>.id read from config/landing-zone.yaml.
+#   --profile     AWS CLI profile that can (a) assume AWSControlTowerExecution
+#                 into the target account and (b) write the S3 state bucket
+#                 (ambient PlatformAdmin). Default: aegis-management-admin.
+#
+#   Example:
+#     ./scripts/cold-start-bootstrap.sh --env-dir security --mode both
+#     ./scripts/cold-start-bootstrap.sh --env-dir logarchive --mode adopt
+#
+# PREREQUISITES:
+#   - `aws sso login --sso-session aegis` already run.
+#   - The target environment's Terraform code already exists at
+#     terraform/environments/<env-dir>/bootstrap/, including a
+#     var.adopt_seeded_iam_roles-gated iam-survivor-import.tf — see
+#     terraform/environments/prod/bootstrap/iam-survivor-import.tf for the
+#     pattern this script expects.
+#   - aws cli v2, jq, python3 (with pyyaml), terraform >= 1.10 on PATH.
+#
+# SAFETY FEATURES:
+#   - Verifies the assumed AWSControlTowerExecution identity's account id
+#     matches the expected account BEFORE any init/plan/apply, in both modes.
+#   - terraform plan always runs and is shown before apply; apply requires
+#     typing "yes" at an interactive prompt — no --auto-approve, no
+#     non-interactive path.
+#   - SEED moves backend.tf aside for local state and restores it via a trap
+#     on ANY exit (including Ctrl-C), so a cold account is never left
+#     without its backend.tf; throwaway local state is deleted after use.
+#   - ADOPT writes a temporary `*_override.tf` (Terraform's override-file
+#     naming convention, so it merges with rather than duplicates the
+#     committed `provider "aws"` block) and removes it via a trap on ANY
+#     exit.
+#   - The committed .terraform.lock.hcl is never touched — only .terraform/
+#     (the provider plugin cache) and throwaway local state are cleared.
+# ============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_FILE="${REPO_ROOT}/config/landing-zone.yaml"
+CT_EXEC_ROLE_NAME="AWSControlTowerExecution"
+
+usage() {
+  cat <<'EOF'
+Usage: cold-start-bootstrap.sh --env-dir <name> --mode <seed|adopt|both>
+                                [--account-id <12-digit-id>] [--profile <aws-profile>]
+
+  --env-dir     terraform/environments/<env-dir>/bootstrap (e.g. security, logarchive)
+  --mode        seed | adopt | both
+  --account-id  optional; defaults to accounts.<env-dir>.id in config/landing-zone.yaml
+  --profile     optional; default aegis-management-admin
+
+See the script's header comment and docs/runbooks/002-cold-account-bootstrap.md
+for the full procedure.
+EOF
+}
+
+ENV_DIR=""
+MODE=""
+ACCOUNT_ID=""
+PROFILE="aegis-management-admin"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-dir)
+      ENV_DIR="$2"
+      shift 2
+      ;;
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --account-id)
+      ACCOUNT_ID="$2"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${ENV_DIR}" ]]; then
+  echo "ERROR: --env-dir is required." >&2
+  usage >&2
+  exit 1
+fi
+
+case "${MODE}" in
+  seed | adopt | both) ;;
+  *)
+    echo "ERROR: --mode must be one of: seed, adopt, both." >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  echo "ERROR: ${CONFIG_FILE} not found." >&2
+  echo "Copy config/landing-zone.example.yaml to config/landing-zone.yaml and fill in your values." >&2
+  exit 1
+fi
+
+BOOTSTRAP_DIR="${REPO_ROOT}/terraform/environments/${ENV_DIR}/bootstrap"
+if [[ ! -d "${BOOTSTRAP_DIR}" ]]; then
+  echo "ERROR: ${BOOTSTRAP_DIR} does not exist." >&2
+  echo "This script only bootstraps an EXISTING Terraform environment's cold IAM" >&2
+  echo "roles — it does not scaffold the environment itself. See issue #303 for" >&2
+  echo "the security/logarchive precedent." >&2
+  exit 1
+fi
+
+if [[ -z "${ACCOUNT_ID}" ]]; then
+  ACCOUNT_ID="$(python3 -c "
+import yaml
+with open('${CONFIG_FILE}') as f:
+    c = yaml.safe_load(f)
+acct = (c.get('accounts') or {}).get('${ENV_DIR}') or {}
+print(acct.get('id', '') or '')
+" 2>/dev/null)"
+fi
+
+if [[ -z "${ACCOUNT_ID}" || ! "${ACCOUNT_ID}" =~ ^[0-9]{12}$ ]]; then
+  echo "ERROR: could not resolve a 12-digit account id for env-dir '${ENV_DIR}'." >&2
+  echo "Pass --account-id explicitly, or set accounts.${ENV_DIR}.id in config/landing-zone.yaml." >&2
+  exit 1
+fi
+
+echo "=================================================================="
+echo "env-dir=${ENV_DIR}  account=${ACCOUNT_ID}  mode=${MODE}  profile=${PROFILE}"
+echo "=================================================================="
+echo "Source profile identity:"
+aws sts get-caller-identity --profile "${PROFILE}" --query Arn --output text
+
+# --- shared: assume AWSControlTowerExecution and verify the target account ---
+#
+# Populates CT_EXEC_AK / CT_EXEC_SK / CT_EXEC_ST on success. FATAL on any
+# mismatch — this is the "identity verification before any apply" gate for
+# both SEED and ADOPT.
+assume_ct_exec() {
+  local creds live_acct
+  creds="$(aws sts assume-role \
+    --role-arn "arn:aws:iam::${ACCOUNT_ID}:role/${CT_EXEC_ROLE_NAME}" \
+    --role-session-name "cold-start-bootstrap" \
+    --profile "${PROFILE}" \
+    --query 'Credentials' --output json)"
+  CT_EXEC_AK="$(jq -r '.AccessKeyId' <<<"${creds}")"
+  CT_EXEC_SK="$(jq -r '.SecretAccessKey' <<<"${creds}")"
+  CT_EXEC_ST="$(jq -r '.SessionToken' <<<"${creds}")"
+  if [[ -z "${CT_EXEC_AK}" || "${CT_EXEC_AK}" == "null" ]]; then
+    echo "FATAL: failed to assume ${CT_EXEC_ROLE_NAME} into ${ACCOUNT_ID}." >&2
+    return 1
+  fi
+
+  live_acct="$(AWS_ACCESS_KEY_ID="${CT_EXEC_AK}" \
+    AWS_SECRET_ACCESS_KEY="${CT_EXEC_SK}" \
+    AWS_SESSION_TOKEN="${CT_EXEC_ST}" \
+    aws sts get-caller-identity --query Account --output text)"
+  if [[ "${live_acct}" != "${ACCOUNT_ID}" ]]; then
+    echo "FATAL: ${CT_EXEC_ROLE_NAME} resolved to account ${live_acct}, expected ${ACCOUNT_ID}. Aborting." >&2
+    return 1
+  fi
+  echo "confirmed identity: arn:aws:sts::${ACCOUNT_ID}:assumed-role/${CT_EXEC_ROLE_NAME}/cold-start-bootstrap"
+}
+
+# --- SEED: local state, CT-exec creds, backend.tf moved aside -------------
+seed() {
+  echo
+  echo "=================================================================="
+  echo ">>> SEED: ${ENV_DIR} (${ACCOUNT_ID})"
+  echo "=================================================================="
+
+  echo "--- assuming ${CT_EXEC_ROLE_NAME} into ${ACCOUNT_ID} ---"
+  assume_ct_exec
+  export AWS_ACCESS_KEY_ID="${CT_EXEC_AK}" AWS_SECRET_ACCESS_KEY="${CT_EXEC_SK}" AWS_SESSION_TOKEN="${CT_EXEC_ST}"
+
+  cd "${BOOTSTRAP_DIR}" || exit 1
+
+  local backend_moved=0
+  restore_seed_state() {
+    if [[ -f backend.tf.seedbak && ${backend_moved} -eq 1 ]]; then
+      mv backend.tf.seedbak backend.tf
+      echo "(restored backend.tf)"
+    fi
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+  }
+  trap restore_seed_state RETURN
+
+  if [[ -f backend.tf ]]; then
+    mv backend.tf backend.tf.seedbak
+    backend_moved=1
+  fi
+
+  # Keep the committed .terraform.lock.hcl (pins provider versions); only
+  # clear the backend/plugin cache and any prior throwaway local state.
+  rm -rf .terraform terraform.tfstate terraform.tfstate.backup
+
+  echo "--- terraform init (local state; backend.tf removed for seed) ---"
+  terraform init -input=false
+
+  echo "--- terraform plan (review what will be created) ---"
+  local plan_file="/tmp/cold-start-${ENV_DIR}-seed.tfplan"
+  terraform plan -input=false -out="${plan_file}"
+
+  echo
+  read -r -p ">>> Apply SEED to ${ENV_DIR} (${ACCOUNT_ID})? Type 'yes' to proceed: " confirm
+  if [[ "${confirm}" != "yes" ]]; then
+    echo "Skipped SEED for ${ENV_DIR} (no apply)."
+    return 0
+  fi
+
+  echo "--- terraform apply ---"
+  terraform apply -input=false "${plan_file}"
+
+  echo "--- roles now present in ${ENV_DIR}: ---"
+  aws iam list-roles \
+    --query "Roles[?starts_with(RoleName,'gh-tf-')||starts_with(RoleName,'aegis-emergency-')].RoleName" \
+    --output text
+
+  # Clean the throwaway local state so it can never be mistaken for real state.
+  rm -f terraform.tfstate terraform.tfstate.backup
+  echo ">>> SEED complete for ${ENV_DIR}."
+}
+
+# --- ADOPT: real S3 state (ambient profile), CT-exec provider override ----
+adopt() {
+  echo
+  echo "=================================================================="
+  echo ">>> ADOPT: ${ENV_DIR} (${ACCOUNT_ID}) into S3 state"
+  echo "=================================================================="
+
+  echo "--- verifying ${CT_EXEC_ROLE_NAME} still resolves to ${ACCOUNT_ID} ---"
+  assume_ct_exec
+  unset CT_EXEC_AK CT_EXEC_SK CT_EXEC_ST
+
+  echo "Ambient (backend) identity: $(aws sts get-caller-identity --profile "${PROFILE}" --query Arn --output text)"
+
+  cd "${BOOTSTRAP_DIR}" || exit 1
+
+  # Terraform override-file naming convention (*_override.tf): this MERGES
+  # with the committed `provider "aws" {}` block instead of conflicting with
+  # it, adding an assume_role for resource operations while the backend block
+  # (declared separately in backend.tf) keeps using the ambient profile.
+  local override_file="${BOOTSTRAP_DIR}/cold_start_adopt_override.tf"
+  cleanup_adopt() {
+    rm -f "${override_file}"
+    unset AWS_PROFILE
+  }
+  trap cleanup_adopt RETURN
+
+  cat >"${override_file}" <<EOF
+# TEMPORARY — generated by scripts/cold-start-bootstrap.sh --mode adopt.
+# Provider assumes ${CT_EXEC_ROLE_NAME} for resource operations while the S3
+# backend authenticates as the ambient profile (${PROFILE}). Removed
+# automatically when the script exits. Do not commit this file.
+provider "aws" {
+  assume_role {
+    role_arn     = "arn:aws:iam::${ACCOUNT_ID}:role/${CT_EXEC_ROLE_NAME}"
+    session_name = "cold-start-adopt"
+  }
+}
+EOF
+
+  export AWS_PROFILE="${PROFILE}"
+  rm -rf .terraform
+
+  echo "--- terraform init (S3 backend, ambient profile ${PROFILE}) ---"
+  terraform init -input=false
+
+  echo "--- terraform plan (adopt_seeded_iam_roles=true: expect 8 imports, no other changes) ---"
+  local plan_file="/tmp/cold-start-${ENV_DIR}-adopt.tfplan"
+  terraform plan -input=false -var="adopt_seeded_iam_roles=true" -out="${plan_file}"
+
+  echo
+  read -r -p ">>> Apply ADOPT to ${ENV_DIR} (${ACCOUNT_ID})? Type 'yes' to proceed: " confirm
+  if [[ "${confirm}" != "yes" ]]; then
+    echo "Skipped ADOPT for ${ENV_DIR} (no apply)."
+    return 0
+  fi
+
+  echo "--- terraform apply ---"
+  terraform apply -input=false "${plan_file}"
+
+  echo "--- state now contains: ---"
+  terraform state list
+
+  echo ">>> ADOPT complete for ${ENV_DIR} (state in S3)."
+}
+
+# --- exit-safety net: catches anything the per-function traps miss (e.g. a
+# kill -9 between the two RETURN traps in --mode both) ---
+cleanup_all() {
+  if [[ -f "${BOOTSTRAP_DIR}/backend.tf.seedbak" ]]; then
+    mv "${BOOTSTRAP_DIR}/backend.tf.seedbak" "${BOOTSTRAP_DIR}/backend.tf"
+    echo "(exit-restore: ${BOOTSTRAP_DIR}/backend.tf)"
+  fi
+  rm -f "${BOOTSTRAP_DIR}/cold_start_adopt_override.tf"
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_PROFILE CT_EXEC_AK CT_EXEC_SK CT_EXEC_ST
+}
+trap cleanup_all EXIT INT TERM
+
+case "${MODE}" in
+  seed)
+    seed
+    ;;
+  adopt)
+    adopt
+    ;;
+  both)
+    seed
+    adopt
+    ;;
+esac
+
+echo
+echo "=================================================================="
+echo "cold-start-bootstrap.sh (${MODE}) done for ${ENV_DIR} (${ACCOUNT_ID})."
+echo "Next: a normal CI apply (gh-tf-apply-baseline, adopt_seeded_iam_roles"
+echo "defaults to false) against this environment should now show NO changes."
+echo "See docs/runbooks/002-cold-account-bootstrap.md and issue #309 (future"
+echo "AFT-style automation of this procedure)."
+echo "=================================================================="


### PR DESCRIPTION
Follow-up to #303 (LZ-S1). Codifies the seed→adopt cold-start procedure from ad-hoc /tmp scripts into committed repo artifacts (per the "preserve verification code / no scratchpad-only" discipline).

- `scripts/cold-start-bootstrap.sh` — parameterized (`--env-dir`, `--mode seed|adopt|both`, `--account-id`, `--profile`), no hardcoded account IDs, shellcheck-clean. Preserves + improves the /tmp safety (per-phase credential scoping, identity re-verification before init, plan-then-interactive-confirm, backend move-aside + provider-override with two-layer traps).
- `docs/runbooks/002-cold-account-bootstrap.md` — documents the WHY (chicken-and-egg, state-bucket write allow-list excluding CT-exec, split-credential adopt). Fills the gap where security/logarchive `check` blocks reference a "Runbook 001 Part 9" that is actually about provisioning staging+prod (unrelated).
- README index updated.

Interim step toward the AFT-style CI-native redesign tracked in #309.

Validation: shellcheck clean, bash -n clean, arg-parsing dry-runs pass. Script makes no AWS calls unless run interactively by an operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)