### PR TITLE
fix: add OIDC environment-sub trust for gated apply-scps job (#330)

### DIFF
--- a/docs/incidents.md
+++ b/docs/incidents.md
@@ -946,6 +946,94 @@ After the SLR was destroyed the `IamServiceLinkedRoleLifecycle` Sid was removed 
 
 ---
 
+## Incident 16 — `apply-scps` OIDC assumption fails closed after Environment binding (PR #330)
+
+**Date**: 2026-07-08 (post-ADR-022 gated SCP apply)
+**Severity**: S3
+**Duration**: detected immediately (first run after merge); no partial apply, ~1 day to land the fix PR
+
+### Symptom
+
+The first baseline apply run after PR #330 merged (run 29015217599) failed in job
+"Apply management/scps (gated)" with:
+
+```
+Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
+```
+
+The job failed at the `aws-actions/configure-aws-credentials` step, before any
+`terraform plan` or `apply` ran — nothing was applied, no state drift.
+
+### Root cause
+
+PR #330 (ADR-022) bound the `apply-scps` job in
+`.github/workflows/terraform-apply-baseline.yml` to the GitHub Environment
+`landing-zone-apply-scps` (`environment: landing-zone-apply-scps`) so a required
+reviewer can gate the org-root SCP apply. A job running under a GitHub
+Environment presents a different OIDC `sub` claim shape than a plain branch
+push: `repo:<org>/<repo>:environment:<name>` instead of
+`repo:<org>/<repo>:ref:refs/heads/main`. The `gh-tf-apply-baseline` role's trust
+policy in `terraform/environments/management/bootstrap/oidc-github-baseline-role.tf`
+only allowed the `ref:refs/heads/main` sub shape — PR #330 changed the
+workflow's job-to-environment binding without updating the IAM trust policy
+that job depends on, so the two drifted out of sync in the same merge.
+
+### Detection
+
+The scheduled/push-triggered `terraform-apply-baseline.yml` run failed in CI;
+the job log showed the `configure-aws-credentials` STS error directly — no
+digging required beyond reading the failed step's log.
+
+### Resolution
+
+Added the environment sub shape as a second, additive `StringLike` value on
+the existing `gh-tf-apply-baseline` trust policy (list form, same condition
+key), keeping the pre-existing `ref:refs/heads/main` value untouched:
+
+```hcl
+StringLike = {
+  "${replace(local.github_oidc_url, "https://", "")}:sub" = [
+    "repo:${local.github_org}/*:ref:refs/heads/main",
+    "repo:${local.github_org}/*:environment:landing-zone-apply-scps",
+  ]
+}
+```
+
+Verified no other job in the workflow gained an environment binding in #330
+(`gh pr diff 330 | grep -n environment` — only `apply-scps`). The fix
+self-heals on merge: the `management/bootstrap` layer (which owns this trust
+policy) applies through the still-working, non-gated `apply-baseline` job, so
+merging the trust-policy PR re-applies it and the next `apply-scps` run
+authenticates.
+
+### Prevention
+
+- **Rule for future Environment bindings**: whenever a workflow job's
+  `environment:` key is added or changed, grep every IAM trust policy the
+  job's role appears in for `StringLike`/`sub` conditions and add the matching
+  `repo:<org>/<repo>:environment:<name>` shape in the same PR. A job-to-role
+  binding and the role's trust policy are two halves of one contract; #330
+  changed only one half.
+- Consider a CI lint step that diffs `environment:` keys across
+  `.github/workflows/*.yml` against the sub patterns present in
+  `terraform/environments/*/bootstrap/oidc-github-*-role.tf` and fails the
+  plan job if a job references an environment with no matching trust-policy
+  sub. Not implemented yet — flagged as a gap, not a promise.
+
+### Lessons
+
+- OIDC `sub` claim shape is trigger-dependent, not just repo-dependent: `push`,
+  `pull_request`, and `environment`-bound jobs each mint a structurally
+  different `sub` string. A trust policy written for one trigger shape does
+  not implicitly cover another, even for the same repo and the same role.
+- A failure that happens at `configure-aws-credentials` (before `terraform
+  init`) is always a trust-policy problem, not a permissions problem — the
+  role's IAM policy is never consulted until after the `AssumeRoleWithWebIdentity`
+  call succeeds. Read the failing step first; it narrows the search
+  immediately.
+
+---
+
 ## Adding a new incident
 
 Append new sections at the bottom, before this footer, using the format below. The next incident to be recorded is Incident 16.

--- a/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/management/bootstrap/oidc-github-baseline-role.tf
@@ -6,9 +6,17 @@
 # state-bucket / SLR. Cost-incurring workload-tier surfaces (EC2 / VPC / EKS /
 # ELB / RDS) are not part of this repository's scope.
 #
-# Trust policy is keyed on the OIDC `sub` claim `ref:refs/heads/main` only —
-# the `pull_request` trigger assumes its own read-only role, `gh-tf-plan`. See
+# Trust policy is keyed on the OIDC `sub` claim `ref:refs/heads/main` — the
+# `pull_request` trigger assumes its own read-only role, `gh-tf-plan`. See
 # ADR-014 for the full identity-by-trigger split.
+#
+# ADR-022 (`terraform-apply-baseline.yml` gated SCP apply) binds the
+# `apply-scps` job to GitHub Environment `landing-zone-apply-scps`. A job
+# running under a GitHub Environment presents `sub:
+# repo:<org>/<repo>:environment:<name>` instead of `...:ref:refs/heads/main` —
+# a second, additive sub pattern is required or that job's OIDC assumption
+# fails closed (Incident: run 29015217599, PR #330 bound the environment
+# without updating this trust policy).
 #
 # Scope per account: this is the management-account variant. It covers the
 # union of API surfaces mutated by `terraform/environments/management/
@@ -44,8 +52,16 @@ resource "aws_iam_role" "gh_tf_apply_baseline" {
           # Rename-proof: the immutable repository_id (StringEquals above) is the
           # binding; the sub wildcards the repo NAME so a repo rename cannot break
           # OIDC auth (the failure this trust restructure fixes).
+          #
+          # Two sub shapes are accepted: the `ref:refs/heads/main` push trigger
+          # (apply-baseline, plan-scps, and apply-scps all assume this role) and
+          # the `environment:landing-zone-apply-scps` shape GitHub presents when
+          # a job is bound to that Environment (apply-scps only, ADR-022).
           StringLike = {
-            "${replace(local.github_oidc_url, "https://", "")}:sub" = "repo:${local.github_org}/*:ref:refs/heads/main"
+            "${replace(local.github_oidc_url, "https://", "")}:sub" = [
+              "repo:${local.github_org}/*:ref:refs/heads/main",
+              "repo:${local.github_org}/*:environment:landing-zone-apply-scps",
+            ]
           }
         }
       }


### PR DESCRIPTION
## Summary

PR #330 (ADR-022) bound the `apply-scps` job in
`.github/workflows/terraform-apply-baseline.yml` to GitHub Environment
`landing-zone-apply-scps` for the human-gated SCP apply, but the
`gh-tf-apply-baseline` trust policy in
`terraform/environments/management/bootstrap/oidc-github-baseline-role.tf`
was not updated to match. A job running under a GitHub Environment presents
`sub: repo:<org>/<repo>:environment:<name>`, not `...:ref:refs/heads/main`.

First post-merge run (**29015217599**) failed job **"Apply management/scps
(gated)"** at `configure-aws-credentials`:

```
Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

Failure is pre-plan — nothing was applied, no state drift.

## What changed

- `terraform/environments/management/bootstrap/oidc-github-baseline-role.tf`:
  the `StringLike` `sub` condition on `gh_tf_apply_baseline`'s trust policy
  becomes a list, additively including
  `repo:${local.github_org}/*:environment:landing-zone-apply-scps` alongside
  the existing `repo:${local.github_org}/*:ref:refs/heads/main`. Every other
  condition (the `repository_id` `StringEquals` binding, `aud`) is untouched.
- `docs/incidents.md`: Incident 16 — symptom / root cause / detection /
  resolution / prevention / lessons, per repo discipline.

Checked whether any other job in the workflow got an environment binding in
#330 (`gh pr diff 330 | grep -n environment`) — only `apply-scps` did, so no
other role needs a matching sub.

## Change-review checklist (`docs/principles/change-review-discipline.md`)

1. **Blast radius**: narrow. This is an additive trust-policy change on one
   role (`gh-tf-apply-baseline`, management account only). It adds a second
   accepted `sub` shape; it removes nothing and does not touch the
   `repository_id` binding that is the actual repo-pinning control (ADR-019).
   Worst case if the added sub value were wrong: `apply-scps` still fails
   closed exactly as it does today — no new privilege leaks to a wrong caller.
2. **Dependency assumptions**: this fix assumes the `apply-scps` job's
   `environment:` value stays `landing-zone-apply-scps` (matches the string in
   `terraform-apply-baseline.yml` today) and that `local.github_org` still
   resolves to `BinHsu`/the configured org. If the environment is ever
   renamed, this sub value must be updated in the same PR as the workflow
   change — the same class of drift that caused this incident.
3. **Deprecation status**: not applicable — no provider/action version
   touched, only a `StringLike` condition value.
4. **Rollback plan**: fastest path — `git revert` this commit + let
   `management/bootstrap` re-apply via the non-gated `apply-baseline` job on
   merge. Reverting only removes the added sub value; the pre-existing
   `ref:refs/heads/main` trust is untouched throughout, so revert carries no
   risk of locking out the primary apply path.
5. **2 AM readability**: added inline comments at both the file-header
   "trust policy is keyed on..." block and directly above the `StringLike`
   condition, explaining why two sub shapes exist and which jobs use which.
   ADR-022 is cited in both places.

## Why merging self-heals the failed run

The trust policy this PR changes lives in `management/bootstrap`, which is
applied by the **non-gated** `apply-baseline` job (auto-applies on merge to
main, no environment gate). Merging this PR re-applies `management/bootstrap`
first-in-matrix-order on the next `terraform-apply-baseline.yml` run, which
updates the IAM trust policy in AWS. The next run's `apply-scps` job (or a
manual `workflow_dispatch` re-run) then authenticates successfully against the
updated trust.

## Test plan

- [x] `terraform fmt -check -recursive terraform/` — clean, no diff
- [x] `terraform validate` in `terraform/environments/management/bootstrap/`
      — success
- [ ] CI `Terraform Plan` job green on this PR (verify before merge)
- [ ] Checkov green on this PR (verify before merge)
- [ ] Post-merge: confirm `management/bootstrap` re-applies cleanly and the
      next `apply-scps` run authenticates (no `AssumeRoleWithWebIdentity`
      error)

Refs #330, failed run 29015217599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjR9eozKUjq6LL8tgxrEhK