### PR TITLE
fix(ci): grant plan role GuardDuty + Security Hub read shapes

### DIFF
--- a/terraform/environments/management/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-plan-role.tf
@@ -154,6 +154,13 @@ resource "aws_iam_role_policy" "gh_tf_plan" {
           # rule on the default bus + an SNS topic. Plan-tier refresh needs
           # the read shapes for both services.
           "events:Get*",
+          # LZ-baseline S2 (#311) added GuardDuty + Security Hub delegated-admin
+          # registration in this layer; plan-tier refresh needs both read shapes.
+          "guardduty:Get*",
+          "guardduty:List*",
+          "securityhub:Describe*",
+          "securityhub:Get*",
+          "securityhub:List*",
           "sns:Get*",
           "sns:List*",
           "ram:Get*",


### PR DESCRIPTION
Unblocks all PR plans of management/bootstrap.

## Problem
LZ-baseline S2 (#311) added `aws_guardduty_organization_admin_account` and `aws_securityhub_organization_admin_account` to management/bootstrap, but `gh-tf-plan`'s ReadOnlyAwsApiSurface was never extended. Every PR plan now fails refreshing those resources with 403 (`guardduty:ListOrganizationAdminAccounts`, `securityhub:ListOrganizationAdminAccounts`). First observed on #322.

## Fix
Add `guardduty:Get*/List*` and `securityhub:Describe*/Get*/List*` to the ReadOnlyAwsApiSurface Sid, following the policy's existing read-shape convention.

## Bootstrap note (chicken-and-egg)
A PR plan cannot pass until the permission exists in AWS. Per operator decision (Bin, 2026-07-07), the policy update was applied out-of-band via a targeted apply (`-target=aws_iam_role_policy.gh_tf_plan`, 1 in-place change, management account, admin SSO). The merge apply converges to a no-op for this resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M5J4RtdQ4CqtHrbejbNr8