### PR TITLE
feat(iam): ADR-020 PR-1 — CI permissions boundary policy + attach to gh-tf-* roles (#313)

### DIFF
--- a/docs/principles/change-review-discipline.md
+++ b/docs/principles/change-review-discipline.md
@@ -72,6 +72,7 @@ Before merging a change — whether a Terraform diff or a workflow edit — the 
 - Variable names descriptive enough to re-parse in a coffee-deprived brain?
 - Comments where the *why* is non-obvious and not captured elsewhere?
 - Resource names following the repo-scoped naming convention so they do not collide with sibling repos' resources in the same AWS account? (See `CLAUDE.md` naming discipline — bare `aegis-` prefixes collided twice with a sibling repo.)
+- Does every new CI `aws_iam_role` set `permissions_boundary = aws_iam_policy.ci_boundary.arn`? Post-ADR-020 (PR-1) a CI-managed role without the boundary leaves an unbounded escalation gap, and once SCP S1 lands (PR-2) a `gh-tf-*` caller creating a role without the boundary fails `AccessDenied` at creation. The one deliberate exception is `aegis-emergency-*` (break-glass) — it is the boundary's in-account repair path (ADR-020 D3) and is intentionally left unbounded.
 - ADR reference in the PR description for the decision this change embodies?
 
 **Rule**: the code you ship is the code someone else will read under stress. Optimize for that reader.

--- a/terraform/environments/deployment/bootstrap/ci-permissions-boundary.tf
+++ b/terraform/environments/deployment/bootstrap/ci-permissions-boundary.tf
@@ -1,0 +1,162 @@
+# -----------------------------------------------------------------------------
+# `aegis-landing-zone-aws-ci-boundary` — SCP-enforced CI permissions boundary
+# (ADR-020 D1). PR-1 of the ADR-020 rollout: the boundary policy plus its
+# attachment to every CI (`gh-tf-*`) role. The SCP statements S1/S2 that make
+# the boundary mandatory org-wide are PR-2 and land only after this policy is
+# applied in every account (ADR-020 D4).
+# -----------------------------------------------------------------------------
+# WHAT THIS IS: a permissions BOUNDARY — a ceiling, not a grant. Attaching it to
+# a role cannot expand that role's permissions; it can only intersect them. A
+# bounded role's effective permissions are (its identity policy) ∩ (this
+# boundary). The wide Allow below is the outer cap; per-role least-privilege
+# scoping stays in each role's own policy (ADR-014). The load-bearing security
+# control is the explicit Deny floor, which no Allow can override.
+#
+# SINGLE ORG-UNIFORM DOCUMENT (ADR-020 OQ-1, decided by Bin 2026-07-07): this
+# file is byte-identical across all seven `*/bootstrap` layers. The only
+# per-account input is `local.account_id`, used to build the boundary's own ARN
+# in the deny-floor conditions. Drift between the seven copies is a bug — audit
+# with `diff`/`md5`.
+#
+# NOT ATTACHED TO `aegis-emergency-break-glass` — see the attachment note in
+# each `oidc-github-*-role.tf` / this file's tail. Break-glass is the designated
+# in-account repair path for a corrupted boundary (ADR-020 D3); a bounded
+# break-glass would be blocked by this document's own `DenyMutateBoundaryPolicy`
+# clause and could not repair it. Break-glass is also outside SCP S1's scope by
+# construction (S1 is deny-scoped-to `gh-tf-*` callers). See PR body — flagged
+# as a decision point against ADR-020 D1's literal "every managed role" wording.
+# -----------------------------------------------------------------------------
+
+locals {
+  ci_boundary_name = "aegis-landing-zone-aws-ci-boundary"
+  ci_boundary_arn  = "arn:aws:iam::${local.account_id}:policy/${local.ci_boundary_name}"
+}
+
+data "aws_iam_policy_document" "ci_boundary" {
+  # This document is a permissions BOUNDARY (a ceiling), never attached as a
+  # grant. Attaching it cannot expand any identity's permissions — it only
+  # intersects. The wide Allow is the outer cap required by ADR-020 D1/OQ-1;
+  # the load-bearing control is the explicit Deny floor below, which no Allow
+  # can override. Per-role least privilege lives in the ADR-014 role policies.
+  # Checkov evaluates the rendered policy statically and cannot tell a boundary
+  # ceiling from a grant, so the wildcard-policy checks are skipped with that
+  # rationale (the same posture ADR-014 role policies already carry):
+  # checkov:skip=CKV_AWS_107: Boundary ceiling, not a grant. Credential-exposure breadth is capped here, not granted; each role's own ADR-014 policy is the actual scope.
+  # checkov:skip=CKV_AWS_108: Boundary ceiling — data-exfiltration scoping is enforced by each role's ADR-014 policy, of which this boundary is only the outer cap.
+  # checkov:skip=CKV_AWS_109: `iam:*` in the Allow is the ceiling; permissions-management escalation is denied by DenyMutateBoundaryPolicy / DenyStripAnyBoundary / DenyPutNonAegisBoundary, not by narrowing the Allow.
+  # checkov:skip=CKV_AWS_110: Privilege escalation is closed by this document's own Deny floor (DenyCreateWithoutAegisBoundary forces the boundary onto every created identity), not by removing wildcards from the ceiling.
+  # checkov:skip=CKV_AWS_111: Write access is constrained by the Deny floor plus each role's resource-scoped ADR-014 policy; a boundary cannot enumerate per-ARN writes without duplicating every role policy.
+  # checkov:skip=CKV_AWS_356: Resource:* is required for a namespace-level permissions boundary. The restrictable-action constraint is enforced at the role-policy layer (ADR-014); this document is the ceiling above it.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentional in a permissions boundary — it is the ceiling that lets bounded ADR-014 roles run their scoped IAM operations. Full-IAM escalation is closed by the Deny floor.
+
+  # --- Allow floor: the outer cap ------------------------------------------
+  # Union of service namespaces the CI-managed roles legitimately use
+  # (ADR-020 Appendix A). `ecr` + `sts` cover the platform CI's
+  # `gh-tf-apply-deployment` shared-registry surface verified in the ADR-020
+  # pre-PR-1 cross-repo step. Namespace-level Allow is intentional: the
+  # boundary is a ceiling, and enumerating actions here would duplicate the
+  # ADR-014 per-role policies at a second layer and break on every legitimate
+  # surface addition.
+  statement {
+    sid    = "AllowServiceNamespaceCeiling"
+    effect = "Allow"
+    actions = [
+      "iam:*",
+      "s3:*",
+      "kms:*",
+      "ec2:*",
+      "ram:*",
+      "tag:*",
+      "budgets:*",
+      "events:*",
+      "sns:*",
+      "organizations:*",
+      "sso:*",
+      "identitystore:*",
+      "guardduty:*",
+      "securityhub:*",
+      "ssm:*",
+      "sts:*",
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+
+  # --- Deny floor: the non-negotiable escalation guard ---------------------
+  # An explicit Deny overrides every Allow (in this boundary and in any
+  # identity policy). These clauses are what actually close #313.
+
+  # A bounded identity can never strip a boundary — including its own.
+  statement {
+    sid    = "DenyStripAnyBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+  }
+
+  # A bounded identity cannot swap in a permissive boundary: any
+  # Put*PermissionsBoundary must set THIS boundary's ARN.
+  statement {
+    sid    = "DenyPutNonAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # Self-propagating: any role/user a bounded identity creates must carry THIS
+  # boundary. A create without it (condition key absent → StringNotEquals is
+  # true) is denied. This is what caps the `CreateRole → AttachRolePolicy(
+  # AdministratorAccess) → AssumeRole` primitive regardless of the created
+  # role's name or attachments (ADR-020 §"What the boundary adds").
+  statement {
+    sid    = "DenyCreateWithoutAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # A bounded identity cannot rewrite the boundary document itself. Mirrors
+  # SCP S2 (ADR-020 D3) at the boundary-document layer; boundary evolution is
+  # a break-glass ceremony by design. Break-glass is not bounded (see header),
+  # so this clause does not block the D3 repair path.
+  statement {
+    sid    = "DenyMutateBoundaryPolicy"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+    ]
+    resources = ["arn:aws:iam::*:policy/${local.ci_boundary_name}"]
+  }
+}
+
+resource "aws_iam_policy" "ci_boundary" {
+  # Checkov evaluates the policy JSON on the data source above (where the skips
+  # live); this resource only wires that rendered document to the managed
+  # policy. It is a permissions boundary — a ceiling, never attached as a grant.
+  name        = local.ci_boundary_name
+  description = "ADR-020 SCP-enforced CI permissions boundary. Outer cap on every gh-tf-* CI identity; the Deny floor blocks boundary self-removal, unbounded role/user creation, and mutation of the boundary document. This is a ceiling, not a grant."
+  policy      = data.aws_iam_policy_document.ci_boundary.json
+  tags        = local.tags
+}

--- a/terraform/environments/deployment/bootstrap/oidc-github-apply-deployment-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-apply-deployment-role.tf
@@ -81,7 +81,8 @@ import {
 }
 
 resource "aws_iam_role" "gh_tf_apply_deployment" {
-  name = "gh-tf-apply-deployment"
+  name                 = "gh-tf-apply-deployment"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/deployment/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-baseline-role.tf
@@ -14,7 +14,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_apply_baseline" {
-  name = "gh-tf-apply-baseline"
+  name                 = "gh-tf-apply-baseline"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/deployment/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/deployment/bootstrap/oidc-github-plan-role.tf
@@ -16,7 +16,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_plan" {
-  name = "gh-tf-plan"
+  name                 = "gh-tf-plan"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/logarchive/bootstrap/ci-permissions-boundary.tf
+++ b/terraform/environments/logarchive/bootstrap/ci-permissions-boundary.tf
@@ -1,0 +1,162 @@
+# -----------------------------------------------------------------------------
+# `aegis-landing-zone-aws-ci-boundary` — SCP-enforced CI permissions boundary
+# (ADR-020 D1). PR-1 of the ADR-020 rollout: the boundary policy plus its
+# attachment to every CI (`gh-tf-*`) role. The SCP statements S1/S2 that make
+# the boundary mandatory org-wide are PR-2 and land only after this policy is
+# applied in every account (ADR-020 D4).
+# -----------------------------------------------------------------------------
+# WHAT THIS IS: a permissions BOUNDARY — a ceiling, not a grant. Attaching it to
+# a role cannot expand that role's permissions; it can only intersect them. A
+# bounded role's effective permissions are (its identity policy) ∩ (this
+# boundary). The wide Allow below is the outer cap; per-role least-privilege
+# scoping stays in each role's own policy (ADR-014). The load-bearing security
+# control is the explicit Deny floor, which no Allow can override.
+#
+# SINGLE ORG-UNIFORM DOCUMENT (ADR-020 OQ-1, decided by Bin 2026-07-07): this
+# file is byte-identical across all seven `*/bootstrap` layers. The only
+# per-account input is `local.account_id`, used to build the boundary's own ARN
+# in the deny-floor conditions. Drift between the seven copies is a bug — audit
+# with `diff`/`md5`.
+#
+# NOT ATTACHED TO `aegis-emergency-break-glass` — see the attachment note in
+# each `oidc-github-*-role.tf` / this file's tail. Break-glass is the designated
+# in-account repair path for a corrupted boundary (ADR-020 D3); a bounded
+# break-glass would be blocked by this document's own `DenyMutateBoundaryPolicy`
+# clause and could not repair it. Break-glass is also outside SCP S1's scope by
+# construction (S1 is deny-scoped-to `gh-tf-*` callers). See PR body — flagged
+# as a decision point against ADR-020 D1's literal "every managed role" wording.
+# -----------------------------------------------------------------------------
+
+locals {
+  ci_boundary_name = "aegis-landing-zone-aws-ci-boundary"
+  ci_boundary_arn  = "arn:aws:iam::${local.account_id}:policy/${local.ci_boundary_name}"
+}
+
+data "aws_iam_policy_document" "ci_boundary" {
+  # This document is a permissions BOUNDARY (a ceiling), never attached as a
+  # grant. Attaching it cannot expand any identity's permissions — it only
+  # intersects. The wide Allow is the outer cap required by ADR-020 D1/OQ-1;
+  # the load-bearing control is the explicit Deny floor below, which no Allow
+  # can override. Per-role least privilege lives in the ADR-014 role policies.
+  # Checkov evaluates the rendered policy statically and cannot tell a boundary
+  # ceiling from a grant, so the wildcard-policy checks are skipped with that
+  # rationale (the same posture ADR-014 role policies already carry):
+  # checkov:skip=CKV_AWS_107: Boundary ceiling, not a grant. Credential-exposure breadth is capped here, not granted; each role's own ADR-014 policy is the actual scope.
+  # checkov:skip=CKV_AWS_108: Boundary ceiling — data-exfiltration scoping is enforced by each role's ADR-014 policy, of which this boundary is only the outer cap.
+  # checkov:skip=CKV_AWS_109: `iam:*` in the Allow is the ceiling; permissions-management escalation is denied by DenyMutateBoundaryPolicy / DenyStripAnyBoundary / DenyPutNonAegisBoundary, not by narrowing the Allow.
+  # checkov:skip=CKV_AWS_110: Privilege escalation is closed by this document's own Deny floor (DenyCreateWithoutAegisBoundary forces the boundary onto every created identity), not by removing wildcards from the ceiling.
+  # checkov:skip=CKV_AWS_111: Write access is constrained by the Deny floor plus each role's resource-scoped ADR-014 policy; a boundary cannot enumerate per-ARN writes without duplicating every role policy.
+  # checkov:skip=CKV_AWS_356: Resource:* is required for a namespace-level permissions boundary. The restrictable-action constraint is enforced at the role-policy layer (ADR-014); this document is the ceiling above it.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentional in a permissions boundary — it is the ceiling that lets bounded ADR-014 roles run their scoped IAM operations. Full-IAM escalation is closed by the Deny floor.
+
+  # --- Allow floor: the outer cap ------------------------------------------
+  # Union of service namespaces the CI-managed roles legitimately use
+  # (ADR-020 Appendix A). `ecr` + `sts` cover the platform CI's
+  # `gh-tf-apply-deployment` shared-registry surface verified in the ADR-020
+  # pre-PR-1 cross-repo step. Namespace-level Allow is intentional: the
+  # boundary is a ceiling, and enumerating actions here would duplicate the
+  # ADR-014 per-role policies at a second layer and break on every legitimate
+  # surface addition.
+  statement {
+    sid    = "AllowServiceNamespaceCeiling"
+    effect = "Allow"
+    actions = [
+      "iam:*",
+      "s3:*",
+      "kms:*",
+      "ec2:*",
+      "ram:*",
+      "tag:*",
+      "budgets:*",
+      "events:*",
+      "sns:*",
+      "organizations:*",
+      "sso:*",
+      "identitystore:*",
+      "guardduty:*",
+      "securityhub:*",
+      "ssm:*",
+      "sts:*",
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+
+  # --- Deny floor: the non-negotiable escalation guard ---------------------
+  # An explicit Deny overrides every Allow (in this boundary and in any
+  # identity policy). These clauses are what actually close #313.
+
+  # A bounded identity can never strip a boundary — including its own.
+  statement {
+    sid    = "DenyStripAnyBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+  }
+
+  # A bounded identity cannot swap in a permissive boundary: any
+  # Put*PermissionsBoundary must set THIS boundary's ARN.
+  statement {
+    sid    = "DenyPutNonAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # Self-propagating: any role/user a bounded identity creates must carry THIS
+  # boundary. A create without it (condition key absent → StringNotEquals is
+  # true) is denied. This is what caps the `CreateRole → AttachRolePolicy(
+  # AdministratorAccess) → AssumeRole` primitive regardless of the created
+  # role's name or attachments (ADR-020 §"What the boundary adds").
+  statement {
+    sid    = "DenyCreateWithoutAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # A bounded identity cannot rewrite the boundary document itself. Mirrors
+  # SCP S2 (ADR-020 D3) at the boundary-document layer; boundary evolution is
+  # a break-glass ceremony by design. Break-glass is not bounded (see header),
+  # so this clause does not block the D3 repair path.
+  statement {
+    sid    = "DenyMutateBoundaryPolicy"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+    ]
+    resources = ["arn:aws:iam::*:policy/${local.ci_boundary_name}"]
+  }
+}
+
+resource "aws_iam_policy" "ci_boundary" {
+  # Checkov evaluates the policy JSON on the data source above (where the skips
+  # live); this resource only wires that rendered document to the managed
+  # policy. It is a permissions boundary — a ceiling, never attached as a grant.
+  name        = local.ci_boundary_name
+  description = "ADR-020 SCP-enforced CI permissions boundary. Outer cap on every gh-tf-* CI identity; the Deny floor blocks boundary self-removal, unbounded role/user creation, and mutation of the boundary document. This is a ceiling, not a grant."
+  policy      = data.aws_iam_policy_document.ci_boundary.json
+  tags        = local.tags
+}

--- a/terraform/environments/logarchive/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/logarchive/bootstrap/oidc-github-baseline-role.tf
@@ -18,7 +18,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_apply_baseline" {
-  name = "gh-tf-apply-baseline"
+  name                 = "gh-tf-apply-baseline"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/logarchive/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/logarchive/bootstrap/oidc-github-plan-role.tf
@@ -22,7 +22,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_plan" {
-  name = "gh-tf-plan"
+  name                 = "gh-tf-plan"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/management/bootstrap/ci-permissions-boundary.tf
+++ b/terraform/environments/management/bootstrap/ci-permissions-boundary.tf
@@ -1,0 +1,162 @@
+# -----------------------------------------------------------------------------
+# `aegis-landing-zone-aws-ci-boundary` — SCP-enforced CI permissions boundary
+# (ADR-020 D1). PR-1 of the ADR-020 rollout: the boundary policy plus its
+# attachment to every CI (`gh-tf-*`) role. The SCP statements S1/S2 that make
+# the boundary mandatory org-wide are PR-2 and land only after this policy is
+# applied in every account (ADR-020 D4).
+# -----------------------------------------------------------------------------
+# WHAT THIS IS: a permissions BOUNDARY — a ceiling, not a grant. Attaching it to
+# a role cannot expand that role's permissions; it can only intersect them. A
+# bounded role's effective permissions are (its identity policy) ∩ (this
+# boundary). The wide Allow below is the outer cap; per-role least-privilege
+# scoping stays in each role's own policy (ADR-014). The load-bearing security
+# control is the explicit Deny floor, which no Allow can override.
+#
+# SINGLE ORG-UNIFORM DOCUMENT (ADR-020 OQ-1, decided by Bin 2026-07-07): this
+# file is byte-identical across all seven `*/bootstrap` layers. The only
+# per-account input is `local.account_id`, used to build the boundary's own ARN
+# in the deny-floor conditions. Drift between the seven copies is a bug — audit
+# with `diff`/`md5`.
+#
+# NOT ATTACHED TO `aegis-emergency-break-glass` — see the attachment note in
+# each `oidc-github-*-role.tf` / this file's tail. Break-glass is the designated
+# in-account repair path for a corrupted boundary (ADR-020 D3); a bounded
+# break-glass would be blocked by this document's own `DenyMutateBoundaryPolicy`
+# clause and could not repair it. Break-glass is also outside SCP S1's scope by
+# construction (S1 is deny-scoped-to `gh-tf-*` callers). See PR body — flagged
+# as a decision point against ADR-020 D1's literal "every managed role" wording.
+# -----------------------------------------------------------------------------
+
+locals {
+  ci_boundary_name = "aegis-landing-zone-aws-ci-boundary"
+  ci_boundary_arn  = "arn:aws:iam::${local.account_id}:policy/${local.ci_boundary_name}"
+}
+
+data "aws_iam_policy_document" "ci_boundary" {
+  # This document is a permissions BOUNDARY (a ceiling), never attached as a
+  # grant. Attaching it cannot expand any identity's permissions — it only
+  # intersects. The wide Allow is the outer cap required by ADR-020 D1/OQ-1;
+  # the load-bearing control is the explicit Deny floor below, which no Allow
+  # can override. Per-role least privilege lives in the ADR-014 role policies.
+  # Checkov evaluates the rendered policy statically and cannot tell a boundary
+  # ceiling from a grant, so the wildcard-policy checks are skipped with that
+  # rationale (the same posture ADR-014 role policies already carry):
+  # checkov:skip=CKV_AWS_107: Boundary ceiling, not a grant. Credential-exposure breadth is capped here, not granted; each role's own ADR-014 policy is the actual scope.
+  # checkov:skip=CKV_AWS_108: Boundary ceiling — data-exfiltration scoping is enforced by each role's ADR-014 policy, of which this boundary is only the outer cap.
+  # checkov:skip=CKV_AWS_109: `iam:*` in the Allow is the ceiling; permissions-management escalation is denied by DenyMutateBoundaryPolicy / DenyStripAnyBoundary / DenyPutNonAegisBoundary, not by narrowing the Allow.
+  # checkov:skip=CKV_AWS_110: Privilege escalation is closed by this document's own Deny floor (DenyCreateWithoutAegisBoundary forces the boundary onto every created identity), not by removing wildcards from the ceiling.
+  # checkov:skip=CKV_AWS_111: Write access is constrained by the Deny floor plus each role's resource-scoped ADR-014 policy; a boundary cannot enumerate per-ARN writes without duplicating every role policy.
+  # checkov:skip=CKV_AWS_356: Resource:* is required for a namespace-level permissions boundary. The restrictable-action constraint is enforced at the role-policy layer (ADR-014); this document is the ceiling above it.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentional in a permissions boundary — it is the ceiling that lets bounded ADR-014 roles run their scoped IAM operations. Full-IAM escalation is closed by the Deny floor.
+
+  # --- Allow floor: the outer cap ------------------------------------------
+  # Union of service namespaces the CI-managed roles legitimately use
+  # (ADR-020 Appendix A). `ecr` + `sts` cover the platform CI's
+  # `gh-tf-apply-deployment` shared-registry surface verified in the ADR-020
+  # pre-PR-1 cross-repo step. Namespace-level Allow is intentional: the
+  # boundary is a ceiling, and enumerating actions here would duplicate the
+  # ADR-014 per-role policies at a second layer and break on every legitimate
+  # surface addition.
+  statement {
+    sid    = "AllowServiceNamespaceCeiling"
+    effect = "Allow"
+    actions = [
+      "iam:*",
+      "s3:*",
+      "kms:*",
+      "ec2:*",
+      "ram:*",
+      "tag:*",
+      "budgets:*",
+      "events:*",
+      "sns:*",
+      "organizations:*",
+      "sso:*",
+      "identitystore:*",
+      "guardduty:*",
+      "securityhub:*",
+      "ssm:*",
+      "sts:*",
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+
+  # --- Deny floor: the non-negotiable escalation guard ---------------------
+  # An explicit Deny overrides every Allow (in this boundary and in any
+  # identity policy). These clauses are what actually close #313.
+
+  # A bounded identity can never strip a boundary — including its own.
+  statement {
+    sid    = "DenyStripAnyBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+  }
+
+  # A bounded identity cannot swap in a permissive boundary: any
+  # Put*PermissionsBoundary must set THIS boundary's ARN.
+  statement {
+    sid    = "DenyPutNonAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # Self-propagating: any role/user a bounded identity creates must carry THIS
+  # boundary. A create without it (condition key absent → StringNotEquals is
+  # true) is denied. This is what caps the `CreateRole → AttachRolePolicy(
+  # AdministratorAccess) → AssumeRole` primitive regardless of the created
+  # role's name or attachments (ADR-020 §"What the boundary adds").
+  statement {
+    sid    = "DenyCreateWithoutAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # A bounded identity cannot rewrite the boundary document itself. Mirrors
+  # SCP S2 (ADR-020 D3) at the boundary-document layer; boundary evolution is
+  # a break-glass ceremony by design. Break-glass is not bounded (see header),
+  # so this clause does not block the D3 repair path.
+  statement {
+    sid    = "DenyMutateBoundaryPolicy"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+    ]
+    resources = ["arn:aws:iam::*:policy/${local.ci_boundary_name}"]
+  }
+}
+
+resource "aws_iam_policy" "ci_boundary" {
+  # Checkov evaluates the policy JSON on the data source above (where the skips
+  # live); this resource only wires that rendered document to the managed
+  # policy. It is a permissions boundary — a ceiling, never attached as a grant.
+  name        = local.ci_boundary_name
+  description = "ADR-020 SCP-enforced CI permissions boundary. Outer cap on every gh-tf-* CI identity; the Deny floor blocks boundary self-removal, unbounded role/user creation, and mutation of the boundary document. This is a ceiling, not a grant."
+  policy      = data.aws_iam_policy_document.ci_boundary.json
+  tags        = local.tags
+}

--- a/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
@@ -22,7 +22,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_apply_baseline" {
-  name = "gh-tf-apply-baseline"
+  name                 = "gh-tf-apply-baseline"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/management/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-plan-role.tf
@@ -16,7 +16,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_plan" {
-  name = "gh-tf-plan"
+  name                 = "gh-tf-plan"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/prod/bootstrap/ci-permissions-boundary.tf
+++ b/terraform/environments/prod/bootstrap/ci-permissions-boundary.tf
@@ -1,0 +1,162 @@
+# -----------------------------------------------------------------------------
+# `aegis-landing-zone-aws-ci-boundary` — SCP-enforced CI permissions boundary
+# (ADR-020 D1). PR-1 of the ADR-020 rollout: the boundary policy plus its
+# attachment to every CI (`gh-tf-*`) role. The SCP statements S1/S2 that make
+# the boundary mandatory org-wide are PR-2 and land only after this policy is
+# applied in every account (ADR-020 D4).
+# -----------------------------------------------------------------------------
+# WHAT THIS IS: a permissions BOUNDARY — a ceiling, not a grant. Attaching it to
+# a role cannot expand that role's permissions; it can only intersect them. A
+# bounded role's effective permissions are (its identity policy) ∩ (this
+# boundary). The wide Allow below is the outer cap; per-role least-privilege
+# scoping stays in each role's own policy (ADR-014). The load-bearing security
+# control is the explicit Deny floor, which no Allow can override.
+#
+# SINGLE ORG-UNIFORM DOCUMENT (ADR-020 OQ-1, decided by Bin 2026-07-07): this
+# file is byte-identical across all seven `*/bootstrap` layers. The only
+# per-account input is `local.account_id`, used to build the boundary's own ARN
+# in the deny-floor conditions. Drift between the seven copies is a bug — audit
+# with `diff`/`md5`.
+#
+# NOT ATTACHED TO `aegis-emergency-break-glass` — see the attachment note in
+# each `oidc-github-*-role.tf` / this file's tail. Break-glass is the designated
+# in-account repair path for a corrupted boundary (ADR-020 D3); a bounded
+# break-glass would be blocked by this document's own `DenyMutateBoundaryPolicy`
+# clause and could not repair it. Break-glass is also outside SCP S1's scope by
+# construction (S1 is deny-scoped-to `gh-tf-*` callers). See PR body — flagged
+# as a decision point against ADR-020 D1's literal "every managed role" wording.
+# -----------------------------------------------------------------------------
+
+locals {
+  ci_boundary_name = "aegis-landing-zone-aws-ci-boundary"
+  ci_boundary_arn  = "arn:aws:iam::${local.account_id}:policy/${local.ci_boundary_name}"
+}
+
+data "aws_iam_policy_document" "ci_boundary" {
+  # This document is a permissions BOUNDARY (a ceiling), never attached as a
+  # grant. Attaching it cannot expand any identity's permissions — it only
+  # intersects. The wide Allow is the outer cap required by ADR-020 D1/OQ-1;
+  # the load-bearing control is the explicit Deny floor below, which no Allow
+  # can override. Per-role least privilege lives in the ADR-014 role policies.
+  # Checkov evaluates the rendered policy statically and cannot tell a boundary
+  # ceiling from a grant, so the wildcard-policy checks are skipped with that
+  # rationale (the same posture ADR-014 role policies already carry):
+  # checkov:skip=CKV_AWS_107: Boundary ceiling, not a grant. Credential-exposure breadth is capped here, not granted; each role's own ADR-014 policy is the actual scope.
+  # checkov:skip=CKV_AWS_108: Boundary ceiling — data-exfiltration scoping is enforced by each role's ADR-014 policy, of which this boundary is only the outer cap.
+  # checkov:skip=CKV_AWS_109: `iam:*` in the Allow is the ceiling; permissions-management escalation is denied by DenyMutateBoundaryPolicy / DenyStripAnyBoundary / DenyPutNonAegisBoundary, not by narrowing the Allow.
+  # checkov:skip=CKV_AWS_110: Privilege escalation is closed by this document's own Deny floor (DenyCreateWithoutAegisBoundary forces the boundary onto every created identity), not by removing wildcards from the ceiling.
+  # checkov:skip=CKV_AWS_111: Write access is constrained by the Deny floor plus each role's resource-scoped ADR-014 policy; a boundary cannot enumerate per-ARN writes without duplicating every role policy.
+  # checkov:skip=CKV_AWS_356: Resource:* is required for a namespace-level permissions boundary. The restrictable-action constraint is enforced at the role-policy layer (ADR-014); this document is the ceiling above it.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentional in a permissions boundary — it is the ceiling that lets bounded ADR-014 roles run their scoped IAM operations. Full-IAM escalation is closed by the Deny floor.
+
+  # --- Allow floor: the outer cap ------------------------------------------
+  # Union of service namespaces the CI-managed roles legitimately use
+  # (ADR-020 Appendix A). `ecr` + `sts` cover the platform CI's
+  # `gh-tf-apply-deployment` shared-registry surface verified in the ADR-020
+  # pre-PR-1 cross-repo step. Namespace-level Allow is intentional: the
+  # boundary is a ceiling, and enumerating actions here would duplicate the
+  # ADR-014 per-role policies at a second layer and break on every legitimate
+  # surface addition.
+  statement {
+    sid    = "AllowServiceNamespaceCeiling"
+    effect = "Allow"
+    actions = [
+      "iam:*",
+      "s3:*",
+      "kms:*",
+      "ec2:*",
+      "ram:*",
+      "tag:*",
+      "budgets:*",
+      "events:*",
+      "sns:*",
+      "organizations:*",
+      "sso:*",
+      "identitystore:*",
+      "guardduty:*",
+      "securityhub:*",
+      "ssm:*",
+      "sts:*",
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+
+  # --- Deny floor: the non-negotiable escalation guard ---------------------
+  # An explicit Deny overrides every Allow (in this boundary and in any
+  # identity policy). These clauses are what actually close #313.
+
+  # A bounded identity can never strip a boundary — including its own.
+  statement {
+    sid    = "DenyStripAnyBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+  }
+
+  # A bounded identity cannot swap in a permissive boundary: any
+  # Put*PermissionsBoundary must set THIS boundary's ARN.
+  statement {
+    sid    = "DenyPutNonAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # Self-propagating: any role/user a bounded identity creates must carry THIS
+  # boundary. A create without it (condition key absent → StringNotEquals is
+  # true) is denied. This is what caps the `CreateRole → AttachRolePolicy(
+  # AdministratorAccess) → AssumeRole` primitive regardless of the created
+  # role's name or attachments (ADR-020 §"What the boundary adds").
+  statement {
+    sid    = "DenyCreateWithoutAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # A bounded identity cannot rewrite the boundary document itself. Mirrors
+  # SCP S2 (ADR-020 D3) at the boundary-document layer; boundary evolution is
+  # a break-glass ceremony by design. Break-glass is not bounded (see header),
+  # so this clause does not block the D3 repair path.
+  statement {
+    sid    = "DenyMutateBoundaryPolicy"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+    ]
+    resources = ["arn:aws:iam::*:policy/${local.ci_boundary_name}"]
+  }
+}
+
+resource "aws_iam_policy" "ci_boundary" {
+  # Checkov evaluates the policy JSON on the data source above (where the skips
+  # live); this resource only wires that rendered document to the managed
+  # policy. It is a permissions boundary — a ceiling, never attached as a grant.
+  name        = local.ci_boundary_name
+  description = "ADR-020 SCP-enforced CI permissions boundary. Outer cap on every gh-tf-* CI identity; the Deny floor blocks boundary self-removal, unbounded role/user creation, and mutation of the boundary document. This is a ceiling, not a grant."
+  policy      = data.aws_iam_policy_document.ci_boundary.json
+  tags        = local.tags
+}

--- a/terraform/environments/prod/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/prod/bootstrap/oidc-github-baseline-role.tf
@@ -11,7 +11,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_apply_baseline" {
-  name = "gh-tf-apply-baseline"
+  name                 = "gh-tf-apply-baseline"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/prod/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/prod/bootstrap/oidc-github-plan-role.tf
@@ -16,7 +16,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_plan" {
-  name = "gh-tf-plan"
+  name                 = "gh-tf-plan"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/security/bootstrap/ci-permissions-boundary.tf
+++ b/terraform/environments/security/bootstrap/ci-permissions-boundary.tf
@@ -1,0 +1,162 @@
+# -----------------------------------------------------------------------------
+# `aegis-landing-zone-aws-ci-boundary` — SCP-enforced CI permissions boundary
+# (ADR-020 D1). PR-1 of the ADR-020 rollout: the boundary policy plus its
+# attachment to every CI (`gh-tf-*`) role. The SCP statements S1/S2 that make
+# the boundary mandatory org-wide are PR-2 and land only after this policy is
+# applied in every account (ADR-020 D4).
+# -----------------------------------------------------------------------------
+# WHAT THIS IS: a permissions BOUNDARY — a ceiling, not a grant. Attaching it to
+# a role cannot expand that role's permissions; it can only intersect them. A
+# bounded role's effective permissions are (its identity policy) ∩ (this
+# boundary). The wide Allow below is the outer cap; per-role least-privilege
+# scoping stays in each role's own policy (ADR-014). The load-bearing security
+# control is the explicit Deny floor, which no Allow can override.
+#
+# SINGLE ORG-UNIFORM DOCUMENT (ADR-020 OQ-1, decided by Bin 2026-07-07): this
+# file is byte-identical across all seven `*/bootstrap` layers. The only
+# per-account input is `local.account_id`, used to build the boundary's own ARN
+# in the deny-floor conditions. Drift between the seven copies is a bug — audit
+# with `diff`/`md5`.
+#
+# NOT ATTACHED TO `aegis-emergency-break-glass` — see the attachment note in
+# each `oidc-github-*-role.tf` / this file's tail. Break-glass is the designated
+# in-account repair path for a corrupted boundary (ADR-020 D3); a bounded
+# break-glass would be blocked by this document's own `DenyMutateBoundaryPolicy`
+# clause and could not repair it. Break-glass is also outside SCP S1's scope by
+# construction (S1 is deny-scoped-to `gh-tf-*` callers). See PR body — flagged
+# as a decision point against ADR-020 D1's literal "every managed role" wording.
+# -----------------------------------------------------------------------------
+
+locals {
+  ci_boundary_name = "aegis-landing-zone-aws-ci-boundary"
+  ci_boundary_arn  = "arn:aws:iam::${local.account_id}:policy/${local.ci_boundary_name}"
+}
+
+data "aws_iam_policy_document" "ci_boundary" {
+  # This document is a permissions BOUNDARY (a ceiling), never attached as a
+  # grant. Attaching it cannot expand any identity's permissions — it only
+  # intersects. The wide Allow is the outer cap required by ADR-020 D1/OQ-1;
+  # the load-bearing control is the explicit Deny floor below, which no Allow
+  # can override. Per-role least privilege lives in the ADR-014 role policies.
+  # Checkov evaluates the rendered policy statically and cannot tell a boundary
+  # ceiling from a grant, so the wildcard-policy checks are skipped with that
+  # rationale (the same posture ADR-014 role policies already carry):
+  # checkov:skip=CKV_AWS_107: Boundary ceiling, not a grant. Credential-exposure breadth is capped here, not granted; each role's own ADR-014 policy is the actual scope.
+  # checkov:skip=CKV_AWS_108: Boundary ceiling — data-exfiltration scoping is enforced by each role's ADR-014 policy, of which this boundary is only the outer cap.
+  # checkov:skip=CKV_AWS_109: `iam:*` in the Allow is the ceiling; permissions-management escalation is denied by DenyMutateBoundaryPolicy / DenyStripAnyBoundary / DenyPutNonAegisBoundary, not by narrowing the Allow.
+  # checkov:skip=CKV_AWS_110: Privilege escalation is closed by this document's own Deny floor (DenyCreateWithoutAegisBoundary forces the boundary onto every created identity), not by removing wildcards from the ceiling.
+  # checkov:skip=CKV_AWS_111: Write access is constrained by the Deny floor plus each role's resource-scoped ADR-014 policy; a boundary cannot enumerate per-ARN writes without duplicating every role policy.
+  # checkov:skip=CKV_AWS_356: Resource:* is required for a namespace-level permissions boundary. The restrictable-action constraint is enforced at the role-policy layer (ADR-014); this document is the ceiling above it.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentional in a permissions boundary — it is the ceiling that lets bounded ADR-014 roles run their scoped IAM operations. Full-IAM escalation is closed by the Deny floor.
+
+  # --- Allow floor: the outer cap ------------------------------------------
+  # Union of service namespaces the CI-managed roles legitimately use
+  # (ADR-020 Appendix A). `ecr` + `sts` cover the platform CI's
+  # `gh-tf-apply-deployment` shared-registry surface verified in the ADR-020
+  # pre-PR-1 cross-repo step. Namespace-level Allow is intentional: the
+  # boundary is a ceiling, and enumerating actions here would duplicate the
+  # ADR-014 per-role policies at a second layer and break on every legitimate
+  # surface addition.
+  statement {
+    sid    = "AllowServiceNamespaceCeiling"
+    effect = "Allow"
+    actions = [
+      "iam:*",
+      "s3:*",
+      "kms:*",
+      "ec2:*",
+      "ram:*",
+      "tag:*",
+      "budgets:*",
+      "events:*",
+      "sns:*",
+      "organizations:*",
+      "sso:*",
+      "identitystore:*",
+      "guardduty:*",
+      "securityhub:*",
+      "ssm:*",
+      "sts:*",
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+
+  # --- Deny floor: the non-negotiable escalation guard ---------------------
+  # An explicit Deny overrides every Allow (in this boundary and in any
+  # identity policy). These clauses are what actually close #313.
+
+  # A bounded identity can never strip a boundary — including its own.
+  statement {
+    sid    = "DenyStripAnyBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+  }
+
+  # A bounded identity cannot swap in a permissive boundary: any
+  # Put*PermissionsBoundary must set THIS boundary's ARN.
+  statement {
+    sid    = "DenyPutNonAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # Self-propagating: any role/user a bounded identity creates must carry THIS
+  # boundary. A create without it (condition key absent → StringNotEquals is
+  # true) is denied. This is what caps the `CreateRole → AttachRolePolicy(
+  # AdministratorAccess) → AssumeRole` primitive regardless of the created
+  # role's name or attachments (ADR-020 §"What the boundary adds").
+  statement {
+    sid    = "DenyCreateWithoutAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # A bounded identity cannot rewrite the boundary document itself. Mirrors
+  # SCP S2 (ADR-020 D3) at the boundary-document layer; boundary evolution is
+  # a break-glass ceremony by design. Break-glass is not bounded (see header),
+  # so this clause does not block the D3 repair path.
+  statement {
+    sid    = "DenyMutateBoundaryPolicy"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+    ]
+    resources = ["arn:aws:iam::*:policy/${local.ci_boundary_name}"]
+  }
+}
+
+resource "aws_iam_policy" "ci_boundary" {
+  # Checkov evaluates the policy JSON on the data source above (where the skips
+  # live); this resource only wires that rendered document to the managed
+  # policy. It is a permissions boundary — a ceiling, never attached as a grant.
+  name        = local.ci_boundary_name
+  description = "ADR-020 SCP-enforced CI permissions boundary. Outer cap on every gh-tf-* CI identity; the Deny floor blocks boundary self-removal, unbounded role/user creation, and mutation of the boundary document. This is a ceiling, not a grant."
+  policy      = data.aws_iam_policy_document.ci_boundary.json
+  tags        = local.tags
+}

--- a/terraform/environments/security/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/security/bootstrap/oidc-github-baseline-role.tf
@@ -17,7 +17,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_apply_baseline" {
-  name = "gh-tf-apply-baseline"
+  name                 = "gh-tf-apply-baseline"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/security/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/security/bootstrap/oidc-github-plan-role.tf
@@ -22,7 +22,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_plan" {
-  name = "gh-tf-plan"
+  name                 = "gh-tf-plan"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/shared/bootstrap/ci-permissions-boundary.tf
+++ b/terraform/environments/shared/bootstrap/ci-permissions-boundary.tf
@@ -1,0 +1,162 @@
+# -----------------------------------------------------------------------------
+# `aegis-landing-zone-aws-ci-boundary` — SCP-enforced CI permissions boundary
+# (ADR-020 D1). PR-1 of the ADR-020 rollout: the boundary policy plus its
+# attachment to every CI (`gh-tf-*`) role. The SCP statements S1/S2 that make
+# the boundary mandatory org-wide are PR-2 and land only after this policy is
+# applied in every account (ADR-020 D4).
+# -----------------------------------------------------------------------------
+# WHAT THIS IS: a permissions BOUNDARY — a ceiling, not a grant. Attaching it to
+# a role cannot expand that role's permissions; it can only intersect them. A
+# bounded role's effective permissions are (its identity policy) ∩ (this
+# boundary). The wide Allow below is the outer cap; per-role least-privilege
+# scoping stays in each role's own policy (ADR-014). The load-bearing security
+# control is the explicit Deny floor, which no Allow can override.
+#
+# SINGLE ORG-UNIFORM DOCUMENT (ADR-020 OQ-1, decided by Bin 2026-07-07): this
+# file is byte-identical across all seven `*/bootstrap` layers. The only
+# per-account input is `local.account_id`, used to build the boundary's own ARN
+# in the deny-floor conditions. Drift between the seven copies is a bug — audit
+# with `diff`/`md5`.
+#
+# NOT ATTACHED TO `aegis-emergency-break-glass` — see the attachment note in
+# each `oidc-github-*-role.tf` / this file's tail. Break-glass is the designated
+# in-account repair path for a corrupted boundary (ADR-020 D3); a bounded
+# break-glass would be blocked by this document's own `DenyMutateBoundaryPolicy`
+# clause and could not repair it. Break-glass is also outside SCP S1's scope by
+# construction (S1 is deny-scoped-to `gh-tf-*` callers). See PR body — flagged
+# as a decision point against ADR-020 D1's literal "every managed role" wording.
+# -----------------------------------------------------------------------------
+
+locals {
+  ci_boundary_name = "aegis-landing-zone-aws-ci-boundary"
+  ci_boundary_arn  = "arn:aws:iam::${local.account_id}:policy/${local.ci_boundary_name}"
+}
+
+data "aws_iam_policy_document" "ci_boundary" {
+  # This document is a permissions BOUNDARY (a ceiling), never attached as a
+  # grant. Attaching it cannot expand any identity's permissions — it only
+  # intersects. The wide Allow is the outer cap required by ADR-020 D1/OQ-1;
+  # the load-bearing control is the explicit Deny floor below, which no Allow
+  # can override. Per-role least privilege lives in the ADR-014 role policies.
+  # Checkov evaluates the rendered policy statically and cannot tell a boundary
+  # ceiling from a grant, so the wildcard-policy checks are skipped with that
+  # rationale (the same posture ADR-014 role policies already carry):
+  # checkov:skip=CKV_AWS_107: Boundary ceiling, not a grant. Credential-exposure breadth is capped here, not granted; each role's own ADR-014 policy is the actual scope.
+  # checkov:skip=CKV_AWS_108: Boundary ceiling — data-exfiltration scoping is enforced by each role's ADR-014 policy, of which this boundary is only the outer cap.
+  # checkov:skip=CKV_AWS_109: `iam:*` in the Allow is the ceiling; permissions-management escalation is denied by DenyMutateBoundaryPolicy / DenyStripAnyBoundary / DenyPutNonAegisBoundary, not by narrowing the Allow.
+  # checkov:skip=CKV_AWS_110: Privilege escalation is closed by this document's own Deny floor (DenyCreateWithoutAegisBoundary forces the boundary onto every created identity), not by removing wildcards from the ceiling.
+  # checkov:skip=CKV_AWS_111: Write access is constrained by the Deny floor plus each role's resource-scoped ADR-014 policy; a boundary cannot enumerate per-ARN writes without duplicating every role policy.
+  # checkov:skip=CKV_AWS_356: Resource:* is required for a namespace-level permissions boundary. The restrictable-action constraint is enforced at the role-policy layer (ADR-014); this document is the ceiling above it.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentional in a permissions boundary — it is the ceiling that lets bounded ADR-014 roles run their scoped IAM operations. Full-IAM escalation is closed by the Deny floor.
+
+  # --- Allow floor: the outer cap ------------------------------------------
+  # Union of service namespaces the CI-managed roles legitimately use
+  # (ADR-020 Appendix A). `ecr` + `sts` cover the platform CI's
+  # `gh-tf-apply-deployment` shared-registry surface verified in the ADR-020
+  # pre-PR-1 cross-repo step. Namespace-level Allow is intentional: the
+  # boundary is a ceiling, and enumerating actions here would duplicate the
+  # ADR-014 per-role policies at a second layer and break on every legitimate
+  # surface addition.
+  statement {
+    sid    = "AllowServiceNamespaceCeiling"
+    effect = "Allow"
+    actions = [
+      "iam:*",
+      "s3:*",
+      "kms:*",
+      "ec2:*",
+      "ram:*",
+      "tag:*",
+      "budgets:*",
+      "events:*",
+      "sns:*",
+      "organizations:*",
+      "sso:*",
+      "identitystore:*",
+      "guardduty:*",
+      "securityhub:*",
+      "ssm:*",
+      "sts:*",
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+
+  # --- Deny floor: the non-negotiable escalation guard ---------------------
+  # An explicit Deny overrides every Allow (in this boundary and in any
+  # identity policy). These clauses are what actually close #313.
+
+  # A bounded identity can never strip a boundary — including its own.
+  statement {
+    sid    = "DenyStripAnyBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+  }
+
+  # A bounded identity cannot swap in a permissive boundary: any
+  # Put*PermissionsBoundary must set THIS boundary's ARN.
+  statement {
+    sid    = "DenyPutNonAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # Self-propagating: any role/user a bounded identity creates must carry THIS
+  # boundary. A create without it (condition key absent → StringNotEquals is
+  # true) is denied. This is what caps the `CreateRole → AttachRolePolicy(
+  # AdministratorAccess) → AssumeRole` primitive regardless of the created
+  # role's name or attachments (ADR-020 §"What the boundary adds").
+  statement {
+    sid    = "DenyCreateWithoutAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # A bounded identity cannot rewrite the boundary document itself. Mirrors
+  # SCP S2 (ADR-020 D3) at the boundary-document layer; boundary evolution is
+  # a break-glass ceremony by design. Break-glass is not bounded (see header),
+  # so this clause does not block the D3 repair path.
+  statement {
+    sid    = "DenyMutateBoundaryPolicy"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+    ]
+    resources = ["arn:aws:iam::*:policy/${local.ci_boundary_name}"]
+  }
+}
+
+resource "aws_iam_policy" "ci_boundary" {
+  # Checkov evaluates the policy JSON on the data source above (where the skips
+  # live); this resource only wires that rendered document to the managed
+  # policy. It is a permissions boundary — a ceiling, never attached as a grant.
+  name        = local.ci_boundary_name
+  description = "ADR-020 SCP-enforced CI permissions boundary. Outer cap on every gh-tf-* CI identity; the Deny floor blocks boundary self-removal, unbounded role/user creation, and mutation of the boundary document. This is a ceiling, not a grant."
+  policy      = data.aws_iam_policy_document.ci_boundary.json
+  tags        = local.tags
+}

--- a/terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/shared/bootstrap/oidc-github-baseline-role.tf
@@ -23,7 +23,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_apply_baseline" {
-  name = "gh-tf-apply-baseline"
+  name                 = "gh-tf-apply-baseline"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/shared/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/shared/bootstrap/oidc-github-plan-role.tf
@@ -16,7 +16,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_plan" {
-  name = "gh-tf-plan"
+  name                 = "gh-tf-plan"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/staging/bootstrap/ci-permissions-boundary.tf
+++ b/terraform/environments/staging/bootstrap/ci-permissions-boundary.tf
@@ -1,0 +1,162 @@
+# -----------------------------------------------------------------------------
+# `aegis-landing-zone-aws-ci-boundary` — SCP-enforced CI permissions boundary
+# (ADR-020 D1). PR-1 of the ADR-020 rollout: the boundary policy plus its
+# attachment to every CI (`gh-tf-*`) role. The SCP statements S1/S2 that make
+# the boundary mandatory org-wide are PR-2 and land only after this policy is
+# applied in every account (ADR-020 D4).
+# -----------------------------------------------------------------------------
+# WHAT THIS IS: a permissions BOUNDARY — a ceiling, not a grant. Attaching it to
+# a role cannot expand that role's permissions; it can only intersect them. A
+# bounded role's effective permissions are (its identity policy) ∩ (this
+# boundary). The wide Allow below is the outer cap; per-role least-privilege
+# scoping stays in each role's own policy (ADR-014). The load-bearing security
+# control is the explicit Deny floor, which no Allow can override.
+#
+# SINGLE ORG-UNIFORM DOCUMENT (ADR-020 OQ-1, decided by Bin 2026-07-07): this
+# file is byte-identical across all seven `*/bootstrap` layers. The only
+# per-account input is `local.account_id`, used to build the boundary's own ARN
+# in the deny-floor conditions. Drift between the seven copies is a bug — audit
+# with `diff`/`md5`.
+#
+# NOT ATTACHED TO `aegis-emergency-break-glass` — see the attachment note in
+# each `oidc-github-*-role.tf` / this file's tail. Break-glass is the designated
+# in-account repair path for a corrupted boundary (ADR-020 D3); a bounded
+# break-glass would be blocked by this document's own `DenyMutateBoundaryPolicy`
+# clause and could not repair it. Break-glass is also outside SCP S1's scope by
+# construction (S1 is deny-scoped-to `gh-tf-*` callers). See PR body — flagged
+# as a decision point against ADR-020 D1's literal "every managed role" wording.
+# -----------------------------------------------------------------------------
+
+locals {
+  ci_boundary_name = "aegis-landing-zone-aws-ci-boundary"
+  ci_boundary_arn  = "arn:aws:iam::${local.account_id}:policy/${local.ci_boundary_name}"
+}
+
+data "aws_iam_policy_document" "ci_boundary" {
+  # This document is a permissions BOUNDARY (a ceiling), never attached as a
+  # grant. Attaching it cannot expand any identity's permissions — it only
+  # intersects. The wide Allow is the outer cap required by ADR-020 D1/OQ-1;
+  # the load-bearing control is the explicit Deny floor below, which no Allow
+  # can override. Per-role least privilege lives in the ADR-014 role policies.
+  # Checkov evaluates the rendered policy statically and cannot tell a boundary
+  # ceiling from a grant, so the wildcard-policy checks are skipped with that
+  # rationale (the same posture ADR-014 role policies already carry):
+  # checkov:skip=CKV_AWS_107: Boundary ceiling, not a grant. Credential-exposure breadth is capped here, not granted; each role's own ADR-014 policy is the actual scope.
+  # checkov:skip=CKV_AWS_108: Boundary ceiling — data-exfiltration scoping is enforced by each role's ADR-014 policy, of which this boundary is only the outer cap.
+  # checkov:skip=CKV_AWS_109: `iam:*` in the Allow is the ceiling; permissions-management escalation is denied by DenyMutateBoundaryPolicy / DenyStripAnyBoundary / DenyPutNonAegisBoundary, not by narrowing the Allow.
+  # checkov:skip=CKV_AWS_110: Privilege escalation is closed by this document's own Deny floor (DenyCreateWithoutAegisBoundary forces the boundary onto every created identity), not by removing wildcards from the ceiling.
+  # checkov:skip=CKV_AWS_111: Write access is constrained by the Deny floor plus each role's resource-scoped ADR-014 policy; a boundary cannot enumerate per-ARN writes without duplicating every role policy.
+  # checkov:skip=CKV_AWS_356: Resource:* is required for a namespace-level permissions boundary. The restrictable-action constraint is enforced at the role-policy layer (ADR-014); this document is the ceiling above it.
+  # checkov:skip=CKV2_AWS_40: `iam:*` is intentional in a permissions boundary — it is the ceiling that lets bounded ADR-014 roles run their scoped IAM operations. Full-IAM escalation is closed by the Deny floor.
+
+  # --- Allow floor: the outer cap ------------------------------------------
+  # Union of service namespaces the CI-managed roles legitimately use
+  # (ADR-020 Appendix A). `ecr` + `sts` cover the platform CI's
+  # `gh-tf-apply-deployment` shared-registry surface verified in the ADR-020
+  # pre-PR-1 cross-repo step. Namespace-level Allow is intentional: the
+  # boundary is a ceiling, and enumerating actions here would duplicate the
+  # ADR-014 per-role policies at a second layer and break on every legitimate
+  # surface addition.
+  statement {
+    sid    = "AllowServiceNamespaceCeiling"
+    effect = "Allow"
+    actions = [
+      "iam:*",
+      "s3:*",
+      "kms:*",
+      "ec2:*",
+      "ram:*",
+      "tag:*",
+      "budgets:*",
+      "events:*",
+      "sns:*",
+      "organizations:*",
+      "sso:*",
+      "identitystore:*",
+      "guardduty:*",
+      "securityhub:*",
+      "ssm:*",
+      "sts:*",
+      "ecr:*",
+    ]
+    resources = ["*"]
+  }
+
+  # --- Deny floor: the non-negotiable escalation guard ---------------------
+  # An explicit Deny overrides every Allow (in this boundary and in any
+  # identity policy). These clauses are what actually close #313.
+
+  # A bounded identity can never strip a boundary — including its own.
+  statement {
+    sid    = "DenyStripAnyBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+  }
+
+  # A bounded identity cannot swap in a permissive boundary: any
+  # Put*PermissionsBoundary must set THIS boundary's ARN.
+  statement {
+    sid    = "DenyPutNonAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # Self-propagating: any role/user a bounded identity creates must carry THIS
+  # boundary. A create without it (condition key absent → StringNotEquals is
+  # true) is denied. This is what caps the `CreateRole → AttachRolePolicy(
+  # AdministratorAccess) → AssumeRole` primitive regardless of the created
+  # role's name or attachments (ADR-020 §"What the boundary adds").
+  statement {
+    sid    = "DenyCreateWithoutAegisBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.ci_boundary_arn]
+    }
+  }
+
+  # A bounded identity cannot rewrite the boundary document itself. Mirrors
+  # SCP S2 (ADR-020 D3) at the boundary-document layer; boundary evolution is
+  # a break-glass ceremony by design. Break-glass is not bounded (see header),
+  # so this clause does not block the D3 repair path.
+  statement {
+    sid    = "DenyMutateBoundaryPolicy"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+    ]
+    resources = ["arn:aws:iam::*:policy/${local.ci_boundary_name}"]
+  }
+}
+
+resource "aws_iam_policy" "ci_boundary" {
+  # Checkov evaluates the policy JSON on the data source above (where the skips
+  # live); this resource only wires that rendered document to the managed
+  # policy. It is a permissions boundary — a ceiling, never attached as a grant.
+  name        = local.ci_boundary_name
+  description = "ADR-020 SCP-enforced CI permissions boundary. Outer cap on every gh-tf-* CI identity; the Deny floor blocks boundary self-removal, unbounded role/user creation, and mutation of the boundary document. This is a ceiling, not a grant."
+  policy      = data.aws_iam_policy_document.ci_boundary.json
+  tags        = local.tags
+}

--- a/terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-baseline-role.tf
@@ -11,7 +11,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_apply_baseline" {
-  name = "gh-tf-apply-baseline"
+  name                 = "gh-tf-apply-baseline"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/environments/staging/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/staging/bootstrap/oidc-github-plan-role.tf
@@ -16,7 +16,8 @@
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_plan" {
-  name = "gh-tf-plan"
+  name                 = "gh-tf-plan"
+  permissions_boundary = aws_iam_policy.ci_boundary.arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
## What this is

PR-1 of the ADR-020 rollout (D4): the SCP-enforced CI permissions boundary **policy plus its attachment**. It does **not** include the SCP statements S1/S2 — those are PR-2 and must land only after this boundary is applied in every account (ordering rationale in ADR-020 D4; a bare SCP-first would fail CI's next `CreateRole` against a nonexistent boundary ARN).

Resolves the design in #313 ([HIGH] CI apply-tier role has no permissions boundary). Implements ADR-020 (#324). Part of epic #312.

## Change shape

| Area | Change | Count |
|---|---|---|
| `terraform/environments/*/bootstrap/ci-permissions-boundary.tf` | New `aws_iam_policy.ci_boundary` = `aegis-landing-zone-aws-ci-boundary`, single org-uniform document (OQ-1), **byte-identical across all 7 layers** | +7 files |
| `oidc-github-plan-role.tf` | `permissions_boundary` added to `gh-tf-plan` | 7 roles |
| `oidc-github-baseline-role.tf` | `permissions_boundary` added to `gh-tf-apply-baseline` | 7 roles |
| `oidc-github-apply-deployment-role.tf` | `permissions_boundary` added to `gh-tf-apply-deployment` | 1 role |
| `docs/principles/change-review-discipline.md` | New checklist line: every new CI role must set the boundary (ADR-020 Consequences) | 1 doc |

**Boundary attached to 15 CI roles.** Allow floor = the ADR-020 Appendix A service-namespace ceiling (`iam, s3, kms, ec2, ram, tag, budgets, events, sns, organizations, sso, identitystore, guardduty, securityhub, ssm, sts, ecr`). Deny floor = boundary self-removal, unbounded role/user creation, and boundary-document mutation.

## Step 0 — cross-repo verification (ADR-020 OQ-2, required pre-PR-1)

Verified the platform CI surface reachable through `gh-tf-apply-deployment` against `aegis-platform-aws`.

- **The boundary blocks nothing platform CI needs.** The only actions the platform CI performs when it assumes `gh-tf-apply-deployment` (managing the shared deployment-account registry) are in the `ecr` and `sts` namespaces — both in the boundary allow-list.
- **Finding worth flagging: the ADR's named file `deployment-ecr.tf` no longer exists in `aegis-platform-aws`.** It was removed under platform **ADR-23** (Accepted 2026-06-20): aegis-core now distributes via **public GHCR** on Graviton, not the deployment-account ECR. `deployment-ecr.tf` is described as "stays `count = 0` inert" but is in fact deleted from the tree (`git ls-files` returns nothing). Consequently `gh-tf-apply-deployment` currently manages **no live surface** — its `deployment_account_id` gate (staging) points at a registry that platform TF no longer creates.
- **`ecr` still belongs in the allow-list.** The greeter app is still on ECR (per-account `envs/platform/ecr.tf`, managed by the platform-repo role `gh-tf-apply-platform`, which is **not** an LDZ-created role and so is not bounded by this PR), and the shared-registry path may be reinstated. Keeping `ecr` is forward-compatible cover and costs nothing. All historical `deployment-ecr.tf` / push-role actions surveyed were `ecr:*` only (Create/Describe/Get/List/Put/Delete repository, lifecycle, replication, layer upload) — fully inside the `ecr` namespace.

Net: **no boundary allow-list gap; nothing to fold in beyond `ecr`, which was already the OQ-2 decision.**

## DECISION POINT — break-glass is not bounded (narrows ADR-020 D1)

ADR-020 D1 says the boundary attaches to "every `aws_iam_role` this repository manages," and its inventory table lists `aegis-emergency-break-glass`. **I did not attach the boundary to break-glass**, because D1's own `DenyMutateBoundaryPolicy` deny clause and D3's break-glass repair path are mutually exclusive if break-glass is bounded:

- D3 makes `aegis-emergency-*` the **in-account repair path** for a corrupted/over-tight boundary (the alternative is an org-root SCP detach, the exact lockout D3 exists to avoid). Repair = `iam:CreatePolicyVersion` / `SetDefaultPolicyVersion` on the boundary policy.
- But D1's deny floor denies exactly those actions on the boundary policy for **any bounded identity**. A bounded break-glass could not repair the boundary — it would be as stuck as the CI roles, collapsing the D3 recovery guarantee.
- This is also consistent with SCP S1 (PR-2), which is **deny-scoped-to `gh-tf-*` callers only** — the ADR explicitly places `aegis-emergency-*` "outside S1's scope by construction." Bounding break-glass here would be the *only* thing constraining it, and would do so at the cost of the repair path.

**Result: the boundary is attached to the CI tier (`gh-tf-*`, 15 roles) and break-glass stays unbounded as the repair hatch.** This fully closes #313's stated finding (the CI apply tier). 

**Two ways for you to resolve, @BinHsu:**
1. **Confirm CI-tier-only** (this PR as-is) — simplest, keeps the boundary document exactly as D1 specifies and preserves D3 repair.
2. **Bound break-glass too (literal D1)** — then the boundary's `DenyMutateBoundaryPolicy` clause needs an `aegis-emergency-*` carve-out (an `ArnNotLike aws:PrincipalArn` condition, mirroring S2), which is a small ADR-020 amendment. Say the word and I'll do it in a follow-up.

## 5-step change-review checklist (docs/principles/change-review-discipline.md §2)

1. **Blast radius** — Largest: every CI apply in all 7 accounts (a missing allow-list namespace would fail apply `AccessDenied`). Smallest: one account's boundary policy. **Rollback**: `git revert` + CI apply (single commit, no state surgery — the boundary is additive and nothing depends on it yet; no SCP references it until PR-2).
2. **Dependency assumptions** — (a) The boundary policy must exist before any SCP references it (why PR-2 is separate). (b) `gh-tf-apply-baseline`'s existing `iam:*` on `role/gh-tf-*` + `policy/aegis-*` covers `CreatePolicy` + `PutRolePermissionsBoundary` at apply time (verified against `oidc-github-baseline-role.tf`). (c) The `gh-tf-apply-deployment` import blocks stay intact; `permissions_boundary` becomes a `PutRolePermissionsBoundary` in-place update on the imported role.
3. **Deprecation status** — None. `aws_iam_policy`, `data.aws_iam_policy_document`, `permissions_boundary`, and the `iam:PermissionsBoundary` condition key are all current (AWS provider 6.x).
4. **Rollback plan** — `git revert <sha> && <CI apply>`. No partial-state hazard (additive resources; deny floor becomes self-immutable to CI only *after* apply, but a revert is a `DeletePolicy`/detach which the pre-apply actor can still perform, and post-apply the boundary detach is a normal `PutRolePermissionsBoundary`-to-remove that Terraform handles before deleting the policy).
5. **2 AM readability** — Boundary file header explains ceiling-vs-grant, the byte-identical-across-layers invariant, and the break-glass exclusion. Repo-scoped name `aegis-landing-zone-aws-ci-boundary` per the CLAUDE.md collision carve-out.

## Validation

- `terraform fmt -recursive` — clean.
- `terraform init -backend=false && terraform validate` — green on all 7 bootstrap layers.
- Checkov (repo skip list, `soft_fail: false` parity) — **0 failed**. The 7 boundary data sources carry inline `checkov:skip` for CKV_AWS_107/108/109/110/111/356 + CKV2_AWS_40 with ceiling-not-grant justification (these fire on the `aws_iam_policy_document`, not the resource).
- CI Terraform Plan (all 7 layers) + Checkov run on this PR — see checks below.

## Apply-time note (post-merge, for the ADR-020 D4 gate)

The boundary's `DenyMutateBoundaryPolicy` clause makes the boundary document **self-immutable to CI the moment it is attached** — even before PR-2's SCP S2. So the ADR-020 D4 verification gate (full-matrix green apply + a subsequent all-green plan cycle) must confirm no role lost a used permission, and any future boundary edit already routes through the D3 break-glass ceremony from here on. This is per-design (ADR-020 Consequences → "Boundary evolution is a ceremony"), just flagging that D1's own deny floor already enforces it without S2.

## What PR-2 needs next

- SCP S1 `DenyUnboundedRoleCreateByCi` + S2 `ProtectBoundaryPolicy` in `terraform/environments/management/scps/main.tf`, **only after this PR is applied in all member accounts** (D4 order).
- Runbook 002 gains the "create/verify `aegis-landing-zone-aws-ci-boundary` before seeding `gh-tf-*` roles" cold-start step (D4) — deferred to PR-2 because the seeding-needs-boundary constraint only bites once S1 is attached at the org root.
- `gh-tf-apply-deployment` own-policy tightening (off `AdministratorAccess`) stays a follow-up outside ADR-020 (OQ-2).

Do **not** merge automatically — Bin merges with `gh pr merge --admin` after reviewing the break-glass decision point above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjR9eozKUjq6LL8tgxrEhK
