### PR TITLE
feat(fabric): LZ-baseline S2 — register GuardDuty + SecurityHub delegated admins

### DIFF
--- a/docs/runbooks/001-bootstrap-aws-account.md
+++ b/docs/runbooks/001-bootstrap-aws-account.md
@@ -822,6 +822,13 @@ This file should not exist or should be empty of `aegis-*` content. If it does c
 
   See also [Incident 7](../incidents.md#incident-7--ipam-delegated-admin-not-configured-for-cross-account-vpc-allocation) for the full story of discovering this sequence the hard way.
 
+- **`aws_guardduty_organization_admin_account` / `aws_securityhub_organization_admin_account` apply fails with `AccessDeniedException: ... you must enable service access before you can delegate an administrator for this service`**: Same root cause as the IPAM entry above — GuardDuty and Security Hub each require AWS Organizations trusted-service access enabled for their own service principal before the delegated-admin resource can be created. This is independent per service (enabling it for `ipam.amazonaws.com` does NOT cover `guardduty.amazonaws.com` or `securityhub.amazonaws.com`), and the AWS Terraform provider does not expose it as a standalone resource, so it is a one-time manual CLI step per organization:
+  ```
+  aws organizations enable-aws-service-access --service-principal guardduty.amazonaws.com
+  aws organizations enable-aws-service-access --service-principal securityhub.amazonaws.com
+  ```
+  Run this under `aegis-management-admin` before the first `terraform apply` of `terraform/environments/management/bootstrap/detective-delegation.tf` (Epic #302 Stage S2). Both are idempotent no-ops if already enabled. Unlike Security Hub in some Control Tower landing zones, this org's precheck (2026-07-06) found BOTH `list-organization-admin-accounts` calls empty — the Terraform resources are pure `create`, not imports.
+
 ## Cross-References
 
 - ADR-001: Landing Zone Scope Boundary — the "SSO only for humans" principle.

--- a/terraform/environments/management/bootstrap/detective-delegation.tf
+++ b/terraform/environments/management/bootstrap/detective-delegation.tf
@@ -1,0 +1,55 @@
+# -----------------------------------------------------------------------------
+# Detective Services — Delegated Admin Registration (Epic #302 Stage S2)
+# -----------------------------------------------------------------------------
+# Registers the `security` account as the org-wide delegated administrator for
+# GuardDuty and Security Hub. This is management-side delegation ONLY — per
+# epic #302 decision D5, the detective services themselves (GuardDuty auto-
+# enable for member accounts, Security Hub standards subscriptions) are owned
+# by a separate `security/detective` Terraform layer (Stages S3/S4), not this
+# account-fabric baseline.
+#
+# Unlike the generic `aws_organizations_delegated_administrator` resource used
+# for IPAM above, GuardDuty and Security Hub each have their OWN dedicated
+# Terraform resource / AWS API (`EnableOrganizationAdminAccount`) that performs
+# the delegated-admin registration for that service specifically. Functionally
+# analogous two-step prerequisite as the IPAM pattern above:
+#
+#   1. Enable AWS Organizations trusted-service access for the service
+#      (one-time, manual CLI — see PREREQUISITE note on each resource below).
+#   2. Register the delegated admin account (this Terraform).
+#
+# Precheck (2026-07-06): both `list-organization-admin-accounts` calls
+# (GuardDuty and Security Hub) returned empty in this org — these are pure
+# `create` resources, not imports. `security` (763879260536) is already a
+# delegated administrator for other Control-Tower-managed services, so the
+# org-level trust relationship exists, but the per-service service-access
+# enablement below is independent per service and must still be done once.
+# -----------------------------------------------------------------------------
+
+# PREREQUISITE (one-time, manual CLI, run under aegis-management-admin before
+# the first apply of this resource):
+#
+#   aws organizations enable-aws-service-access \
+#     --service-principal guardduty.amazonaws.com
+#
+# Without this, apply fails with:
+# "AccessDeniedException: ... you must enable service access before you can
+# delegate an administrator for this service" (same failure shape as the IPAM
+# precedent above — see docs/runbooks/001-bootstrap-aws-account.md).
+resource "aws_guardduty_organization_admin_account" "security" {
+  admin_account_id = local.config.accounts.security.id
+}
+
+# PREREQUISITE (one-time, manual CLI, run under aegis-management-admin before
+# the first apply of this resource):
+#
+#   aws organizations enable-aws-service-access \
+#     --service-principal securityhub.amazonaws.com
+#
+# Precheck confirmed Control Tower did NOT pre-set a Security Hub delegated
+# admin in this org (list-organization-admin-accounts returned empty) — this
+# is a create, not an import, despite Security Hub sometimes arriving
+# pre-delegated in other Control Tower landing zones.
+resource "aws_securityhub_organization_admin_account" "security" {
+  admin_account_id = local.config.accounts.security.id
+}

--- a/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
@@ -58,7 +58,7 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
   # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Describe* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-014.
   # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-014. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
   # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-*/github-actions-*/gh-tf-*) plus the OIDC provider and account alias — see Sid IamScoped Resource list. The role is the apply-tier identity for `terraform-apply-baseline.yml` and must be able to manage the project's own IAM resources. Permission-management within a fixed prefix is the apply contract, not a misuse.
-  # checkov:skip=CKV_AWS_290: Service-namespace wildcards (organizations:*, sso:*, identitystore:*) are needed because these AWS APIs do not support resource-level ARN constraints on most write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
+  # checkov:skip=CKV_AWS_290: Service-namespace wildcards (organizations:*, sso:*, identitystore:*, guardduty:*OrganizationAdmin*, securityhub:*OrganizationAdmin*) are needed because these AWS APIs do not support resource-level ARN constraints on most write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
   # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on AWS APIs without resource-level ARN support. Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
   # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within the aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations (creating IRSA roles, OIDC providers, account aliases). Full IAM privileges on a fixed ARN-prefix scope is a deliberate design — an enumerated whitelist of iam:CreateRole/UpdateRole/DeleteRole/...x20+ would be a maintenance liability with the same effective surface. ADR-014 §Decision describes the apply-baseline scope. Same pattern applies to `events:*` (scoped to `rule/aegis-detective-*`) and `sns:*` (scoped to `aegis-security-alerts*`) added by ADR-016 Item A.
   name = "apply-baseline-scoped"
@@ -122,10 +122,42 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
       },
       {
         # Organizations — mgmt-only. Covers SCPs, OUs, accounts, delegated-
-        # administrator (used to delegate IPAM to shared per ADR).
+        # administrator (used to delegate IPAM to shared per ADR). This
+        # Sid already covers organizations:RegisterDelegatedAdministrator
+        # and organizations:EnableAWSServiceAccess — the GuardDuty/Security
+        # Hub delegation added by Epic #302 Stage S2 needed no additions
+        # here, only the service-specific Sids below.
         Sid      = "OrganizationsFull"
         Effect   = "Allow"
         Action   = "organizations:*"
+        Resource = "*"
+      },
+      {
+        # GuardDuty organization delegated-admin registration — Epic #302
+        # Stage S2. `guardduty:*OrganizationAdmin*` is a single wildcard
+        # that matches Enable/Disable/ListOrganizationAdminAccount(s) — the
+        # full lifecycle needed for `terraform apply` (create), `terraform
+        # plan` (read/refresh), and `terraform destroy -target` (the
+        # documented revert path in issue #304). Listing
+        # `EnableOrganizationAdminAccount` on its own would be redundant
+        # (it's a strict substring match of the wildcard) so only the
+        # wildcard is kept. Resource:"*" because GuardDuty's org-admin API
+        # does not support resource-level ARNs.
+        Sid      = "GuardDutyOrgAdminDelegation"
+        Effect   = "Allow"
+        Action   = "guardduty:*OrganizationAdmin*"
+        Resource = "*"
+      },
+      {
+        # Security Hub organization delegated-admin registration — Epic
+        # #302 Stage S2. Same rationale as GuardDuty above: the wildcard
+        # covers Enable/Disable/List so `terraform plan` refresh and the
+        # `terraform destroy -target` revert path both work, not just the
+        # initial apply. Resource:"*" because Security Hub's org-admin API
+        # does not support resource-level ARNs.
+        Sid      = "SecurityHubOrgAdminDelegation"
+        Effect   = "Allow"
+        Action   = "securityhub:*OrganizationAdmin*"
         Resource = "*"
       },
       {


### PR DESCRIPTION
Implements #304 (S2 of detective-baseline epic #302). Registers the security account (763879260536) as org delegated administrator for GuardDuty + Security Hub — the prerequisite for S3/S4 (which turn the services ON; **S2 itself is FREE** — delegation only).

Precheck confirmed both admins EMPTY → pure CREATE (no imports).

### Changes
- `management/bootstrap/detective-delegation.tf` — `aws_guardduty_organization_admin_account` + `aws_securityhub_organization_admin_account` (admin = security account).
- `management/bootstrap/oidc-github-baseline-role.tf` — `guardduty:*OrganizationAdmin*` + `securityhub:*OrganizationAdmin*` Sids (wildcard, not Create-only, so plan/destroy work end-to-end; `organizations:*` already covered).
- runbook 001 — enable-aws-service-access prereq entry.

### ⚠️ ONE-TIME manual prereq BEFORE merge (apply needs org service-access enabled first)
Run under `aegis-management-admin`:
```
aws organizations enable-aws-service-access --service-principal guardduty.amazonaws.com
aws organizations enable-aws-service-access --service-principal securityhub.amazonaws.com
```

### Validation
- terraform validate + fmt clean. The `plan` matrix job will show "2 to add" (the delegations) — that's expected; apply needs the prereq above first.

Part of epic #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)