### PR TITLE
fix(break-glass): extend S3 grant to aegis-platform-aws state buckets

### DIFF
--- a/terraform/environments/deployment/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/deployment/bootstrap/aegis-emergency-role.tf
@@ -84,6 +84,35 @@ resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
         Resource = "*"
       },
       {
+        # Cross-repo emergency access to the platform tier's Terraform state
+        # (platform#90 residual, closed here per platform PR #194's pointer;
+        # pattern follows this repo's own per-account isolation in LDZ #322).
+        # `aegis-platform-aws`'s `envs/bootstrap` provisions one globally-
+        # unique bucket per account — `aegis-platform-aws-tfstate-<account-
+        # id>` — with NO bucket policy of its own, so same-account IAM grant
+        # is the only access path. The account-id suffix makes this
+        # name-pattern self-scoping even though S3 ARNs carry no account
+        # segment: a break-glass role in another account cannot use this
+        # statement to reach a bucket it doesn't own, because cross-account
+        # S3 access would still need an explicit bucket-policy grant that
+        # the platform bucket does not have. Read+write (Get/Put/Delete) to
+        # match "repair/inspect" from the residual — break-glass state
+        # recovery is not read-only.
+        Sid    = "PlatformStateBreakGlass"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*",
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*/*",
+        ]
+      },
+      {
         # KMS read + Decrypt scoped to local-account keys only. Required
         # for reading SSM PS SecureString values during diagnosis. No
         # Encrypt / GenerateDataKey — break-glass is read-recovery.

--- a/terraform/environments/logarchive/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/logarchive/bootstrap/aegis-emergency-role.tf
@@ -84,6 +84,35 @@ resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
         Resource = "*"
       },
       {
+        # Cross-repo emergency access to the platform tier's Terraform state
+        # (platform#90 residual, closed here per platform PR #194's pointer;
+        # pattern follows this repo's own per-account isolation in LDZ #322).
+        # `aegis-platform-aws`'s `envs/bootstrap` provisions one globally-
+        # unique bucket per account — `aegis-platform-aws-tfstate-<account-
+        # id>` — with NO bucket policy of its own, so same-account IAM grant
+        # is the only access path. The account-id suffix makes this
+        # name-pattern self-scoping even though S3 ARNs carry no account
+        # segment: a break-glass role in another account cannot use this
+        # statement to reach a bucket it doesn't own, because cross-account
+        # S3 access would still need an explicit bucket-policy grant that
+        # the platform bucket does not have. Read+write (Get/Put/Delete) to
+        # match "repair/inspect" from the residual — break-glass state
+        # recovery is not read-only.
+        Sid    = "PlatformStateBreakGlass"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*",
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*/*",
+        ]
+      },
+      {
         # KMS read + Decrypt scoped to local-account keys only. Required
         # for reading SSM PS SecureString values during diagnosis. No
         # Encrypt / GenerateDataKey — break-glass is read-recovery.

--- a/terraform/environments/management/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/management/bootstrap/aegis-emergency-role.tf
@@ -154,6 +154,35 @@ resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
         Resource = "*"
       },
       {
+        # Cross-repo emergency access to the platform tier's Terraform state
+        # (platform#90 residual, closed here per platform PR #194's pointer;
+        # pattern follows this repo's own per-account isolation in LDZ #322).
+        # `aegis-platform-aws`'s `envs/bootstrap` provisions one globally-
+        # unique bucket per account — `aegis-platform-aws-tfstate-<account-
+        # id>` — with NO bucket policy of its own, so same-account IAM grant
+        # is the only access path. The account-id suffix makes this
+        # name-pattern self-scoping even though S3 ARNs carry no account
+        # segment: a break-glass role in another account cannot use this
+        # statement to reach a bucket it doesn't own, because cross-account
+        # S3 access would still need an explicit bucket-policy grant that
+        # the platform bucket does not have. Read+write (Get/Put/Delete) to
+        # match "repair/inspect" from the residual — break-glass state
+        # recovery is not read-only.
+        Sid    = "PlatformStateBreakGlass"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*",
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*/*",
+        ]
+      },
+      {
         # KMS read + Decrypt scoped to local-account keys only. Required
         # for reading SSM PS SecureString values during diagnosis. No
         # Encrypt / GenerateDataKey here — break-glass is read-recovery,

--- a/terraform/environments/prod/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/prod/bootstrap/aegis-emergency-role.tf
@@ -84,6 +84,35 @@ resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
         Resource = "*"
       },
       {
+        # Cross-repo emergency access to the platform tier's Terraform state
+        # (platform#90 residual, closed here per platform PR #194's pointer;
+        # pattern follows this repo's own per-account isolation in LDZ #322).
+        # `aegis-platform-aws`'s `envs/bootstrap` provisions one globally-
+        # unique bucket per account — `aegis-platform-aws-tfstate-<account-
+        # id>` — with NO bucket policy of its own, so same-account IAM grant
+        # is the only access path. The account-id suffix makes this
+        # name-pattern self-scoping even though S3 ARNs carry no account
+        # segment: a break-glass role in another account cannot use this
+        # statement to reach a bucket it doesn't own, because cross-account
+        # S3 access would still need an explicit bucket-policy grant that
+        # the platform bucket does not have. Read+write (Get/Put/Delete) to
+        # match "repair/inspect" from the residual — break-glass state
+        # recovery is not read-only.
+        Sid    = "PlatformStateBreakGlass"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*",
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*/*",
+        ]
+      },
+      {
         # KMS read + Decrypt scoped to local-account keys only. Required
         # for reading SSM PS SecureString values during diagnosis. No
         # Encrypt / GenerateDataKey — break-glass is read-recovery.

--- a/terraform/environments/security/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/security/bootstrap/aegis-emergency-role.tf
@@ -84,6 +84,35 @@ resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
         Resource = "*"
       },
       {
+        # Cross-repo emergency access to the platform tier's Terraform state
+        # (platform#90 residual, closed here per platform PR #194's pointer;
+        # pattern follows this repo's own per-account isolation in LDZ #322).
+        # `aegis-platform-aws`'s `envs/bootstrap` provisions one globally-
+        # unique bucket per account — `aegis-platform-aws-tfstate-<account-
+        # id>` — with NO bucket policy of its own, so same-account IAM grant
+        # is the only access path. The account-id suffix makes this
+        # name-pattern self-scoping even though S3 ARNs carry no account
+        # segment: a break-glass role in another account cannot use this
+        # statement to reach a bucket it doesn't own, because cross-account
+        # S3 access would still need an explicit bucket-policy grant that
+        # the platform bucket does not have. Read+write (Get/Put/Delete) to
+        # match "repair/inspect" from the residual — break-glass state
+        # recovery is not read-only.
+        Sid    = "PlatformStateBreakGlass"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*",
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*/*",
+        ]
+      },
+      {
         # KMS read + Decrypt scoped to local-account keys only. Required
         # for reading SSM PS SecureString values during diagnosis. No
         # Encrypt / GenerateDataKey — break-glass is read-recovery.

--- a/terraform/environments/shared/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/shared/bootstrap/aegis-emergency-role.tf
@@ -84,6 +84,35 @@ resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
         Resource = "*"
       },
       {
+        # Cross-repo emergency access to the platform tier's Terraform state
+        # (platform#90 residual, closed here per platform PR #194's pointer;
+        # pattern follows this repo's own per-account isolation in LDZ #322).
+        # `aegis-platform-aws`'s `envs/bootstrap` provisions one globally-
+        # unique bucket per account — `aegis-platform-aws-tfstate-<account-
+        # id>` — with NO bucket policy of its own, so same-account IAM grant
+        # is the only access path. The account-id suffix makes this
+        # name-pattern self-scoping even though S3 ARNs carry no account
+        # segment: a break-glass role in another account cannot use this
+        # statement to reach a bucket it doesn't own, because cross-account
+        # S3 access would still need an explicit bucket-policy grant that
+        # the platform bucket does not have. Read+write (Get/Put/Delete) to
+        # match "repair/inspect" from the residual — break-glass state
+        # recovery is not read-only.
+        Sid    = "PlatformStateBreakGlass"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*",
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*/*",
+        ]
+      },
+      {
         # KMS read + Decrypt scoped to local-account keys only. Required
         # for reading SSM PS SecureString values during diagnosis. No
         # Encrypt / GenerateDataKey — break-glass is read-recovery.

--- a/terraform/environments/staging/bootstrap/aegis-emergency-role.tf
+++ b/terraform/environments/staging/bootstrap/aegis-emergency-role.tf
@@ -84,6 +84,35 @@ resource "aws_iam_role_policy" "aegis_emergency_break_glass" {
         Resource = "*"
       },
       {
+        # Cross-repo emergency access to the platform tier's Terraform state
+        # (platform#90 residual, closed here per platform PR #194's pointer;
+        # pattern follows this repo's own per-account isolation in LDZ #322).
+        # `aegis-platform-aws`'s `envs/bootstrap` provisions one globally-
+        # unique bucket per account — `aegis-platform-aws-tfstate-<account-
+        # id>` — with NO bucket policy of its own, so same-account IAM grant
+        # is the only access path. The account-id suffix makes this
+        # name-pattern self-scoping even though S3 ARNs carry no account
+        # segment: a break-glass role in another account cannot use this
+        # statement to reach a bucket it doesn't own, because cross-account
+        # S3 access would still need an explicit bucket-policy grant that
+        # the platform bucket does not have. Read+write (Get/Put/Delete) to
+        # match "repair/inspect" from the residual — break-glass state
+        # recovery is not read-only.
+        Sid    = "PlatformStateBreakGlass"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+        ]
+        Resource = [
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*",
+          "arn:aws:s3:::aegis-platform-aws-tfstate-*/*",
+        ]
+      },
+      {
         # KMS read + Decrypt scoped to local-account keys only. Required
         # for reading SSM PS SecureString values during diagnosis. No
         # Encrypt / GenerateDataKey — break-glass is read-recovery.


### PR DESCRIPTION
Refs BinHsu/aegis-platform-aws#90, follows up on BinHsu/aegis-platform-aws#194.

## Problem

Platform PR #194 closed issue #90's state-migration work but flagged a residual it could not fix in its own repo: `aegis-emergency-break-glass` (this repo's break-glass role, materialized per-account under `terraform/environments/*/bootstrap/aegis-emergency-role.tf`) has no S3 grant covering `aegis-platform-aws`'s Terraform state buckets. In an incident, break-glass cannot read or repair platform-tier state.

Verified real bucket naming from the platform repo (read-only): `terraform/envs/bootstrap/main.tf` computes `bucket_name = "${var.bucket_prefix}-${account_id}"`, and `backend.hcl` shows the live value `aegis-platform-aws-tfstate-506221082337` (prod). One bucket per account, **no bucket policy of its own** — so same-account IAM identity policy is the only access path today.

## Fix

Added a `PlatformStateBreakGlass` Sid to every environment's `aegis-emergency-role.tf` (`management`, `shared`, `staging`, `prod`, `security`, `logarchive`, `deployment`):

```hcl
Sid    = "PlatformStateBreakGlass"
Effect = "Allow"
Action = [
  "s3:GetObject",
  "s3:PutObject",
  "s3:DeleteObject",
  "s3:ListBucket",
  "s3:GetBucketLocation",
]
Resource = [
  "arn:aws:s3:::aegis-platform-aws-tfstate-*",
  "arn:aws:s3:::aegis-platform-aws-tfstate-*/*",
]
```

Read+write, matching "repair/inspect" from the residual — break-glass state recovery is not read-only. Additive only; no other Sid touched.

Mirrors this repo's own per-account isolation pattern from LDZ #322, adapted for a cross-repo bucket: since the platform bucket carries no bucket policy, cross-account access is blocked regardless of this statement's wildcard — the account-id suffix in the bucket name makes the grant self-scoping to the account it's deployed in.

## 5-step checklist (`docs/principles/change-review-discipline.md`)

1. **Blast radius**: smallest — one new `Allow` Sid on one existing role, scoped to a specific bucket-name pattern, additive. Largest — bounded to break-glass sessions only (PlatformAdmin SSO, 1h max), which already carry broad IAM/KMS/SSM read + scoped IAM mutation; this adds scoped S3 read/write on a specific external bucket family. No change to trust policy, no change to any other identity.
2. **Dependency assumptions**: assumes the platform bucket's name keeps the `aegis-platform-aws-tfstate-<account-id>` shape and stays same-account with this repo's break-glass role (true today: prod `506221082337`, staging `251774439261` per platform PR #194). Assumes the platform bucket keeps no bucket policy of its own (if platform later adds one, cross-account behavior would need re-review, but same-account behavior here is unaffected).
3. **Deprecation status**: no provider/API deprecation involved — standard S3 IAM actions, no new dependency version.
4. **Rollback plan**: fastest path — `git revert` this commit + let `terraform-apply-baseline.yml` apply on merge to main (single in-place `aws_iam_role_policy` update, no state lock contention expected). Sub-minute apply, matches "Component: baseline IAM policy" shape in the version-tracking table.
5. **2 AM readability**: Sid named for its purpose (`PlatformStateBreakGlass`), inline comment explains the cross-repo bucket-naming contract and why the wildcard is self-scoping despite lacking an account segment. Resource name follows existing repo convention (bare `aegis-` family already grandfathered per CLAUDE.md naming discipline note).

## Validation

- `terraform fmt -check -recursive terraform/` — clean.
- `terraform validate` (init `-backend=false`) — Success on all 7 modified layers (management, shared, staging, prod, security, logarchive, deployment bootstrap).
- `checkov` (matching CI's `skip_path`/`skip_check` from `.github/workflows/checkov.yml`) — 245 passed, 0 failed, 154 skipped.
- `make config-check` and `make policy` (config-policy gate, #321/#322) — both pass (`policy_test: PASS (86 checks)`).
- CI plan matrix on this PR is the authoritative check.

## No apply

Merge auto-applies via `terraform-apply-baseline.yml` — an in-place IAM policy update, free, no NAT/EKS/ALB introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjR9eozKUjq6LL8tgxrEhK