### PR TITLE
feat(scps): ADR-020 PR-2 — SCP S1/S2 force + protect the CI permissions boundary (#313)

### DIFF
--- a/docs/runbooks/002-cold-account-bootstrap.md
+++ b/docs/runbooks/002-cold-account-bootstrap.md
@@ -75,6 +75,30 @@ This is the same precedent as `prod/bootstrap`'s `iam-survivor-import.tf`
 are simply the first pair of accounts where the seed+adopt ceremony had to run
 against a truly cold account rather than one break-glass-created resource.
 
+### 4. ADR-020: the boundary must exist before the CI roles that carry it
+
+ADR-020 (PR-1) added the `aegis-landing-zone-aws-ci-boundary` permissions
+boundary to every `*/bootstrap` layer and set `permissions_boundary` on all
+three `gh-tf-*`/`gh-tf-apply-*` roles. Two consequences for cold-start:
+
+- **Ordering within the seed apply is automatic.** The seed layer now creates
+  `aws_iam_policy.ci_boundary` too, and each `gh-tf-*` role references
+  `aws_iam_policy.ci_boundary.arn`, so Terraform creates the boundary *before*
+  the roles inside the same apply. No manual pre-create is needed on the normal
+  path. `aegis-emergency-break-glass` is deliberately **not** bounded (it is the
+  boundary's own in-account repair path — ADR-020 D3).
+- **Post-PR-2, the org-root SCP requires the boundary at role-create time.**
+  Once ADR-020 PR-2's SCP S1 is attached at the org root, a `gh-tf-*` caller
+  that runs `iam:CreateRole` without the boundary is denied
+  (`DenyUnboundedRoleCreateByCi`). Cold-start is unaffected **by construction**:
+  the seed runs under `AWSControlTowerExecution`, which is outside S1's
+  `gh-tf-*` scope, and the boundary is created first in the same apply — so CI
+  (`gh-tf-*`) only ever runs against an account that already has the boundary.
+  If the boundary is somehow absent or corrupt on a fresh account, break-glass
+  (`aegis-emergency-*`, exempt from S1 and from S2's `ProtectBoundaryPolicy`)
+  can create or repair it with `iam:CreatePolicy` — that action is in no deny
+  list.
+
 ## Prerequisites
 
 - `aws sso login --sso-session aegis` already run.
@@ -91,6 +115,34 @@ against a truly cold account rather than one break-glass-created resource.
   `--account-id` explicitly.
 
 ## Procedure
+
+### Phase 0 — Boundary preflight (ADR-020)
+
+Before seeding `gh-tf-*` roles on any cold account, create or verify the
+`aegis-landing-zone-aws-ci-boundary` permissions boundary exists in the target
+account. On the normal path this is automatic — the seed apply in Phase 1
+creates the boundary before the roles that reference it (see "The problem" §4) —
+so this step is a **verify**, not a manual create:
+
+```
+aws iam get-policy \
+  --policy-arn "arn:aws:iam::<target-account-id>:policy/aegis-landing-zone-aws-ci-boundary" \
+  --query 'Policy.PolicyName' --output text 2>/dev/null || echo "ABSENT — expected during Phase 1"
+```
+
+- **Absent before Phase 1**: expected on a truly cold account — Phase 1 creates
+  it. Proceed.
+- **Absent after Phase 1 completed**: a bug — the seed apply should have created
+  it. Do not let CI (`gh-tf-*`) run against this account until it exists (post-
+  PR-2, CI's first `CreateRole` would be denied `AccessDenied` by SCP S1). Repair
+  via break-glass `iam:CreatePolicy` (the only identity SCP S2 exempts), then
+  re-run Phase 1's converge.
+
+Attaching the boundary to the seeded roles at seed time is hygiene, not a hard
+requirement: the roles carry `permissions_boundary` in code, so Phase 1's apply
+attaches it, and any later CI apply converges a boundary-less seeded role via
+`iam:PutRolePermissionsBoundary` to the correct ARN — which SCP S1 allows
+(ADR-020 D2).
 
 ### Phase 1 — Seed
 
@@ -184,6 +236,17 @@ its `terraform-plan.yml` run should also show no diff once merged and
   trap can catch) blocks the next run. The script's own EXIT/INT/TERM trap
   cleans these up on every normal exit and on `Ctrl-C`; if one is still
   present, delete it manually before re-running.
+- **The ADR-020 boundary is not yet in the `iam-survivor-import.tf` gate.** The
+  import blocks adopt the eight original bootstrap resources; PR-1 added
+  `aws_iam_policy.ci_boundary` on top of them but did not extend the import
+  gate. On the normal seed then adopt path this is harmless — seed discards its
+  local state and adopt re-imports only the gated eight, then apply *creates*
+  the boundary fresh in S3 state. It only bites the manual hand-seed escape
+  hatch (`var.adopt_seeded_iam_roles=true` after pre-creating resources by
+  hand): adopt would then `EntityAlreadyExists` on the boundary. If you hit
+  that, add a gated `import` block for `aws_iam_policy.ci_boundary` (mirror the
+  role blocks), or delete the hand-created boundary before adopt. Tracked as an
+  ADR-020 PR-1 follow-up.
 
 ## Cross-references
 
@@ -204,6 +267,10 @@ its `terraform-plan.yml` run should also show no diff once merged and
   scripts seed and adopt.
 - [ADR-015](../decisions/015-permission-boundary-hardening.md) — the
   `aegis-emergency-break-glass` role.
+- [ADR-020](../decisions/020-scp-enforced-ci-permissions-boundary.md) — the
+  `aegis-landing-zone-aws-ci-boundary` permissions boundary (PR-1) and the
+  SCP S1/S2 that force and protect it (PR-2); the source of the Phase 0
+  boundary preflight above.
 - [Runbook 001](001-bootstrap-aws-account.md) — the from-zero project
   bootstrap this runbook assumes is already complete (management account,
   Control Tower, state bucket, SSO).

--- a/terraform/environments/management/scps/main.tf
+++ b/terraform/environments/management/scps/main.tf
@@ -18,6 +18,16 @@ data "aws_organizations_organization" "current" {}
 
 locals {
   root_id = data.aws_organizations_organization.current.roots[0].id
+
+  # ADR-020 boundary identity. The SCP is one document attached at the org root
+  # and evaluated in every member account, so the boundary ARN it references is
+  # account-wildcarded (`::*:`) — each account holds its own copy of the
+  # byte-identical `aegis-landing-zone-aws-ci-boundary` policy (ADR-020 OQ-1). A
+  # permissions boundary must live in the same account as the role it caps, so
+  # the wildcard cannot match a cross-account attacker-controlled policy; it
+  # only ever resolves to the in-account Aegis boundary.
+  ci_boundary_name        = "aegis-landing-zone-aws-ci-boundary"
+  ci_boundary_arn_pattern = "arn:aws:iam::*:policy/${local.ci_boundary_name}"
 }
 
 # -----------------------------------------------------------------------------
@@ -192,11 +202,47 @@ resource "aws_organizations_policy_attachment" "deny_leave_org" {
 # principals (users + roles) only. This is documented AWS behavior; see
 # https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html
 # under "What SCPs don't affect."
+#
+# ADR-020 extension (S1 + S2) — closes the residual the name exemption above
+# leaves open. The base statement watches the CALLER'S name; it exempts
+# `gh-tf-*` because the apply tier legitimately runs `iam:CreateRole`. But a
+# name exemption cannot constrain what the exempted identity CREATES, so a
+# hijacked `gh-tf-*` role could still mint `aegis-evil`, attach
+# `AdministratorAccess`, and assume it (#313). ADR-020 caps that by forcing the
+# `aegis-landing-zone-aws-ci-boundary` permissions boundary onto everything the
+# CI tier creates, and protecting the boundary document from the CI tier:
+#
+#   S1 (DenyUnboundedRoleCreateByCi + DenyBoundaryStripByCi) — deny-SCOPED-TO
+#      `gh-tf-*` (ArnLike, not the base statement's ArnNotLike allow-list).
+#      Every OTHER identity is out of S1's scope BY CONSTRUCTION, not by
+#      exemption — so break-glass seeding of `gh-tf-*` roles (Runbook 002) and
+#      any future IAM-mutating identity never trip S1. This is the shape #319
+#      wants for the base statement; S1 does not add to the name-exemption debt
+#      #319 tracks, and deliberately does not "fix" #319 here.
+#   S2 (ProtectBoundaryPolicy) — deny mutation of the boundary DOCUMENT by all
+#      member principals except `aegis-emergency-*`. The single break-glass
+#      carve-out is the in-account repair path (ADR-020 D3): IAM policies are
+#      account-local, so without it a corrupted boundary would be unrepairable
+#      short of detaching this whole SCP at the org root. It is one narrowly
+#      scoped exemption (one resource, one principal family already trusted as
+#      break-glass), not a widening of the base allow-list.
+#
+# Boundary-ARN matching uses ArnLike/ArnNotLike with an account-wildcarded ARN
+# (`local.ci_boundary_arn_pattern`) because this one SCP document is evaluated
+# in every account and each holds its own copy of the boundary. ADR-020 D2
+# phrases this as `StringNotEquals the boundary ARN`; StringNotEquals cannot
+# wildcard the account segment, so ArnNotLike is the faithful cross-account
+# implementation of the same intent (see PR body).
+#
+# Rollout ordering (ADR-020 D4): S1/S2 land ONLY after PR-1's boundary policy is
+# applied in every member account. Otherwise CI's first `CreateRole` here would
+# reference a nonexistent boundary ARN and fail. PR-1 (#325) is merged and
+# applied in all accounts before this statement lands.
 # -----------------------------------------------------------------------------
 
 resource "aws_organizations_policy" "deny_iam_privilege_escalation" {
   name        = "deny-iam-privilege-escalation"
-  description = "Deny IAM principal/policy mutation by anything other than AWS-managed and break-glass identities. ISO 27001 A.8.2."
+  description = "Deny IAM principal/policy mutation by non-AWS-managed/break-glass identities; force+protect the CI permissions boundary (ADR-015 Item A + ADR-020 S1/S2). ISO 27001 A.8.2."
   type        = "SERVICE_CONTROL_POLICY"
 
   content = jsonencode({
@@ -234,7 +280,78 @@ resource "aws_organizations_policy" "deny_iam_privilege_escalation" {
             ]
           }
         }
-      }
+      },
+      # --- ADR-020 S1 -------------------------------------------------------
+      # Force the boundary onto everything the CI tier creates. Deny-scoped-TO
+      # `gh-tf-*` (ArnLike). `iam:CreateRole` / `iam:PutRolePermissionsBoundary`
+      # are denied unless `iam:PermissionsBoundary` is the Aegis boundary. When
+      # a `gh-tf-*` caller creates a role WITHOUT any boundary, the
+      # `iam:PermissionsBoundary` key is absent and the negated ArnNotLike
+      # matches → the create is denied. Converging a boundary-less break-glass-
+      # seeded role IS `PutRolePermissionsBoundary` to the correct ARN, which
+      # this statement allows (ArnNotLike false) — so cold-start seeding
+      # (Runbook 002) is untouched. `iam:PermissionsBoundary` exists only on
+      # Create*/Put*PermissionsBoundary, so those are the only actions this
+      # statement can and needs to condition (ADR-020 D2 technical note).
+      {
+        Sid    = "DenyUnboundedRoleCreateByCi"
+        Effect = "Deny"
+        Action = [
+          "iam:CreateRole",
+          "iam:PutRolePermissionsBoundary",
+        ]
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::*:role/gh-tf-*"
+          }
+          ArnNotLike = {
+            "iam:PermissionsBoundary" = local.ci_boundary_arn_pattern
+          }
+        }
+      },
+      # A bounded CI identity can never strip a boundary (its own or another's).
+      # Unconditional for `gh-tf-*` callers — `iam:DeleteRolePermissionsBoundary`
+      # carries no `iam:PermissionsBoundary` key to condition on. Split from the
+      # statement above so the "unconditional" intent (ADR-020 D2) is explicit
+      # rather than resting on absent-key semantics.
+      {
+        Sid    = "DenyBoundaryStripByCi"
+        Effect = "Deny"
+        Action = [
+          "iam:DeleteRolePermissionsBoundary",
+        ]
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::*:role/gh-tf-*"
+          }
+        }
+      },
+      # --- ADR-020 S2 -------------------------------------------------------
+      # Protect the boundary DOCUMENT from rewrite/removal. Denied for every
+      # member principal EXCEPT `aegis-emergency-*` (ArnNotLike) — the break-
+      # glass in-account repair path (ADR-020 D3). No `gh-tf-*` exemption by
+      # design: a CI role that can rewrite its own boundary defeats the whole
+      # control, so post-PR-2 boundary evolution is a break-glass ceremony
+      # (ADR-020 Consequences → Makes harder). `iam:CreatePolicy` is NOT denied,
+      # so break-glass cold-start creation of the boundary still works.
+      {
+        Sid    = "ProtectBoundaryPolicy"
+        Effect = "Deny"
+        Action = [
+          "iam:CreatePolicyVersion",
+          "iam:SetDefaultPolicyVersion",
+          "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
+        ]
+        Resource = local.ci_boundary_arn_pattern
+        Condition = {
+          ArnNotLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::*:role/aegis-emergency-*"
+          }
+        }
+      },
     ]
   })
 }


### PR DESCRIPTION
## What & why

PR-2 of the ADR-020 rollout. PR-1 (#325, merged, applied green in all 7
accounts) created the `aegis-landing-zone-aws-ci-boundary` permissions boundary
and attached it to every `gh-tf-*` CI role. This PR adds the two SCP statements
(ADR-020 D2/D3) that make the boundary **mandatory** and **tamper-proof** for
the CI tier, closing the residual escalation path in finding #313.

The base `deny-iam-privilege-escalation` SCP (ADR-015 Item A) watches the
*caller's name* and exempts `gh-tf-*` because the apply tier legitimately runs
`iam:CreateRole`. A name exemption cannot constrain what the exempted identity
*creates*, so a hijacked `gh-tf-*` role could still
`CreateRole → AttachRolePolicy(AdministratorAccess) → AssumeRole`. S1/S2 cap
that by forcing the boundary onto everything the CI tier mints and protecting
the boundary document from the CI tier.

Both statements are added **into the existing `deny-iam-privilege-escalation`
policy** (not a new SCP) — extends ADR-015 Item A as the ADR states, and adds
zero new root SCP attachments (avoids the 5-SCP-per-root ceiling).

## Exact statements added

**S1a — `DenyUnboundedRoleCreateByCi`** (deny-scoped-TO `gh-tf-*`, `ArnLike`):
```
Deny iam:CreateRole, iam:PutRolePermissionsBoundary
  where PrincipalArn ArnLike        arn:aws:iam::*:role/gh-tf-*
    AND iam:PermissionsBoundary ArnNotLike arn:aws:iam::*:policy/aegis-landing-zone-aws-ci-boundary
```
A create with no boundary → `iam:PermissionsBoundary` key absent → the negated
`ArnNotLike` matches → denied. A create/put with the correct boundary → allowed.
`iam:PermissionsBoundary` exists only on `Create*`/`Put*PermissionsBoundary`, so
those are the only actions this can (and needs to) condition — attaching
`AdministratorAccess` to an already-bounded role is harmless (effective perms =
attached ∩ boundary).

**S1b — `DenyBoundaryStripByCi`** (deny-scoped-TO `gh-tf-*`):
```
Deny iam:DeleteRolePermissionsBoundary
  where PrincipalArn ArnLike arn:aws:iam::*:role/gh-tf-*
```
Split from S1a so the "unconditional" intent (ADR-020 D2) is explicit, not
resting on absent-key semantics.

**S2 — `ProtectBoundaryPolicy`** (deny-all-member-EXCEPT `aegis-emergency-*`):
```
Deny iam:CreatePolicyVersion, iam:SetDefaultPolicyVersion,
     iam:DeletePolicy, iam:DeletePolicyVersion
  on  arn:aws:iam::*:policy/aegis-landing-zone-aws-ci-boundary
  where PrincipalArn ArnNotLike arn:aws:iam::*:role/aegis-emergency-*
```

### How S2 preserves the break-glass repair path
IAM policies are account-local — management principals cannot reach into a
member account to repair a corrupted boundary. S2 therefore exempts
`aegis-emergency-*` (`ArnNotLike`): when the caller **is** break-glass, the
condition is false, the Deny does not apply, and break-glass can rewrite/repair
the boundary document in-account (ADR-020 D3). `iam:CreatePolicy` is in no deny
list, so break-glass can also *create* the boundary cold (Runbook 002 Phase 0).
Without this exemption an over-tight boundary would be unrepairable short of
detaching the whole SCP at the org root — a policy bug converted into a
mandatory org-root ceremony that also drops the base escalation wall while
detached. The ultimate backstop remains org-admin SCP detach from management,
which no member-account compromise can reach.

## As-built divergences from ADR text (as-built wins, flagged)
- **Break-glass is unbounded.** ADR-020 D1 literal wording says "every managed
  role"; PR-1 (Bin-ratified by merge) left `aegis-emergency-break-glass`
  unbounded so it can serve as the boundary's in-account repair path. S1
  (scoped to `gh-tf-*`) and S2 (exempts `aegis-emergency-*`) are consistent with
  the as-built state — break-glass is out of S1 by construction and exempt from
  S2. No SCP carve-out for break-glass is needed or added.
- **`ArnNotLike` vs `StringNotEquals`.** ADR-020 D2/D3 phrase the boundary match
  as `StringNotEquals the boundary ARN`. One SCP document is evaluated in all 7
  accounts and each holds its own copy of the boundary (its own account ID in
  the ARN). `StringNotEquals` cannot wildcard the account segment;
  `ArnNotLike arn:aws:iam::*:policy/...` is the faithful cross-account
  implementation of the same intent. A permissions boundary must live in the
  same account as the role it caps, so the `::*:` wildcard cannot match a
  cross-account attacker-controlled policy of the same name.

## Interaction with #319 (name-based SCP exemptions) — not fixed here, not worsened
- **S1 uses the preferred shape.** Deny-scoped-TO `gh-tf-*` (`ArnLike`) is
  exactly the pattern #319 wants for the base statement — it adds **zero**
  entries to the name-based allow-list; every non-CI identity is out of scope by
  construction, not by exemption.
- **S2 adds one narrowly-scoped name exemption** (`aegis-emergency-*`), but only
  for one resource (the boundary policy) and only for a principal family already
  trusted as break-glass. It does not touch or widen the base statement's
  6-entry allow-list that #319 targets. #319's fix (tightening that base
  allow-list) stays orthogonal and is deliberately **not** attempted in this PR.

## Runbook 002 change
- New **Phase 0 — Boundary preflight**: verify (not manually create) the
  boundary exists before seeding `gh-tf-*` roles; repair via break-glass
  `iam:CreatePolicy` if absent post-seed.
- New problem subsection §4 explaining the seed-apply ordering and why cold-start
  is unaffected by S1 (seed runs under `AWSControlTowerExecution`, outside S1).
- New gotcha: PR-1's boundary is **not yet in `iam-survivor-import.tf`** — only
  bites the manual hand-seed escape hatch; flagged as an ADR-020 PR-1 follow-up
  (see Open questions).

## 5-step change-review checklist (per `docs/principles/change-review-discipline.md`)
1. **Blast radius**: Highest — a new statement on a root-attached SCP, effective
   in all 7 member accounts. Management account is outside SCP reach (unchanged,
   ADR-020 residual). **Merging this PR auto-applies it at the org root** — see
   the merge-gate section below.
2. **Dependency assumptions**: The boundary policy must already exist in every
   account (SCPs apply last — the classic self-lockout, doc §2.2). Satisfied:
   PR-1 #325 is applied green in all 7 accounts. If S1 landed before the
   boundary, CI's next `CreateRole` would reference a nonexistent ARN and fail.
3. **Deprecation status**: none — `iam:PermissionsBoundary`, `ArnLike`/
   `ArnNotLike`, and the IAM actions used are all current SCP condition keys /
   AWS IAM actions.
4. **Rollback plan**: `git revert <this-merge>` + baseline apply removes S1/S2
   from the SCP document (the boundary itself stays; it is self-defending via
   PR-1's Deny floor). If S1/S2 somehow self-lock CI: root-credential escape via
   the management account (root is SCP-immune) per `break-glass-apply.md`, detach
   `deny-iam-privilege-escalation` at the root, fix, re-attach.
5. **2 AM readability**: statements carry inline `why` comments; Sids are
   self-describing; boundary ARN is a named local with a rationale comment.

## ⚠️ Merge-gate: what the org-root auto-apply will do
Merging this PR triggers `terraform-apply-baseline.yml`, which **auto-applies
the SCP at the organization root (highest blast radius)**. The apply will:
- Update the content of the existing `aws_organizations_policy.deny-iam-privilege-escalation` (in-place, no new attachment) to add the 3 statements above.
- After apply, in **all 7 member accounts**: any `gh-tf-*` caller that runs
  `iam:CreateRole` / `iam:PutRolePermissionsBoundary` **without** the Aegis
  boundary is denied; `gh-tf-*` cannot `DeleteRolePermissionsBoundary`; **no**
  member principal except `aegis-emergency-*` can mutate the boundary document.
- **Side effect to expect (by design):** future changes to the boundary
  *document itself* via the normal CI apply will now be denied (S2) — boundary
  evolution becomes a break-glass ceremony (ADR-020 D3/Consequences). This is
  intended, not a regression.
- No resource is destroyed or created; management account is unaffected (SCPs do
  not bind it).

Gate the merge deliberately: confirm PR-1 is applied everywhere (it is) and that
you accept the boundary-evolution-is-now-a-ceremony consequence.

## Validation
- `terraform fmt` clean, `terraform validate` Success.
- Checkov: exit 0, no findings (SCP `aws_organizations_policy` content is not in
  scope of Checkov's IAM-policy-document checks).
- CI plan on this PR — see checks. **No apply in this PR.**

Refs ADR-020, #313. Sibling: #319 (not fixed here, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjR9eozKUjq6LL8tgxrEhK
