### PR TITLE
fix(iam): gate the CI boundary policy into iam-survivor-import.tf

### DIFF
--- a/docs/decisions/021-ci-native-cold-account-bootstrap.md
+++ b/docs/decisions/021-ci-native-cold-account-bootstrap.md
@@ -52,7 +52,7 @@ Runbook 002 resolves both with a two-phase, operator-laptop ceremony run by
   operator's ambient `PlatformAdmin` SSO identity (which *can* write state),
   while the **provider** temporarily assumes CT-exec via a generated
   `*_override.tf`. Run with `-var=adopt_seeded_iam_roles=true`, which flips
-  `iam-survivor-import.tf` from *create* to *import* so the eight
+  `iam-survivor-import.tf` from *create* to *import* so the nine
   already-existing resources are imported into S3 state rather than
   re-created.
 

--- a/docs/runbooks/002-cold-account-bootstrap.md
+++ b/docs/runbooks/002-cold-account-bootstrap.md
@@ -26,8 +26,9 @@ scaffold the environment first (mirror an existing `bootstrap/` layer, see #303)
 Every environment's `bootstrap/` layer creates three roles GitHub Actions
 assumes via OIDC — `gh-tf-plan` (read-only, on pull requests),
 `gh-tf-apply-baseline` (on merge to `main`, per ADR-014) — plus
-`aegis-emergency-break-glass` (ADR-015), the GitHub OIDC provider, and the
-account alias. Eight resources in total.
+`aegis-emergency-break-glass` (ADR-015), the GitHub OIDC provider, the
+account alias, and the ADR-020 `aegis-landing-zone-aws-ci-boundary`
+permissions boundary policy. Nine resources in total.
 
 CI's `terraform-plan.yml` / `terraform-apply-baseline.yml` workflows assume one
 of those roles to run. On a cold account, none of them exist — CI has nothing
@@ -50,7 +51,7 @@ The procedure is two phases against the same account:
 
 - **SEED** — `terraform apply` under `AWSControlTowerExecution`, with
   `backend.tf` moved aside so state is local and throwaway. This actually
-  creates the eight resources in the account. Local state is fine here
+  creates the nine resources in the account. Local state is fine here
   because nothing durable needs to survive this phase — the resources
   themselves are the durable output, not the state file.
 - **ADOPT** — a **split-credential** apply: the Terraform **backend**
@@ -59,8 +60,8 @@ The procedure is two phases against the same account:
   actually talks to the target account's resources) temporarily assumes
   `AWSControlTowerExecution` via a generated override file. Run with
   `-var=adopt_seeded_iam_roles=true`, which flips the environment's
-  `iam-survivor-import.tf` from *create* to *import* for the eight resources
-  SEED just created — so ADOPT's plan is exactly eight imports and (ideally)
+  `iam-survivor-import.tf` from *create* to *import* for the nine resources
+  SEED just created — so ADOPT's plan is exactly nine imports and (ideally)
   no other changes.
 
 After ADOPT, the S3 state matches reality. The committed default of
@@ -193,10 +194,10 @@ The script:
    on any exit — it is never committed.
 4. Runs `terraform init` against the real S3 backend under the ambient
    profile, then `terraform plan -var=adopt_seeded_iam_roles=true` — expect
-   exactly eight imports and no other changes.
+   exactly nine imports and no other changes.
 5. Prompts interactively for confirmation, same pattern as Seed.
 6. On confirmation, applies (imports land in S3 state) and prints
-   `terraform state list` to confirm all eight resources are now tracked.
+   `terraform state list` to confirm all nine resources are now tracked.
 
 ### Both in one run
 
@@ -223,7 +224,7 @@ its `terraform-plan.yml` run should also show no diff once merged and
 
 ## Gotchas
 
-- **Do not run Adopt before Seed.** Adopt's plan expects the eight resources
+- **Do not run Adopt before Seed.** Adopt's plan expects the nine resources
   to already exist in the account; running it first produces an empty import
   set and then a normal (failing) create attempt under the wrong credentials.
 - **`--profile` must be able to do both things Adopt needs**: assume
@@ -236,17 +237,15 @@ its `terraform-plan.yml` run should also show no diff once merged and
   trap can catch) blocks the next run. The script's own EXIT/INT/TERM trap
   cleans these up on every normal exit and on `Ctrl-C`; if one is still
   present, delete it manually before re-running.
-- **The ADR-020 boundary is not yet in the `iam-survivor-import.tf` gate.** The
-  import blocks adopt the eight original bootstrap resources; PR-1 added
-  `aws_iam_policy.ci_boundary` on top of them but did not extend the import
-  gate. On the normal seed then adopt path this is harmless — seed discards its
-  local state and adopt re-imports only the gated eight, then apply *creates*
-  the boundary fresh in S3 state. It only bites the manual hand-seed escape
-  hatch (`var.adopt_seeded_iam_roles=true` after pre-creating resources by
-  hand): adopt would then `EntityAlreadyExists` on the boundary. If you hit
-  that, add a gated `import` block for `aws_iam_policy.ci_boundary` (mirror the
-  role blocks), or delete the hand-created boundary before adopt. Tracked as an
-  ADR-020 PR-1 follow-up.
+- **Fixed: the ADR-020 boundary is now in the `iam-survivor-import.tf` gate.**
+  PR-1 added `aws_iam_policy.ci_boundary` alongside the original eight
+  bootstrap resources but did not extend the import gate to cover it, so the
+  manual hand-seed escape hatch (`var.adopt_seeded_iam_roles=true` after
+  pre-creating resources by hand) hit `EntityAlreadyExists` on the boundary.
+  All three `iam-survivor-import.tf` files (`prod`, `security`, `logarchive`
+  bootstrap) now carry a gated `import` block for `aws_iam_policy.ci_boundary`
+  mirroring the role blocks, so Adopt's plan is exactly nine imports on every
+  path, including hand-seed. Tracked as an ADR-020 PR-1 follow-up.
 
 ## Cross-references
 

--- a/terraform/environments/logarchive/bootstrap/iam-survivor-import.tf
+++ b/terraform/environments/logarchive/bootstrap/iam-survivor-import.tf
@@ -6,7 +6,7 @@
 # the account has never had Terraform managing it. The normal cold-start
 # path is a first LOCAL `terraform apply` under break-glass credentials (see
 # the PR body for #303 / issue #303's manual-seed runbook), which CREATEs
-# all eight resources below fresh — no import needed.
+# all nine resources below fresh — no import needed.
 #
 # This file exists as the ESCAPE HATCH for the other case: an operator who
 # manually pre-created the resources (console/CLI, or a local `terraform
@@ -21,9 +21,10 @@
 # as prod/bootstrap's iam-survivor-import.tf (#278) and #15
 # (oidc-github-apply-deployment-role.tf in the deployment account).
 #
-# SCOPE: covers all eight resources this layer creates in a member account —
-# the account alias, the GitHub OIDC provider, the three gh-tf-*/aegis-
-# emergency-* roles, and their three inline role policies. The role policies
+# SCOPE: covers all nine resources this layer creates in a member account —
+# the account alias, the GitHub OIDC provider, the ADR-020 CI permissions
+# boundary policy, the three gh-tf-*/aegis-emergency-* roles, and their three
+# inline role policies. The role policies
 # are Put*-idempotent (PutRolePolicy upserts, no EntityAlreadyExists) so they
 # are technically safe to leave un-imported, but importing them too avoids a
 # spurious "will be created" noise in the first plan/apply against adopted
@@ -94,8 +95,8 @@ import {
 }
 
 # ---- Account-global singletons ----------------------------------------------
-# Unlike the roles above, these two import ids are NOT stable literals across
-# accounts — they must resolve per-account, so each uses a dynamic or
+# Unlike the roles above, these three import ids are NOT stable literals
+# across accounts — they must resolve per-account, so each uses a dynamic or
 # per-account-config expression rather than a hardcoded string shared with
 # another environment's copy of this file.
 
@@ -110,6 +111,19 @@ import {
   for_each = var.adopt_seeded_iam_roles ? toset(["oidc_provider"]) : toset([])
   to       = aws_iam_openid_connect_provider.github
   id       = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(local.github_oidc_url, "https://", "")}"
+}
+
+# ADR-020 CI permissions boundary policy (ci-permissions-boundary.tf), attached
+# as permissions_boundary on the gh-tf-* roles above. Import id is the policy
+# ARN, which embeds this account's id — reuses `local.ci_boundary_arn` already
+# declared in that file so it can never drift from the resource's own `name`
+# argument. Must exist before the roles that carry it (runbook 002 §4);
+# closes the gap where the hand-seed escape hatch would otherwise hit
+# EntityAlreadyExists on this policy (runbook 002 Gotchas).
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["ci_boundary"]) : toset([])
+  to       = aws_iam_policy.ci_boundary
+  id       = local.ci_boundary_arn
 }
 
 # IAM account alias (main.tf). Import id is the alias string itself; this

--- a/terraform/environments/prod/bootstrap/iam-survivor-import.tf
+++ b/terraform/environments/prod/bootstrap/iam-survivor-import.tf
@@ -1,10 +1,11 @@
 # ============================================================================
-# One-time adoption (prod cold-start) of the IAM roles this bootstrap layer
-# manages but that survived a state clear.
+# One-time adoption (prod cold-start) of the IAM roles and the CI permissions
+# boundary policy this bootstrap layer manages but that survived a state clear.
 #
 # WHY: the prod account had its prod/bootstrap Terraform STATE cleared, but the
-# three roles below still EXIST as live AWS resources (survivors — IAM roles are
-# account-global and outlive the state). A prod cold-start `terraform apply`
+# three roles and the CI boundary policy below still EXIST as live AWS
+# resources (survivors — IAM roles and policies are account-global and outlive
+# the state). A prod cold-start `terraform apply`
 # would otherwise fail EntityAlreadyExists when it tries to CREATE each role that
 # already exists. These config-driven import blocks ADOPT the existing roles into
 # state instead. After import, apply UPDATEs each role in place to match the
@@ -52,4 +53,16 @@ import {
   for_each = var.adopt_seeded_iam_roles ? toset(["plan"]) : toset([])
   to       = aws_iam_role.gh_tf_plan
   id       = "gh-tf-plan"
+}
+
+# ADR-020 CI permissions boundary policy (ci-permissions-boundary.tf), attached
+# as permissions_boundary on all three roles above. Import id is the policy
+# ARN; reuses `local.ci_boundary_arn` already declared in that file so it can
+# never drift from the resource's own `name` argument. Closes the gap where
+# the hand-seed escape hatch would otherwise hit EntityAlreadyExists on this
+# policy (runbook 002 §4 / Gotchas).
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["ci_boundary"]) : toset([])
+  to       = aws_iam_policy.ci_boundary
+  id       = local.ci_boundary_arn
 }

--- a/terraform/environments/security/bootstrap/iam-survivor-import.tf
+++ b/terraform/environments/security/bootstrap/iam-survivor-import.tf
@@ -5,7 +5,7 @@
 # WHY: `security/bootstrap` is a BRAND NEW Terraform environment (#303) — the
 # account has never had Terraform managing it. The normal cold-start path is
 # a first LOCAL `terraform apply` under break-glass credentials (see the PR
-# body for #303 / issue #303's manual-seed runbook), which CREATEs all eight
+# body for #303 / issue #303's manual-seed runbook), which CREATEs all nine
 # resources below fresh — no import needed.
 #
 # This file exists as the ESCAPE HATCH for the other case: an operator who
@@ -21,9 +21,10 @@
 # as prod/bootstrap's iam-survivor-import.tf (#278) and #15
 # (oidc-github-apply-deployment-role.tf in the deployment account).
 #
-# SCOPE: covers all eight resources this layer creates in a member account —
-# the account alias, the GitHub OIDC provider, the three gh-tf-*/aegis-
-# emergency-* roles, and their three inline role policies. The role policies
+# SCOPE: covers all nine resources this layer creates in a member account —
+# the account alias, the GitHub OIDC provider, the ADR-020 CI permissions
+# boundary policy, the three gh-tf-*/aegis-emergency-* roles, and their three
+# inline role policies. The role policies
 # are Put*-idempotent (PutRolePolicy upserts, no EntityAlreadyExists) so they
 # are technically safe to leave un-imported, but importing them too avoids a
 # spurious "will be created" noise in the first plan/apply against adopted
@@ -94,8 +95,8 @@ import {
 }
 
 # ---- Account-global singletons ----------------------------------------------
-# Unlike the roles above, these two import ids are NOT stable literals across
-# accounts — they must resolve per-account, so each uses a dynamic or
+# Unlike the roles above, these three import ids are NOT stable literals
+# across accounts — they must resolve per-account, so each uses a dynamic or
 # per-account-config expression rather than a hardcoded string shared with
 # another environment's copy of this file.
 
@@ -110,6 +111,19 @@ import {
   for_each = var.adopt_seeded_iam_roles ? toset(["oidc_provider"]) : toset([])
   to       = aws_iam_openid_connect_provider.github
   id       = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${replace(local.github_oidc_url, "https://", "")}"
+}
+
+# ADR-020 CI permissions boundary policy (ci-permissions-boundary.tf), attached
+# as permissions_boundary on the gh-tf-* roles above. Import id is the policy
+# ARN, which embeds this account's id — reuses `local.ci_boundary_arn` already
+# declared in that file so it can never drift from the resource's own `name`
+# argument. Must exist before the roles that carry it (runbook 002 §4);
+# closes the gap where the hand-seed escape hatch would otherwise hit
+# EntityAlreadyExists on this policy (runbook 002 Gotchas).
+import {
+  for_each = var.adopt_seeded_iam_roles ? toset(["ci_boundary"]) : toset([])
+  to       = aws_iam_policy.ci_boundary
+  id       = local.ci_boundary_arn
 }
 
 # IAM account alias (main.tf). Import id is the alias string itself; this


### PR DESCRIPTION
## Summary

PR #325 added `aws_iam_policy.ci_boundary` (`aegis-landing-zone-aws-ci-boundary`) to every bootstrap layer and attached it as `permissions_boundary` on all `gh-tf-*` roles. #327 (ADR-020 PR-2) found and documented the gap in runbook 002's Gotchas section: the three `iam-survivor-import.tf` files (`prod`, `security`, `logarchive` bootstrap) were never extended to cover the boundary policy. On the manual hand-seed escape-hatch path (`var.adopt_seeded_iam_roles=true` after pre-creating resources by hand), Adopt hits `EntityAlreadyExists` on the boundary policy because there is no gated import block for it.

- Add a `var.adopt_seeded_iam_roles`-gated `import` block for `aws_iam_policy.ci_boundary` to each of the three files, mirroring the existing role import pattern (`id = local.ci_boundary_arn`, already declared in each layer's `ci-permissions-boundary.tf`).
- Update the stale "eight resources / eight imports" counts to nine across the three tf files, runbook 002 (problem statement, Phase 2 steps), and ADR-021's recap.
- Mark runbook 002's Gotchas entry for this gap as fixed instead of open.

## Test plan

- [x] `terraform fmt -check -diff` on the three affected layers — clean
- [x] `terraform validate` on the three affected layers (against `config/landing-zone.example.yaml` copied to the gitignored `config/landing-zone.yaml` for local validation only, then removed) — all three `Success!`
- [ ] CI plan matrix green on this PR (all `terraform-plan.yml` jobs, not just Checkov, per repo policy)
- [ ] Checkov green (runs in CI; not installed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjR9eozKUjq6LL8tgxrEhK