### PR TITLE
[COST-GATED: lands dormant] feat(detective): LZ-baseline S3–S5 — GuardDuty org auto-enable + Security Hub FSBP + docs reconciliation

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -41,8 +41,7 @@ jobs:
             CKV_AWS_18,
             CKV_AWS_144,
             CKV2_AWS_62,
-            CKV_AWS_274,
-            CKV2_AWS_3
+            CKV_AWS_274
           # CKV_AWS_18  (S3 access logging) — deferred per ADR-003 Future Hardening.
           #   Enabling requires a separate log-destination bucket with ACL-based
           #   write permissions. Tracked for Phase 2 observability work.
@@ -54,8 +53,9 @@ jobs:
           # CKV_AWS_274 (AdministratorAccess policy) — intentional for lab per
           #   ADR-001 scope boundary and inline comments in oidc-github.tf.
           #   Production should scope down to per-environment minimum permissions.
-          # CKV2_AWS_3  (GuardDuty org-wide) — org-wide GuardDuty delegated-admin
-          #   setup via the security account is a future hardening item.
+          # CKV2_AWS_3 (GuardDuty org-wide) skip REMOVED with epic #302 S3:
+          #   terraform/environments/security/detective/guardduty.tf now codifies
+          #   the org-wide GuardDuty configuration this skip was deferring.
 
       - name: Upload SARIF to GitHub Security tab
         if: always()

--- a/.github/workflows/terraform-apply-baseline.yml
+++ b/.github/workflows/terraform-apply-baseline.yml
@@ -39,6 +39,7 @@ on:
       - 'terraform/environments/staging/bootstrap/**'
       - 'terraform/environments/prod/bootstrap/**'
       - 'terraform/environments/security/bootstrap/**'
+      - 'terraform/environments/security/detective/**'
       - 'terraform/environments/logarchive/bootstrap/**'
       - 'config/**'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Post-v1.0.0 changes on `main`. All changes are to the **account-fabric** scope
 
 ### Added
 
+- **Detective baseline** (ADR-023, epic #302 S3–S5): new `security/detective`
+  Terraform layer — GuardDuty org-wide auto-enable (foundational only, all paid
+  add-ons pinned off), Security Hub LOCAL org config + FSBP standard, read-only
+  CT Config-aggregator assertion. Lifecycle-coupled via `detective_enabled`
+  (~$12–17/mo only while enabled); member-detector teardown script included.
+  Docs reconciled: finops cost model, README Phase-4/Phase-6 status, ADR index,
+  `CKV2_AWS_3` Checkov skip removed. (#305, #306, #307)
 - **Deployments OU + `aegis-deployment` account** (ADR-018): seventh AWS account
   vended via Control Tower; dedicated OU for the shared release-artifact registry.
   Bootstrap layer (OIDC provider, `gh-tf-plan/apply`, break-glass role) wired into

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The landing zone is kept thin deliberately: it is the foundation the platform st
 - **Signed commits enforced** — branch protection + SSH-key signing
 - **Centralized IPAM with RAM cross-account sharing** — the org-wide, collision-free authority that hands non-overlapping VPC CIDRs to every account and every downstream consumer (ADR-012)
 - **Fork-and-deploy by config** — one YAML file + two scripts; no per-deployment forks
-- **Account-fabric security baseline** — organizational CloudTrail, AWS Config, GuardDuty, a layered IAM scope-down ladder (ADR-014–016)
+- **Account-fabric security baseline** — Control-Tower-managed organizational CloudTrail + AWS Config (documented reliance, ADR-023), a layered IAM scope-down ladder (ADR-014–016), and a codified, lifecycle-coupled detective baseline: GuardDuty org-wide + Security Hub FSBP (ADR-023)
 
 ## About this project
 
@@ -180,8 +180,9 @@ Status reflects what exists in `main`. The account fabric is complete: the 7th a
 | 1. Foundation | Config contract, state bucket, SCPs, OIDC, account provisioning | ~Free | **Done** |
 | 2. GitOps Pipeline | plan/apply workflows, Checkov, pre-commit, signed commits | ~Free | **Done** |
 | 3. IPAM | Org-wide IPAM + RAM cross-account sharing (ADR-012) | ~$0 idle | **Done** |
-| 4. Security baseline | Organizational CloudTrail, AWS Config, GuardDuty, IAM scope-down ladder (ADR-014–016) | ~$5/mo | **Done** |
+| 4. Security baseline | CT-managed organizational CloudTrail + AWS Config (documented reliance), IAM scope-down ladder (ADR-014–016) | In the ~$5/mo CT baseline | **Done** (earlier "GuardDuty done" claim was false — corrected by Phase 6) |
 | 5. Deployments OU + registry account | Deployments OU + `aegis-deployment` bootstrap for the shared release-artifact registry (ADR-018; ECR lives in `aegis-platform-aws`) | ~Free fabric; ECR billed downstream | **Account vended — first bootstrap apply pending role seed** |
+| 6. Detective baseline | GuardDuty org auto-enable + Security Hub FSBP + CT Config-aggregator assert, delegated to the security account (epic #302, ADR-023) | ~$12–17/mo **only while `detective_enabled = true`**; $0 toggled off | **Codified — lifecycle-coupled, enabled per validation window** |
 
 ## Reliability & Recovery Posture
 
@@ -222,6 +223,7 @@ All ADRs are **Accepted**.
 | [020](docs/decisions/020-scp-enforced-ci-permissions-boundary.md) | SCP-enforced permissions boundary for the CI apply tier |
 | [021](docs/decisions/021-ci-native-cold-account-bootstrap.md) | CI-native cold-account bootstrap — retire manual seed + adopt (Proposed) |
 | [022](docs/decisions/022-ci-pipeline-hardening.md) | CI pipeline hardening — saved-plan apply + SCP human gate, config-derived matrix, policy-as-code gate |
+| [023](docs/decisions/023-detective-baseline-guardduty-securityhub.md) | Detective baseline — GuardDuty org auto-enable + Security Hub FSBP, lifecycle-coupled |
 
 ## Runbooks
 
@@ -249,7 +251,8 @@ Changes that cross tier boundaries — OIDC trust anchor updates, IPAM pool chan
 
 - Phases 0–3 are ~free (Organizations, SSO, SCPs, S3, IPAM idle, public-repo GitHub Actions).
 - The account-fabric always-on baseline is **~$5/month**: Control Tower + AWS Config recorder + organizational CloudTrail + S3 log storage. IPAM advanced tier bills ~$0 idle.
-- There are **no per-session cost-incurring layers** in this repo — no EKS, no NAT Gateway, no ALB.
+- The **detective baseline adds ~$12–17/month while enabled** (GuardDuty org-wide + Security Hub FSBP, `eu-central-1`) and $0 toggled off — it is lifecycle-coupled to validation windows, not always-on. Full pricing breakdown in [`docs/finops.md`](docs/finops.md); decision in [ADR-023](docs/decisions/023-detective-baseline-guardduty-securityhub.md).
+- There is no EKS, NAT Gateway, or ALB anywhere in this repo; the detective layer is the only toggled cost.
 - Budget alerts: daily $10, monthly $30 (enforced via AWS Budgets in the management account).
 - The account fabric is steady-state — it is not destroyed between sessions. The only destroy is the project-end [`hard-teardown-landing-zone.sh`](scripts/teardown/README.md). See [ADR-009](docs/decisions/009-lifecycle-and-teardown-strategy.md).
 
@@ -282,6 +285,10 @@ aegis-landing-zone-aws/
 │       │   └── aft/               # AFT code (committed, not deployed — ADR-011 Path A)
 │       ├── deployment/bootstrap/  # Alias, GitHub OIDC provider, gh-tf-* + break-glass (ADR-018; ECR lives in aegis-platform-aws)
 │       ├── staging/bootstrap/     # Alias, GitHub OIDC provider, gh-tf-* + break-glass roles
+│       ├── security/
+│       │   ├── bootstrap/         # Alias, GitHub OIDC provider, gh-tf-* + break-glass roles
+│       │   └── detective/         # GuardDuty org auto-enable + Security Hub FSBP (ADR-023, lifecycle-coupled)
+│       ├── logarchive/bootstrap/  # Alias, GitHub OIDC provider, gh-tf-* + break-glass roles
 │       └── prod/bootstrap/        # Alias only
 ├── scripts/
 │   ├── configure-backends.sh      # Sync backend.tf from config

--- a/config/ci-layers.yaml
+++ b/config/ci-layers.yaml
@@ -40,6 +40,13 @@ layers:
     account: security
   - env: logarchive/bootstrap
     account: logarchive
+  # Detective services (epic #302 S3/S4): GuardDuty org auto-enable +
+  # Security Hub FSBP from the delegated-admin (security) account. Ordered
+  # AFTER security/bootstrap — the same apply run must land the detective
+  # IAM Sids on the security account's gh-tf-* roles before this layer
+  # applies with them.
+  - env: security/detective
+    account: security
   # Org-root SCPs: applied LAST (foundation-first ordering) and the single
   # highest-blast-radius layer. `gate: scps` routes it through the human-review
   # apply path (issue #316) instead of the auto-apply matrix.

--- a/docs/decisions/023-detective-baseline-guardduty-securityhub.md
+++ b/docs/decisions/023-detective-baseline-guardduty-securityhub.md
@@ -1,0 +1,131 @@
+# 023. Detective Baseline — GuardDuty Org Auto-Enable + Security Hub FSBP, Lifecycle-Coupled
+
+## Status
+
+Accepted (2026-07-09). Epic #302, stages S2 (#304, PR #311), S3 (#305), S4 (#306), S5 (#307).
+
+## Context
+
+The epic-#302 review found the repo's #1 documentation-vs-reality gap: the README
+asserted GuardDuty / Config / Security Hub were enabled, but no Terraform existed
+for any of them, and the `security` + `logarchive` accounts had no Terraform
+environment at all. S1 (#303) created those environments; S2 (PR #311) registered
+the `security` account as the org delegated administrator for GuardDuty and
+Security Hub (free — delegation only). This ADR records the decisions behind
+S3/S4, the stages that actually turn the services on.
+
+Two facts constrain the design:
+
+1. **The Config aggregator is Control-Tower-managed.** The audit/security
+   account already has a CT-provided org Config aggregator. Rebuilding it would
+   duplicate CT-owned infrastructure and fight the CT baseline on every drift.
+2. **The org is a near-zero-workload lab under a $30/month cap.** GuardDuty and
+   Security Hub bill continuously once enabled, whether or not anything worth
+   protecting exists.
+
+### Non-contradiction with ADR-016 ("Why not GuardDuty")
+
+[ADR-016](016-detective-controls.md) rejected GuardDuty — for a specific job:
+deterministic alerting on failed OIDC assumptions, where an ML-tuned finding
+pipeline is the wrong shape and EventBridge's literal pattern match is right.
+That reasoning is untouched and still holds. This ADR adopts GuardDuty for the
+job ADR-016 explicitly said it IS for: org-wide runtime threat detection across
+member accounts ("GuardDuty earns its keep on the runtime side"). The two
+detective layers are complementary — ADR-016's EventBridge rule watches one
+deterministic control-plane event; this baseline watches everything else.
+
+### CloudTrail: document-reliance (epic decision D1)
+
+CloudTrail in this org is the CT-managed org trail (KMS-encrypted, archived to
+`aegis-logarchive`). This repo does **not** own, re-create, or modify it — it
+documents the reliance and builds on it: CloudTrail management events are
+exactly the foundational data source GuardDuty analyzes. If CT's trail ever
+goes away, GuardDuty's CloudTrail analysis (and much else) silently loses its
+input — which is one reason the aggregator/trail layer stays CT-owned and
+asserted rather than duplicated.
+
+## Decision
+
+| # | Decision | Where |
+|---|----------|-------|
+| 1 | GuardDuty org auto-enable `ALL` (existing + future members), foundational data sources only; every paid add-on (S3 / EKS audit / EBS malware / RDS login / Lambda network / Runtime Monitoring) explicitly pinned off at detector and org level | `terraform/environments/security/detective/guardduty.tf` |
+| 2 | Security Hub LOCAL org configuration, `auto_enable_standards = "NONE"`, exactly one standards subscription (FSBP); finding aggregator homed in the primary region with the remaining governed region(s) linked | `securityhub.tf` |
+| 3 | CT Config aggregator asserted read-only via a `check` block + `external` probe — never created or owned here | `ct-config-aggregator-check.tf` |
+| 4 | **Lifecycle-coupled, not always-on** (decided by Bin on #305/#306, 2026-07-06): a single `detective_enabled` toggle destroys/creates every billable resource in the layer; member-detector residue is swept by `scripts/disable-member-detectors.sh` | `variables.tf`, `scripts/` |
+| 5 | The layer is a separate Terraservice (`security/detective`), not mixed into the account baseline (epic D5), primary region only (epic D3) | `config/ci-layers.yaml` |
+
+### Cost (eu-central-1, verified via the AWS Pricing API, 2026-07-09)
+
+| Service | Pricing model | This org, near-zero workload |
+|---------|--------------|------------------------------|
+| GuardDuty foundational | $0.0000046 per CloudTrail management event analyzed ($4.60/M); VPC Flow/DNS $1.15/GB (first 500 GB tier) | 7 accounts × ~50–300k idle events/mo ≈ **$2–9/mo**; VPC/DNS ≈ $0 until VPCs exist |
+| Security Hub CSPM | $0.0010 per security check (first 100k/account/region/mo) | FSBP in the security account only ≈ **$1–5/mo** |
+| Config aggregator | CT-owned, pre-existing | $0 net new |
+| **Total net new** | | **~$3–14/mo idle; plan ~$12–17/mo during an active validation window.** Both services give each account a one-time 30-day free trial. |
+
+### Known gap — CI cannot yet exercise the aggregator check
+
+The ADR-020 org-uniform CI permissions boundary's Allow ceiling covers
+`guardduty:*` + `securityhub:*` (added with S2) but **not** the `config`
+namespace. The aggregator check degrades to a plan **warning** in CI
+(`found = "error"`, AccessDenied) and passes only under operator SSO
+credentials. Fixing it is a deliberate 7-file, byte-identical boundary change
+(all `*/bootstrap/ci-permissions-boundary.tf`) that touches the management
+account's bootstrap — deferred out of the S3–S5 PR to avoid colliding with
+parallel management-area workstreams. Follow-up: add `config:*` (or
+`config:Describe*`) to the boundary ceiling in one uniform PR.
+
+## Alternatives considered
+
+- **Always-on detective services.** Rejected by Bin (2026-07-06, recorded on
+  #305/#306): idle landing-zone accounts have nothing to detect; 24/7 enablement
+  pays for protection on nothing. The Terraform code itself carries the
+  portfolio fidelity; recurring cost accrues only during validation windows.
+- **Security Hub CENTRAL configuration policies.** Would enroll existing member
+  accounts and centrally push FSBP, but requires an ALL_REGIONS-style
+  aggregation posture and adds per-account check volume (≈7× the Security Hub
+  cost) — the wrong default for the frugal posture. Revisit if member-account
+  coverage becomes a requirement (OQ-1).
+- **Owning a Config aggregator in Terraform.** Rejected — the epic's key
+  verified fact: CT already provides it. Import-and-own would make every CT
+  landing-zone update a Terraform drift.
+- **All GuardDuty features on.** Rejected — the paid add-ons protect resource
+  types (S3 data events, EKS, RDS, Lambda, runtime agents) that do not exist in
+  this org; enabling them is pure spend.
+
+## Consequences
+
+- Merging + applying with `detective_enabled = true` starts recurring spend
+  (table above) — detective-layer PRs are **cost-gated**: the PR body carries
+  the cost table and merge is the conscious acceptance of it.
+- Disable path: flip `detective_enabled = false` (one-line PR) → apply destroys
+  the delegated-admin detector, org auto-enable, and Security Hub resources;
+  then run `scripts/disable-member-detectors.sh --execute` under a
+  management-account admin to delete the auto-created member detectors, which
+  are outside Terraform state and would otherwise keep billing.
+- `CKV2_AWS_3` (GuardDuty org-wide) left the Checkov skip list — the control is
+  now codified, so Checkov asserts it instead of excusing it.
+- The security account's CI roles gained `guardduty:*` / `securityhub:*`
+  (apply) and read shapes + `config:Describe*` (plan) — inside the ADR-014
+  namespace-scoping contract and (except `config`) inside the ADR-020 ceiling.
+
+## Open questions
+
+1. **OQ-1 — existing member accounts in Security Hub.** LOCAL org config with
+   `auto_enable = true` covers only accounts that join AFTER the apply; the six
+   existing members are not enrolled and FSBP runs in the security account
+   only. Options when coverage matters: `aws_securityhub_member` resources, or
+   CENTRAL configuration policies (cost ≈ 7×). Awaiting Bin's decision.
+2. **OQ-2 — boundary `config` namespace.** See "Known gap" above; needed before
+   the aggregator check can assert in CI.
+
+## Related
+
+- [ADR-016](016-detective-controls.md) — the deterministic OIDC-failure
+  detective control; explicitly non-contradictory (see Context).
+- [ADR-009](009-lifecycle-and-teardown-strategy.md) — the lifecycle posture the
+  `detective_enabled` toggle extends to org-level services.
+- [ADR-020](020-scp-enforced-ci-permissions-boundary.md) — the boundary ceiling
+  that gates the aggregator check (OQ-2).
+- [`docs/finops.md`](../finops.md) — the detective-baseline cost model.
+- Epic #302; issues #303–#307; PR #311 (S2).

--- a/docs/decisions/023-detective-baseline-guardduty-securityhub.md
+++ b/docs/decisions/023-detective-baseline-guardduty-securityhub.md
@@ -95,12 +95,19 @@ parallel management-area workstreams. Follow-up: add `config:*` (or
 
 ## Consequences
 
-- Merging + applying with `detective_enabled = true` starts recurring spend
-  (table above) — detective-layer PRs are **cost-gated**: the PR body carries
-  the cost table and merge is the conscious acceptance of it.
-- Disable path: flip `detective_enabled = false` (one-line PR) → apply destroys
-  the delegated-admin detector, org auto-enable, and Security Hub resources;
-  then run `scripts/disable-member-detectors.sh --execute` under a
+- `detective_enabled` defaults to **false** (decided by Bin, 2026-07-09): the
+  layer lands and merges **dormant** — applying the default creates the layer
+  scaffolding with zero billable resources. Turning the services on (recurring
+  spend per the table above) is a deliberate follow-up: flip
+  `detective_enabled = true` (one-line PR or tfvars override) and apply, timed
+  together with the ephemeral-EKS validation run rather than as a side effect
+  of landing this code. Detective-layer PRs stay **cost-gated** in spirit —
+  the PR body carries the cost table — but the gate now protects the
+  true-flip, not the initial merge.
+- Disable path (future enabled→disabled transition): flip
+  `detective_enabled = false` (one-line PR) → apply destroys the
+  delegated-admin detector, org auto-enable, and Security Hub resources; then
+  run `scripts/disable-member-detectors.sh --execute` under a
   management-account admin to delete the auto-created member detectors, which
   are outside Terraform state and would otherwise keep billing.
 - `CKV2_AWS_3` (GuardDuty org-wide) left the Checkov skip list — the control is

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -46,10 +46,13 @@ where alternatives were genuinely weighed.
 | [018](018-deployments-ou-and-shared-registry-account.md) | Deployments OU + `aegis-deployment` Account for the Shared Release-Artifact Registry | Accepted |
 | [019](019-budgets-iac-and-oidc-fail-closed.md) | Budgets Are IaC and the OIDC Trust Fails Closed | Accepted |
 | [020](020-scp-enforced-ci-permissions-boundary.md) | SCP-Enforced Permissions Boundary for the CI Apply Tier | Accepted |
+| [021](021-ci-native-cold-account-bootstrap.md) | CI-Native Cold-Account Bootstrap | Accepted |
+| [022](022-ci-pipeline-hardening.md) | CI Pipeline Hardening — Saved-Plan Apply, Config-Derived Matrix, Policy Gate | Accepted |
+| [023](023-detective-baseline-guardduty-securityhub.md) | Detective Baseline — GuardDuty Org Auto-Enable + Security Hub FSBP, Lifecycle-Coupled | Accepted |
 
 ## Reading orders by audience
 
-You do not need to read all 20 ADRs front to back. Pick the path for why you
+You do not need to read all the ADRs front to back. Pick the path for why you
 are here. Each list is ordered so the argument builds on itself.
 
 ### Senior platform / infrastructure reviewer
@@ -82,7 +85,7 @@ piece of durable state the account fabric owns.
 
 Understand the guardrails and the blast-radius controls.
 
-`001` → `005` → `006` → `008` → `014` → `015` → `016` → `019` → `020` → `011`
+`001` → `005` → `006` → `008` → `014` → `015` → `016` → `019` → `020` → `023` → `011`
 
 Scope and the ISO 27001 mapping frame the compliance intent; account taxonomy
 and tooling show where the SCP guardrails sit. `014`–`016` are the CI security
@@ -90,8 +93,9 @@ ladder (OIDC role scope-down → SCP permission-boundary inner wall → detectiv
 control on failed OIDC assumption); `019` closes the ladder's fail-open gap
 (required `infra_repo_id`) and moves the cost guardrails into Terraform.
 `020` upgrades the inner wall from a name-based SCP exemption to an
-SCP-enforced permissions boundary on the CI tier. `011` covers account
-provisioning.
+SCP-enforced permissions boundary on the CI tier. `023` adds the org-wide
+detective baseline (GuardDuty auto-enable + Security Hub FSBP,
+lifecycle-coupled to keep the lab frugal). `011` covers account provisioning.
 
 ### Forker / new contributor
 

--- a/docs/finops.md
+++ b/docs/finops.md
@@ -4,15 +4,15 @@
 
 This repository owns the **AWS account fabric** — Organizations, OUs, SCPs, IAM Identity Center, account bootstrap and vending, the Terraform state backend, the GitHub OIDC provider, the centralized security/audit baseline, and the org-wide IPAM. Resources that bill while idle — EKS, NAT Gateways, ALBs — are platform concerns and out of scope here.
 
-The consequence for cost: this repo has **no per-session cost-incurring layers**. Every layer here is a cheap, persistent baseline layer. The cost model is "what does the always-on fabric cost", not "what leaks if a destroy is skipped" — there is nothing to destroy.
+The consequence for cost: almost every layer here is a cheap, persistent baseline layer, and the cost model is "what does the always-on fabric cost". The one exception since epic #302 is the **detective baseline** (`security/detective` — GuardDuty org-wide + Security Hub FSBP): it is deliberately **lifecycle-coupled**, not always-on — enabled for validation windows, disabled between them (see "Detective baseline" below and ADR-023).
 
 Region for all figures: `eu-central-1` (Frankfurt). Prices are on-demand list and rounded; they move — treat them as order-of-magnitude, not invoices.
 
 ## Cost philosophy
 
-One tier, one lifecycle. Every layer — `management/*`, `shared/*`, `staging/bootstrap`, `prod/bootstrap` — is a baseline layer: cheap, persistent, auto-applied on merge to main. They hold organization structure, SCPs, CloudTrail, AWS Config, GuardDuty, IPAM, and the Terraform state bucket. They cost a few dollars per month and are *never* destroyed.
+Two lifecycles. The baseline layers — `management/*`, `shared/*`, and every `*/bootstrap` — are cheap, persistent, auto-applied on merge to main. They hold organization structure, SCPs, IAM/OIDC, IPAM, and the Terraform state bucket; they cost a few dollars per month and are *never* destroyed. The **detective layer** (`security/detective`) is the exception: it carries a `detective_enabled` toggle and rides the platform bring-up/teardown lifecycle, because idle landing-zone accounts have nothing to detect (decided by Bin on #305/#306; ADR-023).
 
-The discipline in one sentence: **the account fabric runs forever and costs ~$5/month; there is no ephemeral cost in this repo.**
+The discipline in one sentence: **the account fabric runs forever at ~$5/month; the detective baseline adds ~$12–17/month only while a validation window is active.**
 
 ## Per-layer cost breakdown
 
@@ -25,6 +25,8 @@ The discipline in one sentence: **the account fabric runs forever and costs ~$5/
 | `shared/aft` | AFT pipeline (committed, not deployed — ADR-011) | Free while not applied | $0 |
 | `staging/bootstrap` | S3 state bucket (native locking), KMS, GitHub OIDC role | Storage + per-key | <$2/mo |
 | `prod/bootstrap` | Same shape as `staging/bootstrap` | Storage + per-key | <$2/mo |
+| `deployment/bootstrap` / `security/bootstrap` / `logarchive/bootstrap` | IAM roles, OIDC provider, account alias | Free | $0 |
+| `security/detective` | GuardDuty org-wide + Security Hub FSBP (lifecycle-coupled) | Per-event + per-check (see below) | $0 toggled off; ~$12–17/mo enabled |
 
 ## The always-on baseline (~$5/month)
 
@@ -36,9 +38,35 @@ The persistent cost of the account fabric is dominated by the Control Tower base
 | CloudTrail org trail | First trail free; S3 storage + events | ~$0.50 |
 | S3 log storage (CloudTrail + Config archive in `aegis-logarchive`) | Storage + lifecycle | ~$0.50 |
 | KMS customer-managed keys (state bucket, log encryption) | $1/key/mo + per-request | ~$2 |
-| GuardDuty (org-wide) | Per GB of analyzed events / logs | ~$0–1 at fabric-only traffic |
 
-Total order of magnitude: **~$5/month**, persistent. None of it is destroyed — it is the cost of having a governed multi-account organization at all.
+Total order of magnitude: **~$5/month**, persistent. None of it is destroyed — it is the cost of having a governed multi-account organization at all. GuardDuty and Security Hub are deliberately NOT in this table — they belong to the lifecycle-coupled detective baseline below, not the always-on floor.
+
+## Detective baseline (lifecycle-coupled) — ~$12–17/month while enabled
+
+Epic #302 codified GuardDuty (org-wide auto-enable, foundational data sources
+only) and Security Hub (FSBP standard only) in
+`terraform/environments/security/detective/`. Decided by Bin (2026-07-06,
+recorded on #305/#306): these are **not always-on** — the `detective_enabled`
+toggle enables them for platform validation windows and destroys them at
+teardown (member-detector cleanup:
+`terraform/environments/security/detective/scripts/disable-member-detectors.sh`).
+See ADR-023.
+
+Pricing (`eu-central-1`, verified against the AWS Pricing API 2026-07-09):
+
+| Component | Billing shape | This org, ~Monthly while enabled |
+|-----------|---------------|----------------------------------|
+| GuardDuty foundational — CloudTrail management events, all 7 accounts | $0.0000046 per event analyzed ($4.60/M) | ~$2–9 at idle-to-light API traffic |
+| GuardDuty foundational — VPC Flow Logs + DNS logs | $1.15/GB (first 500 GB tier) | ~$0 until platform VPCs exist |
+| Security Hub — FSBP checks (security account only; see ADR-023 OQ-1) | $0.0010 per check, first 100k/account/region/mo | ~$1–5 |
+| Security Hub — finding ingestion | Check-generated findings free; first 10k other events free | ~$0 |
+| GuardDuty paid add-ons (S3/EKS/Malware/RDS/Lambda/Runtime) | Explicitly pinned OFF in Terraform | $0 |
+
+Net new while enabled: **~$3–14/month at today's idle traffic; budget
+~$12–17/month for an active validation window** (more API activity = more
+CloudTrail events analyzed). Both services grant each account a one-time
+30-day free trial, so the first validation window is largely free. Toggled
+off: $0.
 
 ## IPAM — the only usage-priced item
 
@@ -61,7 +89,7 @@ shared in their own bootstrap layers, logarchive via a LinkedAccount-filtered
 budget in the management layer (the logarchive account has no Terraform
 environment of its own).
 
-The expected envelope for this repo is comfortably under the ~$5/month baseline. The $10 daily / $30 monthly caps are kept as generous tripwires; if the daily alert fires for the account fabric alone, something is genuinely wrong (a runaway Config recorder, a misconfigured trail) and warrants investigation.
+The expected envelope for this repo is the ~$5/month always-on baseline, rising to ~$17–22/month total while a detective-enabled validation window is active — still under the $30 monthly cap, but no longer far under it. The $10 daily / $30 monthly caps are kept as tripwires; if the daily alert fires for the account fabric alone, something is genuinely wrong (a runaway Config recorder, a misconfigured trail, or a detective window someone forgot to close) and warrants investigation.
 
 ## Cost-saving levers
 
@@ -72,3 +100,4 @@ The expected envelope for this repo is comfortably under the ~$5/month baseline.
 | Single org CloudTrail trail | First trail per account is free; avoid redundant trails |
 | Config recorder scoped to relevant resource types | Per-configuration-item pricing rewards not recording noise |
 | AFT committed but not deployed (ADR-011) | The scaling path stays fresh via CI validation without incurring the ~$10–15/mo AFT pipeline cost |
+| Detective baseline lifecycle-coupled (`detective_enabled`, ADR-023) | GuardDuty + Security Hub bill only during validation windows, not 24/7; paid GuardDuty add-ons pinned off; FSBP is the only Security Hub standard |

--- a/terraform/environments/security/bootstrap/oidc-github-baseline-role.tf
+++ b/terraform/environments/security/bootstrap/oidc-github-baseline-role.tf
@@ -4,16 +4,20 @@
 # Apply role for the `ref:refs/heads/main` trigger. The `pull_request` trigger
 # assumes its own read-only role, `gh-tf-plan`. These two are the only CI roles.
 #
-# Scope: the security account's only landing-zone Terraform is
-# `security/bootstrap` itself — the account alias, the GitHub OIDC provider,
-# and the gh-tf-* / aegis-emergency-* roles. The permission policy below is
-# therefore exactly IAM-on-project-prefixes + account alias + cross-account
-# Terraform state.
+# Scope: the security account's landing-zone Terraform is `security/bootstrap`
+# (account alias, GitHub OIDC provider, gh-tf-* / aegis-emergency-* roles) plus
+# the `security/detective` layer (epic #302 D5). The permission policy below is
+# IAM-on-project-prefixes + account alias + cross-account Terraform state +
+# the detective-service surface.
 #
-# Scope note (LZ-baseline S1, #303): this is the plain member-account subset —
-# no detective-service (GuardDuty / Security Hub) mutation permissions yet.
-# Those land in #304/#305/#306 once this layer (or a sibling `security/
-# detective` layer, per epic #302 D5) owns those resources.
+# Scope note (LZ-baseline S3/S4, #305/#306 — supersedes the S1 note): the
+# DetectiveServicesAdmin Sid grants guardduty:* + securityhub:* so this role
+# can apply the security/detective layer (delegated-admin org configuration,
+# detector, FSBP subscription). Both namespaces are inside the ADR-020
+# boundary ceiling. `config:Describe*` (read-only CT-aggregator check) is
+# also granted but currently sits OUTSIDE the boundary ceiling — the check
+# degrades to a warning in CI until the org-uniform boundary adds the
+# `config` namespace (see ADR-023).
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_apply_baseline" {
@@ -54,8 +58,8 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
   # checkov:skip=CKV_AWS_287: ReadOnlyAwsApiSurface Sid uses Resource:* on Get*/List*/Simulate* actions only — restrictable per-ARN scoping is not meaningful for inventory-style API calls. Mutation prevention is enforced by the absence of any Create/Update/Delete action paired with Resource:*. See ADR-014.
   # checkov:skip=CKV_AWS_288: Same as CKV_AWS_287 — read-shape data disclosure is the explicit threat model accepted by ADR-014. AWS metadata is classified non-secret per CLAUDE.md "What is NOT a secret" clause.
   # checkov:skip=CKV_AWS_289: `iam:*` is intentionally scoped to project-prefixed resources (aegis-*/github-actions-*/gh-tf-*) plus the OIDC provider and account alias. Permission-management within a fixed prefix is the apply contract for the security baseline role.
-  # checkov:skip=CKV_AWS_290: Service-namespace wildcard `tag:*` is needed because the AWS tagging API does not support resource-level ARN constraints on write actions; service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
-  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on the account-alias actions (AWS rejects resource-level ARNs there). Every mutating action with Resource:* is service-namespace-scoped and trust-policy-gated.
+  # checkov:skip=CKV_AWS_290: Service-namespace wildcards (`tag:*`, and `guardduty:*`/`securityhub:*` for the delegated-admin detective layer) are needed because these APIs create-then-reference their ARNs (or, for tagging, reject resource-level ARN constraints on writes); service-namespace scoping is the tightest contract available and is gated by trust policy `sub: ref:refs/heads/main` plus branch protection on main.
+  # checkov:skip=CKV_AWS_355: Resource:* is by design on the read-only Sid and on the account-alias actions (AWS rejects resource-level ARNs there). Every mutating action with Resource:* (tag/guardduty/securityhub) is service-namespace-scoped and trust-policy-gated.
   # checkov:skip=CKV2_AWS_40: `iam:*` is intentionally allowed within aegis-*/github-actions-*/gh-tf-* prefix scope for apply-tier baseline operations. Full IAM privileges on a fixed ARN-prefix is the deliberate apply-baseline design (ADR-014 §Decision).
   name = "apply-baseline-scoped"
   role = aws_iam_role.gh_tf_apply_baseline.id
@@ -144,6 +148,24 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
         Resource = "*"
       },
       {
+        # Detective layer (S3/S4, #305/#306): this account is the org
+        # delegated administrator for GuardDuty + Security Hub (S2, PR #311)
+        # and owns the security/detective Terraform layer. Service-namespace
+        # wildcards mirror the tag:* contract above: GuardDuty detector /
+        # org-configuration and Security Hub hub / standards ARNs are
+        # created-then-referenced by Terraform, so per-ARN scoping would
+        # break the create path; the trust policy `sub: ref:refs/heads/main`
+        # plus branch protection is the gate, and the ADR-020 boundary
+        # ceiling already carries both namespaces.
+        Sid    = "DetectiveServicesAdmin"
+        Effect = "Allow"
+        Action = [
+          "guardduty:*",
+          "securityhub:*",
+        ]
+        Resource = "*"
+      },
+      {
         # Read shapes for `terraform plan` after apply (refresh + drift
         # detection). Resource: "*" is acceptable here because every
         # action listed is read-only — metadata disclosure is classified
@@ -165,6 +187,9 @@ resource "aws_iam_role_policy" "gh_tf_apply_baseline" {
           "kms:List*",
           "kms:GetKeyRotationStatus",
           "kms:GetKeyPolicy",
+          # Read-only CT Config-aggregator check (security/detective layer,
+          # #306). Outside the ADR-020 boundary ceiling today — see header.
+          "config:Describe*",
           "tag:Get*",
           "sts:GetCallerIdentity",
         ]

--- a/terraform/environments/security/bootstrap/oidc-github-plan-role.tf
+++ b/terraform/environments/security/bootstrap/oidc-github-plan-role.tf
@@ -14,11 +14,13 @@
 # (which CLAUDE.md classifies as not-secret). This is the unlocking move
 # for closing fork-PR-OIDC as a meaningful blast-radius source.
 #
-# Scope note (LZ-baseline S1, #303): this is the plain member-account subset —
-# IAM-prefix reads, state bucket, KMS-via-S3, tagging, generic read-only API
-# surface. No GuardDuty / Security Hub read shapes yet; those land with the
-# detective-service permissions in #305/#306 once this account owns those
-# resources.
+# Scope note (LZ-baseline S3/S4, #305/#306 — supersedes the S1 note): this
+# account owns the `security/detective` layer, so the read-only surface now
+# includes GuardDuty / Security Hub / Config read shapes for planning that
+# layer. `config:Describe*` backs the read-only CT-aggregator check
+# (ct-config-aggregator-check.tf); note it is currently OUTSIDE the ADR-020
+# boundary ceiling, so CI plans degrade that check to a warning until the
+# org-uniform boundary adds the `config` namespace (see ADR-023).
 # -----------------------------------------------------------------------------
 
 resource "aws_iam_role" "gh_tf_plan" {
@@ -165,6 +167,16 @@ resource "aws_iam_role_policy" "gh_tf_plan" {
           "ecr:Get*",
           "ecr:List*",
           "elasticloadbalancing:Describe*",
+          # Detective layer (S3/S4, #305/#306): plan-time refresh of the
+          # security/detective resources + the read-only CT Config-aggregator
+          # check. All read-shape.
+          "guardduty:Get*",
+          "guardduty:List*",
+          "guardduty:Describe*",
+          "securityhub:Get*",
+          "securityhub:List*",
+          "securityhub:Describe*",
+          "config:Describe*",
           "tag:Get*",
           "sts:GetCallerIdentity",
         ]

--- a/terraform/environments/security/detective/.terraform.lock.hcl
+++ b/terraform/environments/security/detective/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.54.0"
+  constraints = "~> 6.40"
+  hashes = [
+    "h1:i89hWLGo3bPwJKYBv3+S67qbfr0tydFqs70Hq5VcoYs=",
+    "h1:pdl5u/cxTU5ctqlHFr/Z4IPPVIDX9Gt+wBQbzZjLWlM=",
+    "h1:reAAk1y/ceiYxNAev+5T10vfp0lWo8RW/eowx3yO+2M=",
+    "zh:0557777baa82faa7907adce61a2a3f9b2a487070bb03f29df20a7502edfe966f",
+    "zh:0767256c36b9c4d4b66d4af882de480c6535ff9eac26410fca253e87b89cb478",
+    "zh:0be7595ef70273af5eb72d850d45eb264d39796d0578c7f3eda9988d7f0781e5",
+    "zh:0fd81edad00c8da35b37aa310c7466f7a8d61056b95b37b349c510d21a8a52f6",
+    "zh:11a976648c864d126a70eb2d40182a17ecfeb3c6c3bf790c4f7eafa5e4c204ba",
+    "zh:14065875294ea597303ae8e462189041067de3b1f5d97c9f2b04b5d14aeb4f7c",
+    "zh:55a76258b109f8394cad20c9e07f376fe3051920931bf43d1b62f4d7242f20c8",
+    "zh:69b04cc363dda4df3d703c3954ae87ef36b0fea8fe45a236db89f8647a879274",
+    "zh:79e3425219f59e285f128e88a7c294a6d33c7bfa73c57a42e31ac0d8daa2f20a",
+    "zh:8d6c46c8a215f73c3c1109695a9bfd8894852d0b1c592516f09efb8a84e08b0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9db8f8fac77d6e999a2886df52bebb106b93ba8dfc4fea1e04decc8fda8070cd",
+    "zh:b4fc365f093b232531905547a50d4f62dbd9d5a843707867520b8b04e8b36e4f",
+    "zh:c9135045fbc561d30ec72f0b9335fcfe7590eed7e6b4eb8988455e6c8b4d348a",
+    "zh:db5f51f9f7037428cb7e8f8d43a63e0d3de498c9730fe98a3c539a75cc49208e",
+    "zh:f807b2a66174b20749c11d58cf7b2ffa8e89b4ec60dd70382959074f8490c387",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.0"
+  constraints = "~> 2.3"
+  hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
+    "h1:K0eLC86zbhVoyS4THmY00KJZKAQORuz6dt9Ro3xo/wA=",
+    "h1:vvIsrZAD5eNoNtXvNcBUxkA9k2A4JcC8JTDFbM9d8gc=",
+    "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
+    "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
+    "zh:32d8492b1bdcc956ca3c6d00c6392d0a83942ff11d4820c7ee63ca6796e06950",
+    "zh:3c0482e894429f528ce6655a76ab0d8a9f7c0dacc6c828865e1515d4a7dbb852",
+    "zh:61e68100b4db2f930b31491f23c602126382fd5e51252be1b551f0e17f8ddbee",
+    "zh:6d60f615a0ad85eb962c9eb94f25e3eba7a72684ce276ba5dfb23f36b295a8f8",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9ced2745eb5f1346203027d2dd7bf856ad1d279a25730ff7dbc6eec187aaca0c",
+    "zh:a8378558a177d43f55aa0d79d4fae91a704695122a1b109668c1daa8fb76f09d",
+    "zh:aadd98086133d3ebea67437d56512fdcc6dfb3bd34dfc23f276c0db9272e27b4",
+    "zh:beff701b653841e70441978137768f54e7dc6c27e7bf12a4589087f01f5bbcee",
+    "zh:c91c2223b29fdbc0044d20e1936ccc051d010727a13f2ff1e75e51f09bff33a3",
+    "zh:d491f9c2d32a39dc4031628469ae7c8aec0074312a7c1f0286b173cdcf854a54",
+  ]
+}

--- a/terraform/environments/security/detective/backend.tf
+++ b/terraform/environments/security/detective/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "aegis-terraform-state-345895787808"
+    key          = "security/detective/terraform.tfstate"
+    region       = "eu-central-1"
+    use_lockfile = true
+  }
+}

--- a/terraform/environments/security/detective/config.tf
+++ b/terraform/environments/security/detective/config.tf
@@ -1,0 +1,29 @@
+locals {
+  config = yamldecode(file("${path.root}/../../../../config/landing-zone.yaml"))
+
+  account_id     = local.config.accounts.security.id
+  primary_region = [for r in local.config.regions : r.name if r.role == "primary"][0]
+
+  # Governed regions other than the primary — the linked-region set for the
+  # Security Hub finding aggregator (the home region itself must not appear in
+  # `specified_regions`; see securityhub.tf).
+  non_primary_regions = [for r in local.config.regions : r.name if r.role != "primary"]
+
+  tags = merge(local.config.tags, {
+    Environment = "security"
+  })
+}
+
+check "exactly_one_primary_region" {
+  assert {
+    condition     = length([for r in local.config.regions : r if r.role == "primary"]) == 1
+    error_message = "config/landing-zone.yaml regions[] must have exactly one entry with role: primary."
+  }
+}
+
+check "config_account_id_not_empty" {
+  assert {
+    condition     = local.account_id != ""
+    error_message = "accounts.security.id in landing-zone.yaml is empty. Create the account first (Runbook 001 Part 9)."
+  }
+}

--- a/terraform/environments/security/detective/ct-config-aggregator-check.tf
+++ b/terraform/environments/security/detective/ct-config-aggregator-check.tf
@@ -1,0 +1,50 @@
+# -----------------------------------------------------------------------------
+# Control Tower Config aggregator — read-only assertion (Epic #302 S4, #306)
+# -----------------------------------------------------------------------------
+# Epic #302's key verified fact: the AWS Config aggregator in this (audit/
+# security) account is PROVIDED BY CONTROL TOWER. This layer must never create
+# or own one — it only asserts the CT-managed aggregator still exists, so a
+# future "cleanup" that deletes it is caught at the next plan instead of
+# silently blinding org-wide Config aggregation.
+#
+# WHY an `external` data source: the AWS provider (6.x) has no
+# `data "aws_config_configuration_aggregator"` (verified 2026-07-09 — the
+# provider docs path 404s). The smallest read-only probe is one
+# `configservice describe-configuration-aggregators` call, wrapped in a script
+# that ALWAYS exits 0 and reports its outcome as data, so a permissions gap
+# degrades to a failed check (a plan/apply WARNING per Terraform check-block
+# semantics) — never a hard failure.
+#
+# KNOWN CI LIMITATION (documented, not hidden): the CI roles are capped by the
+# org-uniform permissions boundary (ADR-020), whose Allow ceiling does not yet
+# include the `config` namespace. Until `config:Describe*` is added to the
+# boundary (a 7-file, all-accounts-uniform change that touches
+# management/bootstrap — deferred to keep this PR out of the parallel
+# management-area workstreams), CI plans report this check as FAILED-WARNING
+# with an AccessDenied detail. The #306 validation criterion ("check passes
+# against the existing CT aggregator") is asserted by running
+# `terraform plan` locally under operator SSO credentials. See ADR-023.
+# -----------------------------------------------------------------------------
+
+check "ct_config_aggregator_exists" {
+  data "external" "ct_config_aggregator" {
+    program = [
+      "bash",
+      "${path.module}/scripts/check-ct-config-aggregator.sh",
+      local.primary_region,
+    ]
+  }
+
+  assert {
+    condition = data.external.ct_config_aggregator.result.found == "true"
+    error_message = join(" ", [
+      "Control-Tower-managed Config aggregator not confirmed in this account",
+      "(result: ${data.external.ct_config_aggregator.result.found};",
+      "detail: ${data.external.ct_config_aggregator.result.detail}).",
+      "If detail says AccessDenied, the caller lacks config:Describe* (CI",
+      "boundary gap, ADR-023) — re-run under operator SSO credentials.",
+      "If found=false under full credentials, the CT aggregator is GONE:",
+      "stop and investigate Control Tower drift before touching this layer.",
+    ])
+  }
+}

--- a/terraform/environments/security/detective/guardduty.tf
+++ b/terraform/environments/security/detective/guardduty.tf
@@ -1,0 +1,182 @@
+# -----------------------------------------------------------------------------
+# GuardDuty — org-wide auto-enable (Epic #302 Stage S3, issue #305)
+# -----------------------------------------------------------------------------
+# Runs in the `security` account, which S2 (#304, PR #311) registered as the
+# org delegated administrator for GuardDuty. This layer turns the service ON:
+#
+#   1. A detector in this (delegated-admin) account.
+#   2. Org configuration with `auto_enable_organization_members = "ALL"` —
+#      AWS auto-creates a detector in every EXISTING and future member
+#      account (this is the "member account shows an auto-created detector"
+#      validation in #305).
+#   3. Explicit DISABLED/NONE feature blocks for every paid add-on, at both
+#      the detector level (this account) and the org level (member accounts).
+#      Frugal posture per epic #302: foundational data sources only
+#      (CloudTrail management events + VPC Flow Logs + DNS logs).
+#
+# COST: foundational analysis bills per CloudTrail event analyzed
+# ($0.0000046/event in eu-central-1) and per GB of VPC Flow/DNS logs ($1.15/GB
+# first tier; ~zero while no VPCs exist). Every account gets a one-time 30-day
+# free trial. See docs/finops.md "Detective baseline" and ADR-023.
+#
+# WHY the paid add-ons are disabled EXPLICITLY rather than by omission:
+# CreateDetector historically defaults S3 Protection ON for first-time
+# detectors; omission would silently opt into a paid feature. The issue (#305)
+# names S3 / EKS / Malware / RDS Protection; LAMBDA_NETWORK_LOGS and
+# RUNTIME_MONITORING are the two remaining billable features in the current
+# feature set, so they are pinned off too — same frugal-posture logic, made
+# visible here rather than left to AWS defaults. (EKS_RUNTIME_MONITORING is
+# omitted deliberately: it is superseded by RUNTIME_MONITORING and AWS rejects
+# configuring both.)
+#
+# WHY the feature resources are depends_on-chained: each feature resource
+# read-modify-writes shared detector/org configuration; letting Terraform run
+# all of them in parallel invites ConcurrentModificationException-shaped API
+# errors. The chain serializes them at negligible wall-clock cost.
+# -----------------------------------------------------------------------------
+
+resource "aws_guardduty_detector" "org" {
+  count = var.detective_enabled ? 1 : 0
+
+  enable = true
+  # Slowest cadence — findings export frequency has no effect on detection
+  # latency in-console, only on EventBridge/S3 export; slowest is the frugal
+  # default for a lab with no downstream consumer.
+  finding_publishing_frequency = "SIX_HOURS"
+
+  tags = local.tags
+}
+
+# --- Detector-level paid features: pinned DISABLED in this account -----------
+
+resource "aws_guardduty_detector_feature" "s3_data_events" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "S3_DATA_EVENTS"
+  status      = "DISABLED"
+}
+
+resource "aws_guardduty_detector_feature" "eks_audit_logs" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "EKS_AUDIT_LOGS"
+  status      = "DISABLED"
+
+  depends_on = [aws_guardduty_detector_feature.s3_data_events]
+}
+
+resource "aws_guardduty_detector_feature" "ebs_malware_protection" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "EBS_MALWARE_PROTECTION"
+  status      = "DISABLED"
+
+  depends_on = [aws_guardduty_detector_feature.eks_audit_logs]
+}
+
+resource "aws_guardduty_detector_feature" "rds_login_events" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "RDS_LOGIN_EVENTS"
+  status      = "DISABLED"
+
+  depends_on = [aws_guardduty_detector_feature.ebs_malware_protection]
+}
+
+resource "aws_guardduty_detector_feature" "lambda_network_logs" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "LAMBDA_NETWORK_LOGS"
+  status      = "DISABLED"
+
+  depends_on = [aws_guardduty_detector_feature.rds_login_events]
+}
+
+resource "aws_guardduty_detector_feature" "runtime_monitoring" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "RUNTIME_MONITORING"
+  status      = "DISABLED"
+
+  depends_on = [aws_guardduty_detector_feature.lambda_network_logs]
+}
+
+# --- Org configuration: auto-enable ALL members, foundational only -----------
+
+resource "aws_guardduty_organization_configuration" "org" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id                      = aws_guardduty_detector.org[count.index].id
+  auto_enable_organization_members = "ALL"
+
+  # Serialize behind the detector-feature updates (same underlying detector).
+  depends_on = [aws_guardduty_detector_feature.runtime_monitoring]
+}
+
+# --- Org-level paid features: pinned NONE for member accounts ----------------
+
+resource "aws_guardduty_organization_configuration_feature" "s3_data_events" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "S3_DATA_EVENTS"
+  auto_enable = "NONE"
+
+  depends_on = [aws_guardduty_organization_configuration.org]
+}
+
+resource "aws_guardduty_organization_configuration_feature" "eks_audit_logs" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "EKS_AUDIT_LOGS"
+  auto_enable = "NONE"
+
+  depends_on = [aws_guardduty_organization_configuration_feature.s3_data_events]
+}
+
+resource "aws_guardduty_organization_configuration_feature" "ebs_malware_protection" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "EBS_MALWARE_PROTECTION"
+  auto_enable = "NONE"
+
+  depends_on = [aws_guardduty_organization_configuration_feature.eks_audit_logs]
+}
+
+resource "aws_guardduty_organization_configuration_feature" "rds_login_events" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "RDS_LOGIN_EVENTS"
+  auto_enable = "NONE"
+
+  depends_on = [aws_guardduty_organization_configuration_feature.ebs_malware_protection]
+}
+
+resource "aws_guardduty_organization_configuration_feature" "lambda_network_logs" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "LAMBDA_NETWORK_LOGS"
+  auto_enable = "NONE"
+
+  depends_on = [aws_guardduty_organization_configuration_feature.rds_login_events]
+}
+
+resource "aws_guardduty_organization_configuration_feature" "runtime_monitoring" {
+  count = var.detective_enabled ? 1 : 0
+
+  detector_id = aws_guardduty_detector.org[count.index].id
+  name        = "RUNTIME_MONITORING"
+  auto_enable = "NONE"
+
+  depends_on = [aws_guardduty_organization_configuration_feature.lambda_network_logs]
+}

--- a/terraform/environments/security/detective/outputs.tf
+++ b/terraform/environments/security/detective/outputs.tf
@@ -1,0 +1,19 @@
+output "guardduty_detector_id" {
+  description = "Delegated-admin GuardDuty detector ID (null when detective_enabled = false)"
+  value       = var.detective_enabled ? aws_guardduty_detector.org[0].id : null
+}
+
+output "guardduty_auto_enable_organization_members" {
+  description = "Org-wide GuardDuty member auto-enrollment mode (null when detective_enabled = false)"
+  value       = var.detective_enabled ? aws_guardduty_organization_configuration.org[0].auto_enable_organization_members : null
+}
+
+output "securityhub_fsbp_subscription_arn" {
+  description = "The single enabled Security Hub standard — FSBP (null when detective_enabled = false)"
+  value       = var.detective_enabled ? aws_securityhub_standards_subscription.fsbp[0].id : null
+}
+
+output "detective_enabled" {
+  description = "Lifecycle toggle state — false means the layer is code-complete but all billable detective resources are destroyed"
+  value       = var.detective_enabled
+}

--- a/terraform/environments/security/detective/providers.tf
+++ b/terraform/environments/security/detective/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = local.primary_region
+
+  default_tags {
+    tags = local.tags
+  }
+
+  allowed_account_ids = [local.account_id]
+}

--- a/terraform/environments/security/detective/scripts/check-ct-config-aggregator.sh
+++ b/terraform/environments/security/detective/scripts/check-ct-config-aggregator.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# check-ct-config-aggregator.sh — probe for the Control-Tower-managed AWS
+# Config aggregator in the current (audit/security) account.
+#
+# Backing script for the `check "ct_config_aggregator_exists"` block in
+# ct-config-aggregator-check.tf (Epic #302 S4, issue #306). Read-only: one
+# `describe-configuration-aggregators` call, nothing mutated.
+#
+# External-data-source protocol: reads (and discards) the query JSON on
+# stdin, prints a single flat JSON object on stdout, and ALWAYS exits 0 —
+# errors are reported in the payload (`found: "error"`) so a permission gap
+# degrades to a check warning instead of failing the plan (see the .tf
+# header for the CI boundary limitation).
+#
+# Usage: check-ct-config-aggregator.sh <region>
+
+set -u
+
+region="${1:-${AWS_REGION:-eu-central-1}}"
+
+# Drain the external-provider query JSON from stdin (unused).
+cat > /dev/null 2>&1 || true
+
+json_escape() {
+  # Minimal escaping for embedding in a JSON string value.
+  printf '%s' "$1" | tr '\t\n"\\' '    '
+}
+
+names="$(aws configservice describe-configuration-aggregators \
+  --region "$region" \
+  --query 'ConfigurationAggregators[].ConfigurationAggregatorName' \
+  --output text 2>&1)"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  printf '{"found":"error","aggregators":"","detail":"describe-configuration-aggregators failed (rc=%s): %s"}' \
+    "$rc" "$(json_escape "$names" | cut -c1-300)"
+  exit 0
+fi
+
+# Control Tower names its aggregator with an `aws-controltower` prefix
+# (canonically: aws-controltower-GuardrailsComplianceAggregator).
+case " $names " in
+  *aws-controltower*) found="true" ;;
+  *) found="false" ;;
+esac
+
+printf '{"found":"%s","aggregators":"%s","detail":"ok"}' \
+  "$found" "$(json_escape "$names")"
+exit 0

--- a/terraform/environments/security/detective/scripts/disable-member-detectors.sh
+++ b/terraform/environments/security/detective/scripts/disable-member-detectors.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# disable-member-detectors.sh — stop member-account GuardDuty billing after a
+# detective-layer toggle-off (Epic #302; Bin's lifecycle decision on #305/#306).
+#
+# WHY THIS EXISTS: `detective_enabled = false` destroys only what Terraform
+# owns — the delegated-admin detector, the org auto-enable configuration, and
+# the Security Hub resources in the security account. The member-account
+# detectors that `auto_enable_organization_members = "ALL"` auto-created are
+# NOT in Terraform state and keep analyzing CloudTrail events (billing) until
+# each one is deleted in its own account. This script does that sweep.
+#
+# RUN AS: a management-account admin (e.g. `aegis-management-admin` SSO
+# profile). It assumes AWSControlTowerExecution in each member account —
+# the delegated admin cannot delete member detectors, only the members can.
+#
+# ORDER: run AFTER the toggle-off apply. If auto-enable were still "ALL",
+# GuardDuty would just re-enroll the accounts you clean up.
+#
+# SAFE BY DEFAULT: dry-run unless --execute is passed. Read-only calls only
+# in dry-run mode.
+#
+# Usage:
+#   ./disable-member-detectors.sh [--execute] [--region eu-central-1]
+
+set -euo pipefail
+
+REGION="eu-central-1"
+EXECUTE=false
+ROLE_NAME="AWSControlTowerExecution"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --execute) EXECUTE=true ;;
+    --region)
+      shift
+      REGION="$1"
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--execute] [--region <region>]" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+mgmt_account="$(aws sts get-caller-identity --query Account --output text)"
+echo "Caller account: ${mgmt_account} | region: ${REGION} | mode: $($EXECUTE && echo EXECUTE || echo DRY-RUN)"
+
+accounts="$(aws organizations list-accounts \
+  --query 'Accounts[?Status==`ACTIVE`].[Id,Name]' --output text)"
+
+while IFS=$'\t' read -r account_id account_name; do
+  [ -z "$account_id" ] && continue
+  if [ "$account_id" = "$mgmt_account" ]; then
+    # The management account is not governed by AWSControlTowerExecution;
+    # its detector (if any) is handled with the caller's own credentials.
+    creds_env=""
+  else
+    if ! creds="$(aws sts assume-role \
+      --role-arn "arn:aws:iam::${account_id}:role/${ROLE_NAME}" \
+      --role-session-name detective-teardown \
+      --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+      --output text 2>/dev/null)"; then
+      echo "SKIP  ${account_id} (${account_name}): cannot assume ${ROLE_NAME}"
+      continue
+    fi
+    creds_env="AWS_ACCESS_KEY_ID=$(echo "$creds" | cut -f1) AWS_SECRET_ACCESS_KEY=$(echo "$creds" | cut -f2) AWS_SESSION_TOKEN=$(echo "$creds" | cut -f3)"
+  fi
+
+  detector_id="$(env $creds_env aws guardduty list-detectors \
+    --region "$REGION" --query 'DetectorIds[0]' --output text 2>/dev/null || true)"
+
+  if [ -z "$detector_id" ] || [ "$detector_id" = "None" ]; then
+    echo "OK    ${account_id} (${account_name}): no detector"
+    continue
+  fi
+
+  if $EXECUTE; then
+    env $creds_env aws guardduty delete-detector \
+      --region "$REGION" --detector-id "$detector_id"
+    echo "DONE  ${account_id} (${account_name}): deleted detector ${detector_id}"
+  else
+    echo "WOULD ${account_id} (${account_name}): delete detector ${detector_id}"
+  fi
+done <<< "$accounts"
+
+echo "Sweep complete. Re-run with --execute to act." | { $EXECUTE && cat > /dev/null || cat; }

--- a/terraform/environments/security/detective/securityhub.tf
+++ b/terraform/environments/security/detective/securityhub.tf
@@ -1,0 +1,80 @@
+# -----------------------------------------------------------------------------
+# Security Hub — org configuration + FSBP standard (Epic #302 Stage S4, #306)
+# -----------------------------------------------------------------------------
+# Runs in the `security` account, the org delegated administrator for Security
+# Hub since S2 (#304, PR #311). Shape per issue #306 / epic #302 decision D4:
+#
+#   1. Security Hub enabled in this account, default standards suppressed.
+#   2. Finding aggregator with home region = primary (created here, in the
+#      primary-region provider) and the remaining governed region(s) linked.
+#   3. Exactly ONE standards subscription: FSBP. No CIS, no PCI.
+#   4. Org configuration LOCAL: auto-enable Security Hub for accounts that
+#      JOIN the org later, with `auto_enable_standards = "NONE"` so no
+#      default standard sneaks in with them.
+#
+# SCOPE NOTE — existing member accounts: with LOCAL configuration,
+# `auto_enable = true` covers only accounts added to the org AFTER this
+# apply. The six existing member accounts are NOT enrolled in Security Hub by
+# this layer (that would need per-account `aws_securityhub_member` resources
+# or CENTRAL configuration policies — deliberately out of #306's resource
+# list, and the cheap end of the cost envelope). FSBP checks therefore run in
+# THIS account only for now. Flagged as an open decision in ADR-023 §OQ-1.
+#
+# REGION NOTE on the aggregator: issue #306 says `SPECIFIED_REGIONS` =
+# primary region. The AWS API defines `specified_regions` as the LINKED
+# regions and rejects the home region in that list — the home region is
+# implicitly where the aggregator is created (this provider = primary). The
+# issue's intent (home/aggregation region = primary) is satisfied by creating
+# the aggregator here; `specified_regions` carries the remaining governed
+# region(s) from config (currently eu-west-1, where Security Hub is not
+# enabled, so nothing flows and nothing bills — aggregation itself is free).
+#
+# COST: FSBP security checks bill per check per account per region:
+# $0.0010/check (first 100k/account/region/month) in eu-central-1. 30-day
+# free trial per account. See docs/finops.md "Detective baseline" + ADR-023.
+# -----------------------------------------------------------------------------
+
+resource "aws_securityhub_account" "this" {
+  count = var.detective_enabled ? 1 : 0
+
+  # FSBP is subscribed explicitly below; suppress the default-standards
+  # bundle (which would also pull in CIS) — epic #302 decision D4.
+  enable_default_standards = false
+
+  # New FSBP controls added by AWS are picked up automatically — the frugal
+  # lever is the standard count (one), not a frozen control list.
+  auto_enable_controls = true
+}
+
+resource "aws_securityhub_finding_aggregator" "primary" {
+  count = var.detective_enabled ? 1 : 0
+
+  linking_mode      = "SPECIFIED_REGIONS"
+  specified_regions = local.non_primary_regions
+
+  depends_on = [aws_securityhub_account.this]
+}
+
+resource "aws_securityhub_standards_subscription" "fsbp" {
+  count = var.detective_enabled ? 1 : 0
+
+  standards_arn = "arn:aws:securityhub:${local.primary_region}::standards/aws-foundational-security-best-practices/v/1.0.0"
+
+  depends_on = [aws_securityhub_account.this]
+}
+
+resource "aws_securityhub_organization_configuration" "org" {
+  count = var.detective_enabled ? 1 : 0
+
+  # LOCAL configuration (the resource default): each account manages its own
+  # standards; the org only auto-enables Security Hub itself for NEW accounts.
+  auto_enable           = true
+  auto_enable_standards = "NONE"
+
+  # Serialize behind the aggregator + subscription — org-configuration and
+  # standards calls against a freshly enabled hub race otherwise.
+  depends_on = [
+    aws_securityhub_finding_aggregator.primary,
+    aws_securityhub_standards_subscription.fsbp,
+  ]
+}

--- a/terraform/environments/security/detective/variables.tf
+++ b/terraform/environments/security/detective/variables.tf
@@ -1,0 +1,23 @@
+# -----------------------------------------------------------------------------
+# Lifecycle toggle — decided by Bin on issues #305/#306 (2026-07-06): the
+# detective services are NOT always-on; they ride the platform bring-up /
+# teardown lifecycle. This variable is the clean enable/disable switch:
+#
+#   true  → GuardDuty org auto-enable + Security Hub (FSBP) are created and
+#           recurring cost accrues (see docs/finops.md "Detective baseline").
+#   false → every billable resource in this layer is destroyed on the next
+#           apply; the layer (and its CI wiring) stays in place, code-complete.
+#
+# CAVEAT on disable: Terraform only destroys what it owns — the delegated-
+# admin detector, the org auto-enable configuration, and the Security Hub
+# resources in THIS account. Member-account GuardDuty detectors that were
+# auto-created by `auto_enable_organization_members = "ALL"` are not in this
+# state and keep billing until removed. Run
+# scripts/disable-member-detectors.sh (this layer's scripts/ dir) after the
+# toggle-off apply to stop member-side cost. See ADR-023.
+# -----------------------------------------------------------------------------
+variable "detective_enabled" {
+  description = "Master lifecycle switch for the detective services (GuardDuty org auto-enable + Security Hub FSBP). false destroys all billable resources in this layer on the next apply while keeping the layer code-complete. Flip via a one-line PR; pair toggle-off with scripts/disable-member-detectors.sh to stop member-account GuardDuty cost."
+  type        = bool
+  default     = true
+}

--- a/terraform/environments/security/detective/variables.tf
+++ b/terraform/environments/security/detective/variables.tf
@@ -8,16 +8,23 @@
 #   false → every billable resource in this layer is destroyed on the next
 #           apply; the layer (and its CI wiring) stays in place, code-complete.
 #
-# CAVEAT on disable: Terraform only destroys what it owns — the delegated-
-# admin detector, the org auto-enable configuration, and the Security Hub
-# resources in THIS account. Member-account GuardDuty detectors that were
-# auto-created by `auto_enable_organization_members = "ALL"` are not in this
-# state and keep billing until removed. Run
-# scripts/disable-member-detectors.sh (this layer's scripts/ dir) after the
-# toggle-off apply to stop member-side cost. See ADR-023.
+# DEFAULT IS false (decided by Bin, 2026-07-09): this layer lands DORMANT.
+# Merging with the default applies only the layer scaffolding — zero billable
+# resources. The paid validation window opens later, deliberately, via a
+# one-line PR flipping this to true (paired with the ephemeral-EKS validation
+# run), not as a side effect of this merge.
+#
+# CAVEAT on disable (applies to the future enabled→disabled path): Terraform
+# only destroys what it owns — the delegated-admin detector, the org
+# auto-enable configuration, and the Security Hub resources in THIS account.
+# Member-account GuardDuty detectors that were auto-created by
+# `auto_enable_organization_members = "ALL"` are not in this state and keep
+# billing until removed. Run scripts/disable-member-detectors.sh (this
+# layer's scripts/ dir) after the toggle-off apply to stop member-side cost.
+# See ADR-023.
 # -----------------------------------------------------------------------------
 variable "detective_enabled" {
-  description = "Master lifecycle switch for the detective services (GuardDuty org auto-enable + Security Hub FSBP). false destroys all billable resources in this layer on the next apply while keeping the layer code-complete. Flip via a one-line PR; pair toggle-off with scripts/disable-member-detectors.sh to stop member-account GuardDuty cost."
+  description = "Master lifecycle switch for the detective services (GuardDuty org auto-enable + Security Hub FSBP). Defaults to false so this layer lands dormant (zero billable resources); flip to true via a one-line PR to open a paid validation window, pairing toggle-off with scripts/disable-member-detectors.sh to stop member-account GuardDuty cost."
   type        = bool
-  default     = true
+  default     = false
 }

--- a/terraform/environments/security/detective/versions.tf
+++ b/terraform/environments/security/detective/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+    # `external` backs the read-only CT Config-aggregator assertion in
+    # ct-config-aggregator-check.tf (no native data source exists for
+    # aws_config_configuration_aggregator as of provider 6.x).
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3"
+    }
+  }
+}


### PR DESCRIPTION
Implements #305 (S3), #306 (S4), #307 (S5) of detective-baseline epic #302. Builds directly on S2 (PR #311, delegated admins registered).

## Lands dormant — merge applies zero paid resources

**Bin's decision (2026-07-09): this PR lands the layer DORMANT.** `detective_enabled` now defaults to `false`, so **merging and applying this PR creates only the layer scaffolding — 0 billable resources.** All 18 gated resources (14 GuardDuty + 4 Security Hub) are `count = var.detective_enabled ? 1 : 0`, and with the default they all evaluate to 0. The plan for `security/detective` should show **no resources to add** (see Validation).

The paid validation window opens later, deliberately, as a separate one-line PR (flip `detective_enabled = true`) or a `-var` / tfvars override — timed together with the ephemeral-EKS validation run, not as a side effect of this merge.

### Cost model for the FUTURE enabled state (unchanged pricing, not applied by this PR)

Pricing verified for `eu-central-1` against the AWS Pricing API (offers v1.0, GuardDuty pub. 2026-06-28, Security Hub pub. 2026-07-07) — not estimated from memory. This table describes what turning the layer on (later) will cost; **merging this PR does not trigger any of it.**

| Service | Pricing model (eu-central-1, exact) | Activates on | Realistic monthly (near-zero workload) |
|---|---|---|---|
| GuardDuty foundational — CloudTrail management events | **$0.0000046 / event analyzed** ($4.60/M) | **All 7 accounts** (auto-enable `ALL`, existing + future members) | ~50–300k idle events/acct/mo → **$2–9/mo** org-wide |
| GuardDuty foundational — VPC Flow + DNS logs | **$1.15/GB** (first 500 GB tier) | All 7 accounts | **~$0** — no VPCs exist yet |
| GuardDuty paid add-ons (S3 / EKS / Malware / RDS / Lambda / Runtime) | — | **Explicitly pinned OFF** at detector + org level | **$0** |
| Security Hub — FSBP security checks | **$0.0010 / check** (first 100k/acct/region/mo; then $0.0008, $0.0005) | **Security account only** (LOCAL org config; existing members NOT enrolled — see Open Questions) | **$1–5/mo** |
| Security Hub — finding ingestion | Check-generated findings free; first 10k other events/mo free | Security account | **~$0** |
| **Total net-new (once enabled)** | | | **~$3–14/mo at today's idle traffic; budget ~$12–17/mo during an active validation window.** First 30 days per account/service: free trial. |

Sources: AWS Pricing API `AmazonGuardDuty` / `AWSSecurityHub` eu-central-1 offer files; cross-checked against aws.amazon.com/guardduty/pricing and the Security Hub CSPM pricing page. Full model committed in `docs/finops.md` + ADR-023.

**Lifecycle (Bin's decision on #305/#306, 2026-07-06, toggle default finalized 2026-07-09):** this is NOT always-on. `detective_enabled = false` is now the default — the layer lands code-complete and dormant. To open a paid validation window later: flip `detective_enabled = true` (one-line PR, or a tfvars/`-var` override) and apply. To close it again afterward: flip back to `false` and apply, then pair with `terraform/environments/security/detective/scripts/disable-member-detectors.sh --execute` to delete the auto-created member detectors (outside Terraform state — they'd keep billing otherwise).

## What lands

### S3 — GuardDuty org auto-enable (#305)
- New `terraform/environments/security/detective/` Terraservice layer (epic D5), primary region only (D3).
- Delegated-admin detector + `aws_guardduty_organization_configuration` with `auto_enable_organization_members = "ALL"` (D6).
- Every paid feature explicitly `DISABLED` (detector) / `NONE` (org): S3_DATA_EVENTS, EKS_AUDIT_LOGS, EBS_MALWARE_PROTECTION, RDS_LOGIN_EVENTS + LAMBDA_NETWORK_LOGS, RUNTIME_MONITORING (the last two are also billable — same frugal logic as the issue's four, made explicit rather than left to AWS defaults, which historically turn S3 Protection ON for new detectors). Feature resources are `depends_on`-chained to serialize read-modify-write calls against the shared detector/org config.

### S4 — Security Hub org config + FSBP + CT aggregator assert (#306)
- Hub enabled with `enable_default_standards = false`; exactly one `aws_securityhub_standards_subscription` (FSBP).
- Finding aggregator: `SPECIFIED_REGIONS`, homed in the primary region. NOTE: the AWS API defines `specified_regions` as the LINKED regions and rejects the home region in the list — the issue's "= primary region" intent is satisfied by creating the aggregator in the primary-region provider; the linked list carries the remaining governed region(s) from config (eu-west-1, where Security Hub is not enabled → nothing flows, aggregation itself is free).
- Org configuration LOCAL, `auto_enable = true` (new accounts only), `auto_enable_standards = "NONE"`.
- CT Config aggregator asserted read-only via a `check` block + `external` CLI probe (`scripts/check-ct-config-aggregator.sh`) — provider 6.x has **no** native data source for Config aggregators. NOT created/owned here (epic's key verified fact). The probe always exits 0; failure shapes degrade to a plan **warning**, never a hard failure.
- **CI limitation (deliberate):** the ADR-020 boundary ceiling lacks the `config` namespace, so in CI this check reports FAILED-WARNING (AccessDenied). Asserting it green requires a local `terraform plan` under operator SSO creds, until the boundary gains `config:*` — a 7-file byte-identical change touching `management/bootstrap`, deferred to avoid racing the parallel management-area work (ADR-023 OQ-2).
- `security/bootstrap` CI roles: `DetectiveServicesAdmin` Sid (`guardduty:*` + `securityhub:*`, both inside the ADR-020 ceiling) on the apply role; guardduty/securityhub/config read shapes on the plan role.
- CI wiring: layer added to `config/ci-layers.yaml` **after** `security/bootstrap` (same apply run lands the new role Sids first, `max-parallel: 1` in manifest order) and to the apply workflow path filter.

### S5 — docs reconciliation (#307)
- **ADR-023** (numbering moved on from the issue's "ADR-020" — 020–022 landed since): non-contradiction with ADR-016's "why not GuardDuty" (deterministic OIDC-failure alerting vs org-wide runtime detection — different jobs), CloudTrail = CT-managed documented reliance (D1), cost model, lifecycle decision, open questions.
- **finops.md**: detective baseline as its own lifecycle-coupled section (~$12–17/mo enabled / $0 off); GuardDuty removed from the always-on table; missing member-bootstrap rows added; envelope corrected.
- **README**: Phase-4 false "GuardDuty … Done ~$5/mo" claim corrected; Phase-6 detective row added; cost bullets, repo tree, ADR table updated.
- **docs/decisions/README.md**: stale index (stopped at 020) now lists 021–023.
- **checkov.yml**: `CKV2_AWS_3` skip REMOVED — the control is codified now; local run (checkov 3.3.8): 248 passed / 0 failed / 0 skipped-new. (Found + fixed en route: `[0]`-indexed detector references break Checkov's graph edge for CKV2_AWS_3; `[count.index]` preserves it.)
- Runbook 001: both `enable-aws-service-access` prereqs already present (landed with S2/PR #311) — no change needed.

### Dormant-landing follow-up (added 2026-07-09)
- `variables.tf`: `detective_enabled` default flipped `true` → `false`; comment block and description rewritten to state the default and the deliberate future enable step.
- ADR-023 Consequences section rewritten: merge no longer starts spend; the cost gate now protects the future true-flip, not this merge.

## Validation
- `terraform fmt -check -recursive` clean; `terraform validate` clean on `security/detective` + `security/bootstrap` (TF 1.14.8, lock file committed for linux_amd64 + darwin_{arm64,amd64}).
- `scripts/ci/policy_test.py`: PASS (90 checks — P4 backend↔config and P5 manifest↔disk include the new layer).
- Checkov green **without** the CKV2_AWS_3 skip (see above).
- PR plan matrix: with `detective_enabled` defaulting to `false`, expect `security/detective` to show **0 to add / 0 to change / 0 to destroy** (all 18 gated resources evaluate their `count` to 0); `security/bootstrap` still shows the role-policy updates (`DetectiveServicesAdmin` Sid etc. — those are unconditional, not lifecycle-gated); the CT-aggregator check will show a **warning** (expected — boundary gap above). **NO apply happens on this PR**, and even when CI applies post-merge, the detective layer's own apply is a no-op until someone deliberately flips the toggle.

## Post-merge apply prerequisites (already satisfied)
`enable-aws-service-access` for `guardduty.amazonaws.com` + `securityhub.amazonaws.com` were required and run before S2's apply (PR #311); delegation is live, so this layer's apply has no manual prereq. (Irrelevant to the dormant merge — relevant only once `detective_enabled` flips to `true`.)

## Open questions for Bin
1. ~~**Toggle default.**~~ **Resolved 2026-07-09:** default flipped to `false`; this PR lands dormant.
2. **Existing members in Security Hub (ADR-023 OQ-1).** LOCAL + `auto_enable` covers only future accounts; FSBP runs in the security account only. Enrolling the 6 existing members ≈ 7× the Security Hub line (~$7–35/mo). Say the word and it's a follow-up.
3. **Boundary `config` namespace (ADR-023 OQ-2).** One uniform 7-file boundary PR makes the CT-aggregator check assert green in CI.

Part of epic #302. Closes #305, closes #306, closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjR9eozKUjq6LL8tgxrEhK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional security “detective baseline” for GuardDuty and Security Hub, with lifecycle-based enable/disable support.
  * Added automated checks for the Control Tower Config aggregator and clearer Terraform apply coverage for the security detective layer.
  * Included a cleanup utility to help remove member-account detectors when turning the baseline off.

* **Documentation**
  * Updated the changelog, README, decision records, and FinOps guidance to reflect the new security baseline, cost expectations, and operating flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->