### PR TITLE
fix(state): isolate Terraform state per account by key prefix (#314)

### DIFF
--- a/terraform/environments/shared/bootstrap/config.tf
+++ b/terraform/environments/shared/bootstrap/config.tf
@@ -12,6 +12,14 @@ locals {
 
   bucket_name = "${local.org_name}-terraform-state-${local.account_id}"
 
+  # Accounts whose CI (`gh-tf-*`) roles write Terraform state. Each account's
+  # state lives under a `<account-name>/` key prefix in the shared state bucket
+  # (e.g. `staging/bootstrap/terraform.tfstate`); the map keys match those
+  # prefixes. Empty ids (an un-vended account in a fork's config) are excluded
+  # so the bucket policy never emits a statement with a malformed principal ARN.
+  # Consumed by the per-account state-isolation statements in main.tf (#314).
+  ci_state_accounts = { for name, acct in local.config.accounts : name => acct.id if acct.id != "" }
+
   tags = merge(local.config.tags, {
     Environment = "shared"
   })

--- a/terraform/environments/shared/bootstrap/main.tf
+++ b/terraform/environments/shared/bootstrap/main.tf
@@ -66,56 +66,129 @@ resource "aws_s3_bucket_public_access_block" "terraform_state" {
   restrict_public_buckets = true
 }
 
+# -----------------------------------------------------------------------------
+# State bucket policy — per-account isolation (issue #314)
+# -----------------------------------------------------------------------------
+# State keys are laid out `<account-name>/<layer>/terraform.tfstate`. Each
+# account's CI role (`gh-tf-*`) may read and write ONLY the object keys under
+# its own `<account-name>/` prefix. The account id in each statement's
+# `ArnLike` pins the calling principal to the same account whose prefix the
+# `Resource` names, so a staging CI role cannot read or overwrite `prod/`,
+# `management/`, or the guardrail state under `management/scps`. This closes
+# the org-wide "any gh-tf-* → all state keys" access that isolation-by-naming-
+# convention left open.
+#
+# Two identities keep bucket-wide access by design:
+#   - `aegis-emergency-*` (break-glass) and the SSO `PlatformAdmin` permission
+#     set are incident-response / human-operator identities that legitimately
+#     cross account boundaries during recovery. Per-account CI isolation does
+#     not apply to them.
+#
+# Object read/write (`GetObject`/`PutObject`/`DeleteObject`) — the sensitive
+# operations that disclose or overwrite state content — are prefix-scoped.
+# `ListBucket`/`GetBucketLocation` stay bucket-wide for every gh-tf-* role:
+# they are the existence/region probes the S3 backend issues, and they expose
+# only object KEY NAMES (account/layer paths), classified non-secret metadata
+# per CLAUDE.md. Prefix-conditioning `ListBucket` risks breaking the backend's
+# workspace/existence enumeration for no confidentiality gain.
+#
+# Same-account note: the shared account owns this bucket, so its own gh-tf-*
+# role's access is governed by the union of its identity policy and this bucket
+# policy. The matching per-prefix cap is therefore ALSO asserted on the
+# identity side in `oidc-github-baseline-role.tf` (`StateObjectsOwnPrefix`);
+# tightening the bucket policy alone would not constrain the shared role.
+# -----------------------------------------------------------------------------
+
 resource "aws_s3_bucket_policy" "terraform_state" {
   bucket = aws_s3_bucket.terraform_state.id
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Sid       = "AllowAllowListedPrincipals"
-        Effect    = "Allow"
-        Principal = "*"
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-        ]
-        Resource = [
-          aws_s3_bucket.terraform_state.arn,
-          "${aws_s3_bucket.terraform_state.arn}/*",
-        ]
-        Condition = {
-          StringEquals = {
-            "aws:PrincipalOrgID" = local.org_id
+    Statement = concat(
+      [
+        {
+          Sid       = "AllowBreakGlassAndAdminAllState"
+          Effect    = "Allow"
+          Principal = "*"
+          Action = [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject",
+            "s3:ListBucket",
+            "s3:GetBucketLocation",
+          ]
+          Resource = [
+            aws_s3_bucket.terraform_state.arn,
+            "${aws_s3_bucket.terraform_state.arn}/*",
+          ]
+          Condition = {
+            StringEquals = {
+              "aws:PrincipalOrgID" = local.org_id
+            }
+            ArnLike = {
+              "aws:PrincipalArn" = [
+                "arn:aws:iam::*:role/aegis-emergency-*",
+                "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*",
+              ]
+            }
           }
-          ArnLike = {
-            "aws:PrincipalArn" = [
-              "arn:aws:iam::*:role/gh-tf-*",
-              "arn:aws:iam::*:role/aegis-emergency-*",
-              "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_PlatformAdmin_*",
-            ]
+        },
+        {
+          Sid       = "AllowCiBucketProbes"
+          Effect    = "Allow"
+          Principal = "*"
+          Action = [
+            "s3:ListBucket",
+            "s3:GetBucketLocation",
+          ]
+          Resource = aws_s3_bucket.terraform_state.arn
+          Condition = {
+            StringEquals = {
+              "aws:PrincipalOrgID" = local.org_id
+            }
+            ArnLike = {
+              "aws:PrincipalArn" = "arn:aws:iam::*:role/gh-tf-*"
+            }
+          }
+        },
+        {
+          Sid       = "DenyInsecureTransport"
+          Effect    = "Deny"
+          Principal = "*"
+          Action    = "s3:*"
+          Resource = [
+            aws_s3_bucket.terraform_state.arn,
+            "${aws_s3_bucket.terraform_state.arn}/*",
+          ]
+          Condition = {
+            Bool = {
+              "aws:SecureTransport" = "false"
+            }
+          }
+        },
+      ],
+      [
+        for name, id in local.ci_state_accounts : {
+          Sid       = "AllowCiStateObjects${title(name)}"
+          Effect    = "Allow"
+          Principal = "*"
+          Action = [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject",
+          ]
+          Resource = "${aws_s3_bucket.terraform_state.arn}/${name}/*"
+          Condition = {
+            StringEquals = {
+              "aws:PrincipalOrgID" = local.org_id
+            }
+            ArnLike = {
+              "aws:PrincipalArn" = "arn:aws:iam::${id}:role/gh-tf-*"
+            }
           }
         }
-      },
-      {
-        Sid       = "DenyInsecureTransport"
-        Effect    = "Deny"
-        Principal = "*"
-        Action    = "s3:*"
-        Resource = [
-          aws_s3_bucket.terraform_state.arn,
-          "${aws_s3_bucket.terraform_state.arn}/*",
-        ]
-        Condition = {
-          Bool = {
-            "aws:SecureTransport" = "false"
-          }
-        }
-      },
-    ]
+      ],
+    )
   })
 }
 

--- a/terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf
@@ -122,13 +122,26 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
         }
       },
       {
-        # State bucket — created and managed in this account. Full
-        # bucket-level mutation plus object-level read/write for both the
-        # state object itself and any other state files in the bucket.
-        Sid      = "StateBucketFull"
+        # State bucket — bucket-level configuration on the state bucket this
+        # account owns (policy, versioning, encryption, lifecycle, public-
+        # access-block, ListBucket, GetBucketLocation). Bucket-level actions
+        # target the bucket ARN; object read/write is the next Sid.
+        Sid      = "StateBucketManage"
         Effect   = "Allow"
         Action   = "s3:*"
-        Resource = "arn:aws:s3:::${local.org_name}-*"
+        Resource = "arn:aws:s3:::${local.bucket_name}"
+      },
+      {
+        # State objects — read/write limited to the shared account's own
+        # `shared/` key prefix (issue #314). The shared account owns the
+        # bucket, so same-account access is the union of this identity policy
+        # and the bucket policy; the per-prefix cap has to be asserted here,
+        # not only in the bucket policy. `management/`, `staging/`, `prod/`,
+        # and `deployment/` state stay unreachable from the shared CI role.
+        Sid      = "StateObjectsOwnPrefix"
+        Effect   = "Allow"
+        Action   = "s3:*"
+        Resource = "arn:aws:s3:::${local.bucket_name}/shared/*"
       },
       {
         # KMS — state encryption key lives in this account. `aegis-*`


### PR DESCRIPTION
Closes #314 (HIGH, review-2026-07, epic #312).

## Problem
The shared state bucket policy granted every `gh-tf-*` role in every org account read+write on **all** state keys. Per-account isolation was key-naming convention only, not IAM-enforced — staging CI could read or overwrite `prod/` and `management/scps` state.

## Fix
Per-account key-prefix isolation on the existing shared bucket (keeps ADR-003's single-bucket topology; the per-account-buckets alternative would need a new ADR):
- One generated bucket-policy statement per account: `gh-tf-*` roles of account X get object R/W on `<X>/*` only, with `aws:PrincipalArn` pinned to that account id.
- `gh-tf-*` bucket-wide access reduced to `ListBucket`/`GetBucketLocation` (backend probes; key names are non-secret metadata per repo policy).
- Break-glass (`aegis-emergency-*`) + SSO PlatformAdmin keep bucket-wide access.
- Shared account's own baseline role narrowed identity-side (`s3:*` on `shared/*` objects only) since bucket policy cannot cap the bucket owner's same-account access.

## Validation
- `terraform fmt -check -recursive` clean; `terraform validate` (init -backend=false) passes on shared/bootstrap.
- Statement rendering verified against real config (7 accounts); policy ≈3KB, well under the 20KB limit.
- CI plan on this PR is the authoritative check.

## Residual (out of scope, tracked)
- KMS state key org-wide grant = #316.
- Future cross-account `terraform_remote_state` reads need explicit per-consumer READ grants (none wired today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M5J4RtdQ4CqtHrbejbNr8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tightened access to Terraform state storage with per-account isolation and clearer separation between bucket-level and object-level permissions.
  * Added scoped permissions for CI roles so they can manage only their own state paths.

* **Bug Fixes**
  * Prevented invalid access rules from being generated for accounts without an ID.
  * Reduced the risk of overly broad state bucket access by limiting permissions to the intended prefixes and identities.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->